### PR TITLE
fix(docs): move inventories option to handler level in mkdocstrings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,11 +58,11 @@ plugins:
       default_handler: python
       handlers:
         python:
+          # Cross-reference inventories (at handler level, not in options)
+          inventories:
+            - https://docs.python.org/3/objects.inv
+            - https://pydantic-docs.helpmanual.io/objects.inv
           options:
-            # Cross-reference inventories
-            inventories:
-              - https://docs.python.org/3/objects.inv
-              - https://pydantic-docs.helpmanual.io/objects.inv
             # Display options
             show_root_heading: true
             show_root_full_path: false


### PR DESCRIPTION
The inventories option must be at the handler level, not inside options.
This fixes the mkdocs build error:
PythonOptions.__init__() got an unexpected keyword argument 'inventories'