### PR TITLE
fix: update mkdocstrings config to use inventories option

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,10 +58,11 @@ plugins:
       default_handler: python
       handlers:
         python:
-          import:
-            - https://docs.python.org/3/objects.inv
-            - https://pydantic-docs.helpmanual.io/objects.inv
           options:
+            # Cross-reference inventories
+            inventories:
+              - https://docs.python.org/3/objects.inv
+              - https://pydantic-docs.helpmanual.io/objects.inv
             # Display options
             show_root_heading: true
             show_root_full_path: false


### PR DESCRIPTION
The `import` key was deprecated and removed in newer versions of
mkdocstrings-python. Cross-reference inventories now need to be
specified under `options.inventories` instead of at the handler level.

This fixes the Deploy Documentation workflow failure.