### PR TITLE
trk-dcde741a: binary as source of truth — retrieval, finalize, hierarchy

### DIFF
--- a/cmd/htmlgraph/agent_init.go
+++ b/cmd/htmlgraph/agent_init.go
@@ -48,9 +48,12 @@ htmlgraph find --status in-progress
 htmlgraph feature start feat-XXXX  # or: htmlgraph bug start bug-XXXX
 ` + "```" + `
 
-If no work item exists for this task, create one first:
+If no work item exists for this task, first run ` + "`htmlgraph relevant <topic>`" + ` to find existing context. If still nothing, create one:
 ` + "```bash" + `
-htmlgraph feature create "Short description of what you're implementing" --track <trk-id> --description "optional detail"
+# Preferred — links the feature to its plan and the plan's track:
+htmlgraph feature create "Short description" --plan <plan-id> --description "optional detail"
+# Last resort (hotfix or pre-plan work):
+htmlgraph feature create "Short description" --standalone "<reason>" --description "optional detail"
 ` + "```" + `
 `
 }

--- a/cmd/htmlgraph/main.go
+++ b/cmd/htmlgraph/main.go
@@ -128,6 +128,10 @@ func buildRoot() *cobra.Command {
 	recommend.GroupID = "query"
 	root.AddCommand(recommend)
 
+	relevant := relevantCmd()
+	relevant.GroupID = "query"
+	root.AddCommand(relevant)
+
 	// quality group
 	check := checkCmd()
 	check.GroupID = "quality"

--- a/cmd/htmlgraph/plan_cmds.go
+++ b/cmd/htmlgraph/plan_cmds.go
@@ -37,7 +37,8 @@ func planCmdWithExtras() *cobra.Command {
 	cmd.AddCommand(planWaitCmd())
 	cmd.AddCommand(planReadFeedbackCmd())
 	cmd.AddCommand(planValidateCmd())
-	cmd.AddCommand(planFinalizeCmd())
+	cmd.AddCommand(planFinalizeFromYAMLCmd())
+	cmd.AddCommand(planReopenCmd())
 	cmd.AddCommand(planCritiqueCmd())
 	cmd.AddCommand(planCreateYAMLCmd())
 	cmd.AddCommand(planAddSliceYAMLCmd())
@@ -54,6 +55,7 @@ func planCmdWithExtras() *cobra.Command {
 	cmd.AddCommand(planRenderCmd())
 	cmd.AddCommand(planFeedbackCmd())
 	cmd.AddCommand(planSetStatusCmd())
+	cmd.AddCommand(planMigrateOrphansCmd())
 	return cmd
 }
 

--- a/cmd/htmlgraph/plan_create.go
+++ b/cmd/htmlgraph/plan_create.go
@@ -42,8 +42,11 @@ Example:
 			if err != nil {
 				return err
 			}
-			planPath := filepath.Join(htmlgraphDir, "plans", planID+".html")
-			fmt.Println(planPath)
+			yamlPath := filepath.Join(htmlgraphDir, "plans", planID+".yaml")
+			htmlPath := filepath.Join(htmlgraphDir, "plans", planID+".html")
+			fmt.Printf("Edit here:  %s\n", yamlPath)
+			fmt.Printf("Then:       htmlgraph plan finalize %s\n", planID)
+			fmt.Println(htmlPath)
 			return nil
 		},
 	}

--- a/cmd/htmlgraph/plan_finalize.go
+++ b/cmd/htmlgraph/plan_finalize.go
@@ -222,10 +222,17 @@ func findTrackForPlan(p *workitem.Project, planID string) string {
 func planFinalizeFromYAMLCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "finalize <plan-id>",
-		Short: "Promote plan slices to real features and lock the plan",
+		Short: "Promote plan slices to real features and lock the plan (hierarchy flow)",
 		Long: `Validate and finalize a YAML plan: promote each slice to a real feature
 linked to both the plan and its track. Writes feature IDs back to YAML.
 After finalize the plan is locked — use 'plan reopen' to unlock.
+
+This is the hierarchy-only flow: the plan must already have a track, and
+every slice in the YAML is promoted unconditionally. It does NOT consult
+SQLite plan_feedback for per-slice approvals.
+
+For the dashboard-review workflow that creates a track and only promotes
+slices with explicit approve actions, use 'plan finalize-yaml' instead.
 
 Requires:
   - plan has a track (set meta.track_id in YAML)
@@ -316,16 +323,22 @@ func executePlanFinalizeFromYAML(p *workitem.Project, htmlgraphDir, planID strin
 		// Write feature_id back to YAML slice immediately.
 		plan.Slices[i].FeatureID = feat.ID
 
-		// Wire part_of (feature→track) and contains (track→feature).
-		wireTrackEdges(p, feat.ID, trackID, feat.Title) //nolint:errcheck
+		// Wire part_of (feature→track) and contains (track→feature). A failure
+		// here means a stale meta.track_id — fail the finalize rather than
+		// locking the plan with inconsistent hierarchy edges.
+		if err := wireTrackEdges(p, feat.ID, trackID, feat.Title); err != nil {
+			return nil, fmt.Errorf("wire track edges for slice %d (%s → %s): %w", s.Num, feat.ID, trackID, err)
+		}
 
 		// Link feature → plan via planned_in edge.
-		p.Features.AddEdge(feat.ID, models.Edge{ //nolint:errcheck
+		if _, err := p.Features.AddEdge(feat.ID, models.Edge{
 			TargetID:     planID,
 			Relationship: models.RelPlannedIn,
 			Title:        planID,
 			Since:        time.Now().UTC(),
-		})
+		}); err != nil {
+			return nil, fmt.Errorf("link feature %s to plan %s: %w", feat.ID, planID, err)
+		}
 	}
 
 	// Wire blocked_by edges from slice deps.

--- a/cmd/htmlgraph/plan_finalize.go
+++ b/cmd/htmlgraph/plan_finalize.go
@@ -20,60 +20,6 @@ type finalizeResult struct {
 	ExecuteCmd       string // CLI command to start working on the track
 }
 
-// planFinalizeCmd creates a cobra command for plan finalize.
-func planFinalizeCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "finalize <plan-id>",
-		Short: "Generate a work item graph from a plan",
-		Long: `Read a plan's steps (slices) and generate the work item graph:
-a track, features per slice, and edges for dependencies.
-
-Idempotent: re-running on an already-finalized plan is a no-op.
-
-Example:
-  htmlgraph plan finalize plan-a1b2c3d4`,
-		Args: cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			htmlgraphDir, err := findHtmlgraphDir()
-			if err != nil {
-				return err
-			}
-			p, err := workitem.Open(htmlgraphDir, "claude-code")
-			if err != nil {
-				return fmt.Errorf("open project: %w", err)
-			}
-			defer p.Close()
-
-			result, err := executePlanFinalize(p, htmlgraphDir, args[0])
-			if err != nil {
-				return err
-			}
-
-			if result.AlreadyFinalized {
-				fmt.Printf("Plan %s is already finalized", args[0])
-				if result.TrackID != "" {
-					fmt.Printf(" (track: %s)", result.TrackID)
-				}
-				fmt.Println()
-				if result.ExecuteCmd != "" {
-					fmt.Printf("\nExecute:\n  %s\n", result.ExecuteCmd)
-				}
-				return nil
-			}
-
-			fmt.Printf("Created track: %s\n", result.TrackID)
-			fmt.Printf("Created %d features\n", len(result.FeatureIDs))
-			for _, fid := range result.FeatureIDs {
-				fmt.Printf("  %s\n", fid)
-			}
-			if result.ExecuteCmd != "" {
-				fmt.Printf("\nExecute:\n  %s\n", result.ExecuteCmd)
-			}
-			return nil
-		},
-	}
-}
-
 // executePlanFinalize reads a plan's steps, creates a track and features,
 // wires edges, and marks the plan as finalized. Idempotent.
 func executePlanFinalize(p *workitem.Project, htmlgraphDir, planID string) (*finalizeResult, error) {
@@ -263,4 +209,181 @@ func findTrackForPlan(p *workitem.Project, planID string) string {
 		}
 	}
 	return ""
+}
+
+// ---- New YAML-first finalize (plan finalize v2) --------------------------------
+
+// planFinalizeFromYAMLCmd creates a cobra command for the new plan finalize.
+// This replaces the old finalize which created a new track. The new design:
+//  1. Validates: plan has a track, problem statement, and ≥1 slice.
+//  2. Creates real features for each slice, linked to plan + track.
+//  3. Writes the promoted feature_id back to each YAML slice.
+//  4. Marks plan status "finalized" and re-renders HTML.
+func planFinalizeFromYAMLCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "finalize <plan-id>",
+		Short: "Promote plan slices to real features and lock the plan",
+		Long: `Validate and finalize a YAML plan: promote each slice to a real feature
+linked to both the plan and its track. Writes feature IDs back to YAML.
+After finalize the plan is locked — use 'plan reopen' to unlock.
+
+Requires:
+  - plan has a track (set meta.track_id in YAML)
+  - plan has a non-empty problem statement
+  - plan has at least one slice
+
+Example:
+  htmlgraph plan finalize plan-a1b2c3d4`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			htmlgraphDir, err := findHtmlgraphDir()
+			if err != nil {
+				return err
+			}
+			p, err := workitem.Open(htmlgraphDir, agentForClaim())
+			if err != nil {
+				return fmt.Errorf("open project: %w", err)
+			}
+			defer p.Close()
+
+			result, err := executePlanFinalizeFromYAML(p, htmlgraphDir, args[0])
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("%d features created, plan locked\n", len(result.FeatureIDs))
+			fmt.Printf("Track: %s\n", result.TrackID)
+			for _, fid := range result.FeatureIDs {
+				fmt.Printf("  %s\n", fid)
+			}
+			if result.ExecuteCmd != "" {
+				fmt.Printf("\nNext: %s\n", result.ExecuteCmd)
+			}
+			return nil
+		},
+	}
+}
+
+// executePlanFinalizeFromYAML implements the new plan finalize logic.
+// It validates the YAML plan, creates features for each slice linked to plan
+// and track, writes feature_id back to YAML, and marks the plan finalized.
+func executePlanFinalizeFromYAML(p *workitem.Project, htmlgraphDir, planID string) (*finalizeResult, error) {
+	planPath := filepath.Join(htmlgraphDir, "plans", planID+".yaml")
+	plan, err := planyaml.Load(planPath)
+	if err != nil {
+		return nil, fmt.Errorf("load plan YAML: %w", err)
+	}
+
+	// Guard: already finalized → must use plan reopen first.
+	if plan.Meta.Status == "finalized" {
+		return nil, fmt.Errorf("plan %s is locked (status: finalized) — use 'plan reopen %s' to unlock", planID, planID)
+	}
+
+	// Validate: must have a track.
+	if plan.Meta.TrackID == "" {
+		return nil, fmt.Errorf("plan must be on a track — set meta.track_id in YAML or use 'plan attach-track %s <trk-id>'", planID)
+	}
+
+	// Validate: must have a problem statement.
+	if strings.TrimSpace(plan.Design.Problem) == "" {
+		return nil, fmt.Errorf("plan must have a non-empty problem statement — set design.problem in YAML")
+	}
+
+	// Validate: must have at least one slice.
+	if len(plan.Slices) == 0 {
+		return nil, fmt.Errorf("plan must have at least one slice — add slices with 'plan add-slice-yaml %s <title>'", planID)
+	}
+
+	trackID := plan.Meta.TrackID
+
+	// Create features for each slice.
+	numToFeatureID := make(map[int]string, len(plan.Slices))
+	var featureIDs []string
+
+	for i, s := range plan.Slices {
+		content := buildSliceFeatureContent(s)
+		feat, err := p.Features.Create(s.Title,
+			workitem.FeatWithTrack(trackID),
+			workitem.FeatWithContent(content),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create feature for slice %d (%q): %w", s.Num, s.Title, err)
+		}
+
+		numToFeatureID[s.Num] = feat.ID
+		featureIDs = append(featureIDs, feat.ID)
+
+		// Write feature_id back to YAML slice immediately.
+		plan.Slices[i].FeatureID = feat.ID
+
+		// Wire part_of (feature→track) and contains (track→feature).
+		wireTrackEdges(p, feat.ID, trackID, feat.Title) //nolint:errcheck
+
+		// Link feature → plan via planned_in edge.
+		p.Features.AddEdge(feat.ID, models.Edge{ //nolint:errcheck
+			TargetID:     planID,
+			Relationship: models.RelPlannedIn,
+			Title:        planID,
+			Since:        time.Now().UTC(),
+		})
+	}
+
+	// Wire blocked_by edges from slice deps.
+	for _, s := range plan.Slices {
+		for _, depNum := range s.Deps {
+			depFeatID, ok := numToFeatureID[depNum]
+			if !ok {
+				continue
+			}
+			p.Features.AddEdge(numToFeatureID[s.Num], models.Edge{ //nolint:errcheck
+				TargetID:     depFeatID,
+				Relationship: "blocked_by",
+				Since:        time.Now().UTC(),
+			})
+		}
+	}
+
+	// Link plan → track via implemented_in.
+	p.Plans.AddEdge(planID, models.Edge{ //nolint:errcheck
+		TargetID:     trackID,
+		Relationship: models.RelImplementedIn,
+		Title:        trackID,
+		Since:        time.Now().UTC(),
+	})
+
+	// Lock the plan: set status to finalized in YAML.
+	plan.Meta.Status = "finalized"
+	if err := planyaml.Save(planPath, plan); err != nil {
+		return nil, fmt.Errorf("save plan YAML: %w", err)
+	}
+
+	// Re-render the plan HTML so it reflects finalized state.
+	_ = renderPlanToFile(htmlgraphDir, planID)
+
+	return &finalizeResult{
+		TrackID:    trackID,
+		FeatureIDs: featureIDs,
+		ExecuteCmd: buildExecuteCmd(trackID),
+	}, nil
+}
+
+// buildSliceFeatureContent constructs a feature description from a YAML slice's
+// what/why/done-when fields.
+func buildSliceFeatureContent(s planyaml.PlanSlice) string {
+	if s.What == "" {
+		return s.Why
+	}
+	var sb strings.Builder
+	sb.WriteString(s.What)
+	if s.Why != "" {
+		sb.WriteString("\n\n## Why\n")
+		sb.WriteString(s.Why)
+	}
+	if len(s.DoneWhen) > 0 {
+		sb.WriteString("\n\n## Done When\n")
+		for _, d := range s.DoneWhen {
+			sb.WriteString("- " + d + "\n")
+		}
+	}
+	return sb.String()
 }

--- a/cmd/htmlgraph/plan_finalize_test.go
+++ b/cmd/htmlgraph/plan_finalize_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/shakestzd/htmlgraph/internal/planyaml"
 	"github.com/shakestzd/htmlgraph/internal/workitem"
 )
 
@@ -147,4 +148,263 @@ func TestPlanFinalize_EmptyPlan(t *testing.T) {
 	if len(result.FeatureIDs) != 0 {
 		t.Errorf("features = %d, want 0", len(result.FeatureIDs))
 	}
+}
+
+// ---- New YAML-based finalize (plan finalize v2) tests -------------------------
+
+// setupYAMLFinalizeProject creates a temp dir with a YAML plan that has a track,
+// problem statement, and the requested number of slices. Returns the plan ID.
+func setupYAMLFinalizeProject(t *testing.T, p *workitem.Project, dir string, numSlices int) (string, string) {
+	t.Helper()
+
+	// Create a track first.
+	track, err := p.Tracks.Create("Test Track")
+	if err != nil {
+		t.Fatalf("create track: %v", err)
+	}
+
+	planID := workitem.GenerateID("plan", "YAML Test Plan")
+	plan := planyaml.NewPlan(planID, "YAML Test Plan", "test plan")
+	plan.Meta.TrackID = track.ID
+	plan.Design.Problem = "We need to solve this problem"
+
+	for i := 1; i <= numSlices; i++ {
+		plan.Slices = append(plan.Slices, planyaml.PlanSlice{
+			ID:    workitem.GenerateID("slice", "slice"),
+			Num:   i,
+			Title: "Slice " + strings.Repeat("I", i),
+			What:  "do something",
+			Why:   "because reasons",
+		})
+	}
+
+	planPath := filepath.Join(dir, "plans", planID+".yaml")
+	if err := planyaml.Save(planPath, plan); err != nil {
+		t.Fatalf("save plan YAML: %v", err)
+	}
+
+	// Also create the HTML workitem for the plan.
+	if _, err := p.Plans.Create("YAML Test Plan",
+		workitem.PlanWithTrack(track.ID),
+	); err != nil {
+		t.Logf("create plan node warning: %v", err)
+	}
+
+	return planID, track.ID
+}
+
+func TestPlanFinalizeFromYAML_HappyPath(t *testing.T) {
+	p, dir := setupFinalizeProject(t)
+	planID, trackID := setupYAMLFinalizeProject(t, p, dir, 2)
+
+	result, err := executePlanFinalizeFromYAML(p, dir, planID)
+	if err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+
+	if result.TrackID != trackID {
+		t.Errorf("trackID = %q, want %q", result.TrackID, trackID)
+	}
+	if len(result.FeatureIDs) != 2 {
+		t.Errorf("features = %d, want 2", len(result.FeatureIDs))
+	}
+	for _, fid := range result.FeatureIDs {
+		if !strings.HasPrefix(fid, "feat-") {
+			t.Errorf("feature ID %q missing feat- prefix", fid)
+		}
+	}
+
+	// Verify features were created and linked.
+	for _, fid := range result.FeatureIDs {
+		feat, err := p.Features.Get(fid)
+		if err != nil {
+			t.Fatalf("get feature %s: %v", fid, err)
+		}
+		if feat.TrackID != trackID {
+			t.Errorf("feature %s track = %q, want %q", fid, feat.TrackID, trackID)
+		}
+		// Should have planned_in edge to plan.
+		plannedIn := feat.Edges[string("planned_in")]
+		found := false
+		for _, e := range plannedIn {
+			if e.TargetID == planID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("feature %s missing planned_in → %s edge", fid, planID)
+		}
+	}
+}
+
+func TestPlanFinalizeFromYAML_FeatureIDWrittenBack(t *testing.T) {
+	p, dir := setupFinalizeProject(t)
+	planID, _ := setupYAMLFinalizeProject(t, p, dir, 2)
+
+	_, err := executePlanFinalizeFromYAML(p, dir, planID)
+	if err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+
+	// Load YAML and verify feature_ids were written back.
+	planPath := filepath.Join(dir, "plans", planID+".yaml")
+	plan, err := planyaml.Load(planPath)
+	if err != nil {
+		t.Fatalf("load plan: %v", err)
+	}
+	for i, s := range plan.Slices {
+		if s.FeatureID == "" {
+			t.Errorf("slice[%d] (num=%d) has no feature_id after finalize", i, s.Num)
+		}
+		if !strings.HasPrefix(s.FeatureID, "feat-") {
+			t.Errorf("slice[%d] feature_id = %q, missing feat- prefix", i, s.FeatureID)
+		}
+	}
+	if plan.Meta.Status != "finalized" {
+		t.Errorf("plan status = %q, want finalized", plan.Meta.Status)
+	}
+}
+
+func TestPlanFinalizeFromYAML_NoTrack(t *testing.T) {
+	p, dir := setupFinalizeProject(t)
+
+	// Create plan YAML without track.
+	planID := workitem.GenerateID("plan", "no-track plan")
+	plan := planyaml.NewPlan(planID, "no-track plan", "")
+	plan.Design.Problem = "a problem"
+	plan.Slices = append(plan.Slices, planyaml.PlanSlice{
+		Num: 1, Title: "slice one", What: "do it",
+	})
+	planPath := filepath.Join(dir, "plans", planID+".yaml")
+	if err := planyaml.Save(planPath, plan); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	_, err := executePlanFinalizeFromYAML(p, dir, planID)
+	if err == nil {
+		t.Fatal("expected error for plan without track")
+	}
+	if !strings.Contains(err.Error(), "track") {
+		t.Errorf("error should mention 'track', got: %v", err)
+	}
+}
+
+func TestPlanFinalizeFromYAML_NoProblemStatement(t *testing.T) {
+	p, dir := setupFinalizeProject(t)
+
+	track, _ := p.Tracks.Create("T")
+	planID := workitem.GenerateID("plan", "no-problem plan")
+	plan := planyaml.NewPlan(planID, "no-problem plan", "")
+	plan.Meta.TrackID = track.ID
+	// Leave Design.Problem empty.
+	plan.Slices = append(plan.Slices, planyaml.PlanSlice{
+		Num: 1, Title: "slice one", What: "do it",
+	})
+	planPath := filepath.Join(dir, "plans", planID+".yaml")
+	if err := planyaml.Save(planPath, plan); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	_, err := executePlanFinalizeFromYAML(p, dir, planID)
+	if err == nil {
+		t.Fatal("expected error for plan without problem statement")
+	}
+	if !strings.Contains(err.Error(), "problem") {
+		t.Errorf("error should mention 'problem', got: %v", err)
+	}
+}
+
+func TestPlanFinalizeFromYAML_NoSlices(t *testing.T) {
+	p, dir := setupFinalizeProject(t)
+
+	track, _ := p.Tracks.Create("T")
+	planID := workitem.GenerateID("plan", "no-slices plan")
+	plan := planyaml.NewPlan(planID, "no-slices plan", "")
+	plan.Meta.TrackID = track.ID
+	plan.Design.Problem = "a real problem"
+	// Leave Slices empty.
+	planPath := filepath.Join(dir, "plans", planID+".yaml")
+	if err := planyaml.Save(planPath, plan); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	_, err := executePlanFinalizeFromYAML(p, dir, planID)
+	if err == nil {
+		t.Fatal("expected error for plan without slices")
+	}
+	if !strings.Contains(err.Error(), "slice") {
+		t.Errorf("error should mention 'slice', got: %v", err)
+	}
+}
+
+func TestPlanFinalizeFromYAML_AlreadyFinalized(t *testing.T) {
+	p, dir := setupFinalizeProject(t)
+	planID, _ := setupYAMLFinalizeProject(t, p, dir, 1)
+
+	// First finalize.
+	if _, err := executePlanFinalizeFromYAML(p, dir, planID); err != nil {
+		t.Fatalf("first finalize: %v", err)
+	}
+
+	// Second finalize should return locked error.
+	_, err := executePlanFinalizeFromYAML(p, dir, planID)
+	if err == nil {
+		t.Fatal("expected error on double-finalize")
+	}
+	if !strings.Contains(err.Error(), "locked") && !strings.Contains(err.Error(), "reopen") {
+		t.Errorf("error should mention 'locked' or 'reopen', got: %v", err)
+	}
+}
+
+func TestPlanFinalizeFromYAML_Reopen(t *testing.T) {
+	p, dir := setupFinalizeProject(t)
+	planID, _ := setupYAMLFinalizeProject(t, p, dir, 1)
+
+	// Finalize then reopen.
+	if _, err := executePlanFinalizeFromYAML(p, dir, planID); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if err := executePlanReopen(dir, planID); err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+
+	// After reopen, status should be todo/draft (not finalized).
+	planPath := filepath.Join(dir, "plans", planID+".yaml")
+	plan, err := planyaml.Load(planPath)
+	if err != nil {
+		t.Fatalf("load plan: %v", err)
+	}
+	if plan.Meta.Status == "finalized" {
+		t.Error("plan should not be finalized after reopen")
+	}
+}
+
+func TestAddSliceYAML_NoPrintsFakeFeatureID(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "plans"), 0o755)
+
+	planID := workitem.GenerateID("plan", "test")
+	plan := planyaml.NewPlan(planID, "test", "")
+	planPath := filepath.Join(dir, "plans", planID+".yaml")
+	if err := planyaml.Save(planPath, plan); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// runPlanAddSliceYAML should return without error.
+	err := runPlanAddSliceYAML(dir, planID, "My Slice", "impl detail", "", "", "", "", "S", "Low", "")
+	if err != nil {
+		t.Fatalf("add-slice-yaml: %v", err)
+	}
+
+	// Load and verify the slice has ID but NOT a feature_id.
+	loaded, _ := planyaml.Load(planPath)
+	if len(loaded.Slices) != 1 {
+		t.Fatalf("expected 1 slice, got %d", len(loaded.Slices))
+	}
+	if loaded.Slices[0].FeatureID != "" {
+		t.Errorf("slice should have empty feature_id before finalize, got %q", loaded.Slices[0].FeatureID)
+	}
+	// The slice ID should be a stable identifier (not a fake feat-ID in the printed output).
+	// The test here just confirms the YAML slice doesn't have a feature_id set.
 }

--- a/cmd/htmlgraph/plan_finalize_test.go
+++ b/cmd/htmlgraph/plan_finalize_test.go
@@ -397,14 +397,20 @@ func TestAddSliceYAML_NoPrintsFakeFeatureID(t *testing.T) {
 		t.Fatalf("add-slice-yaml: %v", err)
 	}
 
-	// Load and verify the slice has ID but NOT a feature_id.
+	// Load and verify the slice has a slice- prefixed ID and NO feature_id yet.
 	loaded, _ := planyaml.Load(planPath)
 	if len(loaded.Slices) != 1 {
 		t.Fatalf("expected 1 slice, got %d", len(loaded.Slices))
 	}
-	if loaded.Slices[0].FeatureID != "" {
-		t.Errorf("slice should have empty feature_id before finalize, got %q", loaded.Slices[0].FeatureID)
+	got := loaded.Slices[0]
+	if got.FeatureID != "" {
+		t.Errorf("slice should have empty feature_id before finalize, got %q", got.FeatureID)
 	}
-	// The slice ID should be a stable identifier (not a fake feat-ID in the printed output).
-	// The test here just confirms the YAML slice doesn't have a feature_id set.
+	// The whole point of bug-32f787d1: slice IDs must not pretend to be features.
+	if strings.HasPrefix(got.ID, "feat-") {
+		t.Errorf("slice ID must not look like a feature ID, got %q", got.ID)
+	}
+	if !strings.HasPrefix(got.ID, "slic") {
+		t.Errorf("slice ID should be slic-prefixed (workitem.GenerateID convention), got %q", got.ID)
+	}
 }

--- a/cmd/htmlgraph/plan_finalize_yaml.go
+++ b/cmd/htmlgraph/plan_finalize_yaml.go
@@ -28,9 +28,17 @@ type planAmendment struct {
 func planFinalizeYAMLCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "finalize-yaml <plan-id>",
-		Short: "Create track and features from approved YAML plan slices",
-		Long: `Read a YAML plan + SQLite feedback, create a track and features for
-approved slices, wire dependency edges. Updates YAML status to finalized.
+		Short: "Create track and features from approved YAML plan slices (dashboard flow)",
+		Long: `Read a YAML plan + SQLite plan_feedback approvals, create a track and
+features for approved slices, wire dependency edges. Updates YAML status to
+finalized.
+
+This is the dashboard-review workflow: only slices with explicit approve
+actions in plan_feedback get promoted, and the track is created from scratch
+when one does not yet exist.
+
+For the simpler hierarchy-only flow that requires an existing track and
+promotes every slice unconditionally, use 'plan finalize' instead.
 
 Example:
   htmlgraph plan finalize-yaml plan-a1b2c3d4`,

--- a/cmd/htmlgraph/plan_migrate_orphans.go
+++ b/cmd/htmlgraph/plan_migrate_orphans.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shakestzd/htmlgraph/internal/models"
+	"github.com/shakestzd/htmlgraph/internal/workitem"
+	"github.com/spf13/cobra"
+)
+
+// planMigrateOrphansCmd creates a cobra command for plan migrate-orphans.
+func planMigrateOrphansCmd() *cobra.Command {
+	var apply bool
+
+	cmd := &cobra.Command{
+		Use:   "migrate-orphans",
+		Short: "Find features with no plan and mark them standalone",
+		Long: `Walk all features and find those whose part_of edges contain no plan-* target.
+These are "orphan" features that predate the plan hierarchy enforcement.
+
+Dry-run by default: prints count and IDs.
+Use --apply to mark each orphan with standalone_reason=pre-enforcement.
+
+Example:
+  htmlgraph plan migrate-orphans
+  htmlgraph plan migrate-orphans --apply`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			htmlgraphDir, err := findHtmlgraphDir()
+			if err != nil {
+				return err
+			}
+			p, err := workitem.Open(htmlgraphDir, agentForClaim())
+			if err != nil {
+				return fmt.Errorf("open project: %w", err)
+			}
+			defer p.Close()
+
+			return executeMigrateOrphans(p, apply)
+		},
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "mark orphan features standalone (default: dry-run)")
+	return cmd
+}
+
+// executeMigrateOrphans finds orphan features and optionally marks them standalone.
+// An orphan feature has no part_of edge pointing to a plan-* ID.
+func executeMigrateOrphans(p *workitem.Project, apply bool) error {
+	features, err := p.Features.List()
+	if err != nil {
+		return fmt.Errorf("list features: %w", err)
+	}
+
+	var orphans []*models.Node
+	for _, feat := range features {
+		if isOrphanFeature(feat) {
+			orphans = append(orphans, feat)
+		}
+	}
+
+	if len(orphans) == 0 {
+		fmt.Println("No orphan features found.")
+		return nil
+	}
+
+	if !apply {
+		fmt.Printf("Orphan features (no plan linkage): %d\n", len(orphans))
+		for _, f := range orphans {
+			fmt.Printf("  %s  %s\n", f.ID, truncate(f.Title, 50))
+		}
+		fmt.Println("\nRe-run with --apply to mark these features as standalone.")
+		return nil
+	}
+
+	// Apply: mark each orphan as standalone.
+	applied := 0
+	for _, feat := range orphans {
+		edit := p.Features.Edit(feat.ID)
+		edit = edit.SetProperty("standalone_reason", "pre-enforcement")
+		if err := edit.Save(); err != nil {
+			fmt.Printf("  Warning: failed to mark %s standalone: %v\n", feat.ID, err)
+			continue
+		}
+		applied++
+		fmt.Printf("  marked standalone: %s  %s\n", feat.ID, truncate(feat.Title, 50))
+	}
+
+	fmt.Printf("\nMarked %d of %d orphan features as standalone.\n", applied, len(orphans))
+	return nil
+}
+
+// isOrphanFeature returns true when the feature has no part_of edge pointing
+// to a plan-* ID. Features with an explicit standalone_reason are also excluded
+// (they've already been handled).
+func isOrphanFeature(feat *models.Node) bool {
+	// Already explicitly marked standalone — not an orphan.
+	if v, ok := feat.Properties["standalone_reason"]; ok && v != "" {
+		return false
+	}
+
+	partOfEdges := feat.Edges[string(models.RelPartOf)]
+	for _, edge := range partOfEdges {
+		if strings.HasPrefix(edge.TargetID, "plan-") {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/htmlgraph/plan_migrate_orphans.go
+++ b/cmd/htmlgraph/plan_migrate_orphans.go
@@ -90,19 +90,21 @@ func executeMigrateOrphans(p *workitem.Project, apply bool) error {
 	return nil
 }
 
-// isOrphanFeature returns true when the feature has no part_of edge pointing
-// to a plan-* ID. Features with an explicit standalone_reason are also excluded
-// (they've already been handled).
+// isOrphanFeature returns true when the feature has no edge linking it to a
+// plan. Both part_of → plan-* and planned_in → plan-* count as plan linkage —
+// plan finalize and feature create --plan write planned_in, while older
+// scaffolding may have used part_of. Features with an explicit
+// standalone_reason are also excluded (they've already been handled).
 func isOrphanFeature(feat *models.Node) bool {
-	// Already explicitly marked standalone — not an orphan.
 	if v, ok := feat.Properties["standalone_reason"]; ok && v != "" {
 		return false
 	}
 
-	partOfEdges := feat.Edges[string(models.RelPartOf)]
-	for _, edge := range partOfEdges {
-		if strings.HasPrefix(edge.TargetID, "plan-") {
-			return false
+	for _, rel := range []models.RelationshipType{models.RelPartOf, models.RelPlannedIn} {
+		for _, edge := range feat.Edges[string(rel)] {
+			if strings.HasPrefix(edge.TargetID, "plan-") {
+				return false
+			}
 		}
 	}
 	return true

--- a/cmd/htmlgraph/plan_migrate_orphans_test.go
+++ b/cmd/htmlgraph/plan_migrate_orphans_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/shakestzd/htmlgraph/internal/models"
+)
+
+func TestIsOrphanFeature(t *testing.T) {
+	tests := []struct {
+		name string
+		feat *models.Node
+		want bool
+	}{
+		{
+			name: "feature with planned_in plan edge is not orphan",
+			feat: &models.Node{
+				ID: "feat-001",
+				Edges: map[string][]models.Edge{
+					string(models.RelPlannedIn): {{TargetID: "plan-abc12345"}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "feature with part_of plan edge is not orphan",
+			feat: &models.Node{
+				ID: "feat-002",
+				Edges: map[string][]models.Edge{
+					string(models.RelPartOf): {{TargetID: "plan-abc12345"}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "feature with only part_of track edge is orphan",
+			feat: &models.Node{
+				ID: "feat-003",
+				Edges: map[string][]models.Edge{
+					string(models.RelPartOf): {{TargetID: "trk-deadbeef"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "feature already marked standalone is not orphan",
+			feat: &models.Node{
+				ID: "feat-004",
+				Properties: map[string]any{
+					"standalone_reason": "pre-enforcement",
+				},
+				Edges: map[string][]models.Edge{
+					string(models.RelPartOf): {{TargetID: "trk-deadbeef"}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "feature with empty standalone_reason and no plan edge is still orphan",
+			feat: &models.Node{
+				ID: "feat-005",
+				Properties: map[string]any{
+					"standalone_reason": "",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "feature with no edges and no properties is orphan",
+			feat: &models.Node{ID: "feat-006"},
+			want: true,
+		},
+		{
+			name: "feature with mixed edges (plan + track) is not orphan",
+			feat: &models.Node{
+				ID: "feat-007",
+				Edges: map[string][]models.Edge{
+					string(models.RelPartOf):    {{TargetID: "trk-deadbeef"}},
+					string(models.RelPlannedIn): {{TargetID: "plan-12345678"}},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isOrphanFeature(tt.feat); got != tt.want {
+				t.Errorf("isOrphanFeature() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/htmlgraph/plan_reopen.go
+++ b/cmd/htmlgraph/plan_reopen.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/shakestzd/htmlgraph/internal/planyaml"
+	"github.com/spf13/cobra"
+)
+
+// planReopenCmd creates a cobra command for plan reopen.
+func planReopenCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "reopen <plan-id>",
+		Short: "Unlock a finalized plan so slices can be edited",
+		Long: `Reopen a finalized plan by setting its status back to 'todo'.
+Promoted features are NOT deleted — they have their own lifecycle.
+Adding or editing slices after reopen will create NEW features on the next finalize.
+
+Example:
+  htmlgraph plan reopen plan-a1b2c3d4`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			htmlgraphDir, err := findHtmlgraphDir()
+			if err != nil {
+				return err
+			}
+			if err := executePlanReopen(htmlgraphDir, args[0]); err != nil {
+				return err
+			}
+			fmt.Printf("Plan %s reopened (status: todo).\n", args[0])
+			fmt.Println("Warning: promoted features are not deleted; editing slices will create NEW features on next finalize.")
+			return nil
+		},
+	}
+}
+
+// executePlanReopen unlocks a finalized plan by setting its YAML status back to "todo".
+// Promoted features are not deleted.
+func executePlanReopen(htmlgraphDir, planID string) error {
+	planPath := filepath.Join(htmlgraphDir, "plans", planID+".yaml")
+	plan, err := planyaml.Load(planPath)
+	if err != nil {
+		return fmt.Errorf("load plan YAML for %s: %w", planID, err)
+	}
+
+	if plan.Meta.Status != "finalized" {
+		return fmt.Errorf("plan %s is not finalized (status: %q) — nothing to reopen", planID, plan.Meta.Status)
+	}
+
+	plan.Meta.Status = "todo"
+	if err := planyaml.Save(planPath, plan); err != nil {
+		return fmt.Errorf("save plan YAML: %w", err)
+	}
+
+	// Re-render HTML to reflect new status.
+	_ = renderPlanToFile(htmlgraphDir, planID)
+
+	return nil
+}

--- a/cmd/htmlgraph/plan_yaml_cmds.go
+++ b/cmd/htmlgraph/plan_yaml_cmds.go
@@ -186,7 +186,7 @@ func runPlanAddSliceYAML(htmlgraphDir, planID, title, what, why, files, doneWhen
 	}
 
 	slice := planyaml.PlanSlice{
-		ID:       workitem.GenerateID("feat", title),
+		ID:       workitem.GenerateID("slice", title),
 		Num:      len(plan.Slices) + 1,
 		Title:    title,
 		What:     what,
@@ -207,6 +207,6 @@ func runPlanAddSliceYAML(htmlgraphDir, planID, title, what, why, files, doneWhen
 
 	commitPlanChange(planPath, fmt.Sprintf("plan(%s): add slice %d — %s", planID, slice.Num, title))
 
-	fmt.Printf("Slice %d added: %s\n", slice.Num, slice.ID)
+	fmt.Printf("Slice %d added\n", slice.Num)
 	return nil
 }

--- a/cmd/htmlgraph/prompts/system-prompt.md
+++ b/cmd/htmlgraph/prompts/system-prompt.md
@@ -16,9 +16,12 @@ Activate the work item you're working on BEFORE any tool calls:
 ```bash
 htmlgraph feature start feat-xxx  # or: htmlgraph bug start bug-xxx / htmlgraph spike start spk-xxx
 ```
-If no item matches, create one:
+If no item matches, **first run `htmlgraph relevant <topic>`** to find existing context. If still nothing, create one:
 ```bash
-htmlgraph feature create "title" --track <trk-id> --description "what you're implementing"
+# Preferred — links the feature to its plan and the plan's track:
+htmlgraph feature create "title" --plan <plan-id> --description "what you're implementing"
+# Last resort (hotfix or pre-plan work):
+htmlgraph feature create "title" --standalone "<reason>" --description "what you're implementing"
 htmlgraph feature start <new-id>
 ```
 The CIGS guidance (injected per-turn) lists open work items — pick from those.

--- a/cmd/htmlgraph/prompts/yolo-prompt.md
+++ b/cmd/htmlgraph/prompts/yolo-prompt.md
@@ -6,7 +6,10 @@ Permission prompts are disabled. You must self-enforce quality at every step.
 ## Mandatory Workflow for Each Feature
 
 ### Step 0 — Work Item (BEFORE anything else)
-1. Create: `htmlgraph feature create "title" --track <trk-id> --description "what you're building"`
+0. **Discover first:** `htmlgraph relevant <topic-or-file>` — surface existing features so you don't create an orphan
+1. Create one of:
+   - `htmlgraph feature create "title" --plan <plan-id> --description "what you're building"` (preferred — links to plan + its track)
+   - `htmlgraph feature create "title" --standalone "<reason>"` (last resort: hotfix or pre-plan work)
 2. Start: Record the active feature for attribution
 3. Isolate: Use a git worktree for each feature — never edit main directly
 

--- a/cmd/htmlgraph/relevant.go
+++ b/cmd/htmlgraph/relevant.go
@@ -171,11 +171,11 @@ func runRelevantSearch(hgDir, query string, qType queryType) ([]relevantResult, 
 		rgQuery = filepath.Base(query)
 	}
 
-	if err := searchWithRipgrep(hgDir, rgQuery, scores); err != nil && !isCommandNotFound(err) {
-		// If rg is missing, return a clear error.
+	if err := searchWithRipgrep(hgDir, rgQuery, scores); err != nil {
 		if isCommandNotFound(err) {
 			return nil, fmt.Errorf("ripgrep (rg) not found in PATH — install it: https://github.com/BurntSushi/ripgrep")
 		}
+		// Other errors are non-fatal: rg may have hit a transient issue. Continue with git-only attribution.
 	}
 
 	// Step 2: git log attribution (commit trailer + file history).
@@ -349,22 +349,26 @@ func attrOrEmpty(sel *goquery.Selection, name string) string {
 
 // searchViaGitFileHistory uses git log --follow to find commits touching the
 // given file, then parses htmlgraph-item trailers to attribute work items.
+//
+// Uses ASCII record separator (\x1e) between commits and unit separator (\x00)
+// between fields so that multi-line commit bodies (where htmlgraph-item trailers
+// usually live) parse correctly.
 func searchViaGitFileHistory(projectDir, hgDir, filePath string, scores map[string]*relevantResult) error {
 	out, err := exec.Command(
 		"git", "-C", projectDir,
-		"log", "--follow", "--format=%H\t%aI\t%s\t%b",
+		"log", "--follow", "--format=%x1e%H%x00%aI%x00%s%x00%b",
 		"--", filePath,
 	).Output()
 	if err != nil {
 		return nil
 	}
 
-	for _, block := range strings.Split(string(out), "\n") {
+	for _, block := range strings.Split(string(out), "\x1e") {
 		block = strings.TrimSpace(block)
 		if block == "" {
 			continue
 		}
-		parts := strings.SplitN(block, "\t", 4)
+		parts := strings.SplitN(block, "\x00", 4)
 		if len(parts) < 4 {
 			continue
 		}
@@ -394,21 +398,23 @@ func searchViaGitFileHistory(projectDir, hgDir, filePath string, scores map[stri
 
 // searchViaGitSHA looks up a specific commit SHA and extracts htmlgraph-item
 // trailers to attribute work items, then augments with ripgrep of item IDs.
+//
+// Uses \x00 field separators so that multi-line commit bodies parse correctly.
 func searchViaGitSHA(projectDir, hgDir, sha string, scores map[string]*relevantResult) error {
 	out, err := exec.Command(
 		"git", "-C", projectDir,
-		"log", "-1", "--format=%H\t%aI\t%s\t%B",
+		"log", "-1", "--format=%H%x00%aI%x00%s%x00%B",
 		sha,
 	).Output()
 	if err != nil {
 		return nil
 	}
 
-	block := strings.TrimSpace(string(out))
+	block := strings.TrimRight(string(out), "\n")
 	if block == "" {
 		return nil
 	}
-	parts := strings.SplitN(block, "\t", 4)
+	parts := strings.SplitN(block, "\x00", 4)
 	if len(parts) < 4 {
 		return nil
 	}

--- a/cmd/htmlgraph/relevant.go
+++ b/cmd/htmlgraph/relevant.go
@@ -293,15 +293,17 @@ func processRipgrepMatch(msg rgMessage, scores map[string]*relevantResult) error
 	return nil
 }
 
+// htmlTagPattern matches an HTML tag — compiled once and reused on the
+// per-ripgrep-line hot path inside isMarkupOnlyLine.
+var htmlTagPattern = regexp.MustCompile(`<[^>]+>`)
+
 // isMarkupOnlyLine returns true for lines that consist entirely of HTML tags/attributes
 // with no visible text content — these are low-signal ripgrep hits.
 func isMarkupOnlyLine(line string) bool {
-	// If the trimmed line starts with "<" and has no text between tags, skip it.
 	if !strings.HasPrefix(line, "<") {
 		return false
 	}
-	// Remove all tag content and check if anything meaningful remains.
-	stripped := regexp.MustCompile(`<[^>]+>`).ReplaceAllString(line, "")
+	stripped := htmlTagPattern.ReplaceAllString(line, "")
 	return strings.TrimSpace(stripped) == ""
 }
 

--- a/cmd/htmlgraph/relevant.go
+++ b/cmd/htmlgraph/relevant.go
@@ -1,0 +1,567 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/spf13/cobra"
+)
+
+// Ranking weight constants — tunable.
+const (
+	weightFileMention  = 2.0 // each ripgrep hit inside HTML content
+	weightCommitItem   = 3.0 // commit attributed to this item via htmlgraph-item trailer
+	weightStatusActive = 1.5 // bonus for in-progress items
+	weightStatusDone   = 0.2 // small weight for done items (still relevant as context)
+)
+
+// queryType classifies the user's query.
+type queryType int
+
+const (
+	queryTypeKeyword queryType = iota
+	queryTypeFile
+	queryTypeSHA
+)
+
+// shaPattern matches 7–40 lowercase hex characters (git SHA prefix or full).
+var shaPattern = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
+
+// knownExtensions is used to classify path-like queries without a slash.
+var knownExtensions = map[string]bool{
+	".go": true, ".md": true, ".html": true, ".yaml": true, ".yml": true,
+	".json": true, ".sh": true, ".ts": true, ".tsx": true, ".js": true,
+	".py": true, ".toml": true, ".txt": true,
+}
+
+// citation is a source reference supporting a match.
+type citation struct {
+	File    string `json:"file,omitempty"`
+	Line    int    `json:"line,omitempty"`
+	Snippet string `json:"snippet,omitempty"`
+	SHA     string `json:"sha,omitempty"`
+	Date    string `json:"date,omitempty"`
+	Subject string `json:"subject,omitempty"`
+}
+
+// relevantResult is one ranked work-item match.
+type relevantResult struct {
+	ID        string     `json:"id"`
+	Type      string     `json:"type"`
+	Title     string     `json:"title"`
+	Status    string     `json:"status"`
+	Score     float64    `json:"score"`
+	Citations []citation `json:"citations"`
+}
+
+func relevantCmd() *cobra.Command {
+	var format string
+
+	cmd := &cobra.Command{
+		Use:   "relevant <query>",
+		Short: "Find work items related to a file path, git SHA, or keyword",
+		Long: `Retrieval-first search: one call returns ranked, cited work-item matches.
+
+Query auto-detection:
+  file path  — contains '/' or ends with a known extension, or the path exists
+  git SHA    — 7–40 lowercase hex characters
+  keyword    — anything else
+
+Reads directly from .htmlgraph/*.html via ripgrep + git log.
+SQLite is not consulted.
+
+Examples:
+  htmlgraph relevant cmd/htmlgraph/relevant.go
+  htmlgraph relevant "retrieval"
+  htmlgraph relevant abc1234`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runRelevant(args[0], format)
+		},
+	}
+
+	isTTY := isTerminal()
+	defaultFmt := "json"
+	if isTTY {
+		defaultFmt = "text"
+	}
+	cmd.Flags().StringVar(&format, "format", defaultFmt, "Output format: json or text")
+	return cmd
+}
+
+// isTerminal returns true when stdout is a TTY.
+func isTerminal() bool {
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// detectQueryType classifies query as file path, git SHA, or keyword.
+func detectQueryType(query string) queryType {
+	// Explicit path separators.
+	if strings.Contains(query, "/") {
+		return queryTypeFile
+	}
+	// Known file extension suffix.
+	ext := strings.ToLower(filepath.Ext(query))
+	if ext != "" && knownExtensions[ext] {
+		return queryTypeFile
+	}
+	// File exists on disk.
+	if _, err := os.Stat(query); err == nil {
+		return queryTypeFile
+	}
+	// Ends with slash (directory).
+	if strings.HasSuffix(query, "/") {
+		return queryTypeFile
+	}
+	// SHA pattern.
+	if shaPattern.MatchString(strings.ToLower(query)) {
+		return queryTypeSHA
+	}
+	return queryTypeKeyword
+}
+
+// runRelevant is the main entry point for the relevant command.
+func runRelevant(query, format string) error {
+	hgDir, err := findHtmlgraphDir()
+	if err != nil {
+		return err
+	}
+
+	qType := detectQueryType(query)
+	results, err := runRelevantSearch(hgDir, query, qType)
+	if err != nil {
+		return err
+	}
+
+	results = rankResults(results)
+
+	switch format {
+	case "json":
+		return printRelevantJSON(results)
+	default:
+		printRelevantText(results)
+		return nil
+	}
+}
+
+// runRelevantSearch performs the multi-source retrieval pipeline and returns
+// unranked (or lightly scored) results. Exported for tests.
+func runRelevantSearch(hgDir, query string, qType queryType) ([]relevantResult, error) {
+	projectDir := filepath.Dir(hgDir)
+	scores := make(map[string]*relevantResult)
+
+	// Step 1: ripgrep search over HTML files.
+	rgQuery := query
+	if qType == queryTypeSHA {
+		// Search for the SHA as a literal string in the HTML files.
+		rgQuery = query
+	} else if qType == queryTypeFile {
+		// For file-path queries, use the base name and path components as keywords.
+		rgQuery = filepath.Base(query)
+	}
+
+	if err := searchWithRipgrep(hgDir, rgQuery, scores); err != nil && !isCommandNotFound(err) {
+		// If rg is missing, return a clear error.
+		if isCommandNotFound(err) {
+			return nil, fmt.Errorf("ripgrep (rg) not found in PATH — install it: https://github.com/BurntSushi/ripgrep")
+		}
+	}
+
+	// Step 2: git log attribution (commit trailer + file history).
+	if qType == queryTypeFile {
+		if err := searchViaGitFileHistory(projectDir, hgDir, query, scores); err != nil {
+			// Non-fatal: git may not be available or file may be untracked.
+			_ = err
+		}
+	} else if qType == queryTypeSHA {
+		if err := searchViaGitSHA(projectDir, hgDir, query, scores); err != nil {
+			_ = err
+		}
+	}
+
+	// Step 3: apply status bonuses to all collected items.
+	for _, r := range scores {
+		switch r.Status {
+		case "in-progress":
+			r.Score += weightStatusActive
+		case "done":
+			r.Score += weightStatusDone
+		}
+	}
+
+	// Collect into slice.
+	var out []relevantResult
+	for _, r := range scores {
+		out = append(out, *r)
+	}
+	return out, nil
+}
+
+// searchWithRipgrep runs rg --json over .htmlgraph/*.html for the given query
+// and adds scores/citations to the scores map.
+func searchWithRipgrep(hgDir, query string, scores map[string]*relevantResult) error {
+	args := []string{
+		"--json",
+		"--type", "html",
+		"--ignore-case",
+		"--max-count", "20",
+		query,
+		hgDir,
+	}
+	out, err := exec.Command("rg", args...).Output()
+	if err != nil {
+		// rg exits 1 when no matches — that's fine. Other errors pass through.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return nil
+		}
+		return err
+	}
+
+	// Parse NDJSON output from rg --json.
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var msg rgMessage
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			continue
+		}
+		if msg.Type != "match" {
+			continue
+		}
+		if err := processRipgrepMatch(msg, scores); err != nil {
+			continue
+		}
+	}
+	return nil
+}
+
+// rgMessage is a minimal ripgrep --json message.
+type rgMessage struct {
+	Type string    `json:"type"`
+	Data rgMatchData `json:"data"`
+}
+
+type rgMatchData struct {
+	Path    rgText   `json:"path"`
+	Lines   rgText   `json:"lines"`
+	LineNumber int   `json:"line_number"`
+}
+
+type rgText struct {
+	Text string `json:"text"`
+}
+
+// processRipgrepMatch extracts the work-item ID from the matched HTML file,
+// filters out hits that land in HTML markup, and updates scores.
+func processRipgrepMatch(msg rgMessage, scores map[string]*relevantResult) error {
+	filePath := msg.Data.Path.Text
+	lineText := strings.TrimSpace(msg.Data.Lines.Text)
+	lineNum := msg.Data.LineNumber
+
+	// Skip lines that look like pure HTML tag markup (data- attribute lines, tags only).
+	// Accept lines with meaningful text content outside angle brackets.
+	if isMarkupOnlyLine(lineText) {
+		return nil
+	}
+
+	// Parse the file to get work-item metadata.
+	node, err := parseHTMLWorkItem(filePath)
+	if err != nil || node == nil {
+		return err
+	}
+
+	r := getOrCreate(scores, node)
+	r.Score += weightFileMention
+	r.Citations = append(r.Citations, citation{
+		File:    filePath,
+		Line:    lineNum,
+		Snippet: truncate(lineText, 80),
+	})
+	return nil
+}
+
+// isMarkupOnlyLine returns true for lines that consist entirely of HTML tags/attributes
+// with no visible text content — these are low-signal ripgrep hits.
+func isMarkupOnlyLine(line string) bool {
+	// If the trimmed line starts with "<" and has no text between tags, skip it.
+	if !strings.HasPrefix(line, "<") {
+		return false
+	}
+	// Remove all tag content and check if anything meaningful remains.
+	stripped := regexp.MustCompile(`<[^>]+>`).ReplaceAllString(line, "")
+	return strings.TrimSpace(stripped) == ""
+}
+
+// parseHTMLWorkItem opens an HTML file and extracts id, type, title, status.
+func parseHTMLWorkItem(filePath string) (*relevantResult, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	doc, err := goquery.NewDocumentFromReader(f)
+	if err != nil {
+		return nil, err
+	}
+
+	article := doc.Find("article[id]").First()
+	if article.Length() == 0 {
+		return nil, nil // not a work item file
+	}
+
+	id, _ := article.Attr("id")
+	if id == "" {
+		return nil, nil
+	}
+
+	title := strings.TrimSpace(doc.Find("header h1").First().Text())
+	if title == "" {
+		title = strings.TrimSpace(doc.Find("title").First().Text())
+	}
+
+	return &relevantResult{
+		ID:     id,
+		Type:   attrOrEmpty(article, "data-type"),
+		Title:  title,
+		Status: attrOrEmpty(article, "data-status"),
+	}, nil
+}
+
+// attrOrEmpty returns an attribute value or empty string.
+func attrOrEmpty(sel *goquery.Selection, name string) string {
+	v, _ := sel.Attr(name)
+	return v
+}
+
+// searchViaGitFileHistory uses git log --follow to find commits touching the
+// given file, then parses htmlgraph-item trailers to attribute work items.
+func searchViaGitFileHistory(projectDir, hgDir, filePath string, scores map[string]*relevantResult) error {
+	out, err := exec.Command(
+		"git", "-C", projectDir,
+		"log", "--follow", "--format=%H\t%aI\t%s\t%b",
+		"--", filePath,
+	).Output()
+	if err != nil {
+		return nil
+	}
+
+	for _, block := range strings.Split(string(out), "\n") {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+		parts := strings.SplitN(block, "\t", 4)
+		if len(parts) < 4 {
+			continue
+		}
+		sha, date, subject, body := parts[0], parts[1], parts[2], parts[3]
+
+		// Extract htmlgraph-item trailers from commit body.
+		for _, itemID := range extractHTMLGraphTrailers(body) {
+			filePath := resolveItemHTMLPath(hgDir, itemID)
+			var node *relevantResult
+			if filePath != "" {
+				node, _ = parseHTMLWorkItem(filePath)
+			}
+			if node == nil {
+				node = &relevantResult{ID: itemID}
+			}
+			r := getOrCreate(scores, node)
+			r.Score += weightCommitItem
+			r.Citations = append(r.Citations, citation{
+				SHA:     sha[:min7(sha)],
+				Date:    date,
+				Subject: truncate(subject, 72),
+			})
+		}
+	}
+	return nil
+}
+
+// searchViaGitSHA looks up a specific commit SHA and extracts htmlgraph-item
+// trailers to attribute work items, then augments with ripgrep of item IDs.
+func searchViaGitSHA(projectDir, hgDir, sha string, scores map[string]*relevantResult) error {
+	out, err := exec.Command(
+		"git", "-C", projectDir,
+		"log", "-1", "--format=%H\t%aI\t%s\t%B",
+		sha,
+	).Output()
+	if err != nil {
+		return nil
+	}
+
+	block := strings.TrimSpace(string(out))
+	if block == "" {
+		return nil
+	}
+	parts := strings.SplitN(block, "\t", 4)
+	if len(parts) < 4 {
+		return nil
+	}
+	fullSHA, date, subject, body := parts[0], parts[1], parts[2], parts[3]
+
+	for _, itemID := range extractHTMLGraphTrailers(body) {
+		filePath := resolveItemHTMLPath(hgDir, itemID)
+		var node *relevantResult
+		if filePath != "" {
+			node, _ = parseHTMLWorkItem(filePath)
+		}
+		if node == nil {
+			node = &relevantResult{ID: itemID}
+		}
+		r := getOrCreate(scores, node)
+		r.Score += weightCommitItem
+		r.Citations = append(r.Citations, citation{
+			SHA:     fullSHA[:min7(fullSHA)],
+			Date:    date,
+			Subject: truncate(subject, 72),
+		})
+	}
+
+	// Also search the HTML files for the SHA as a keyword.
+	_ = searchWithRipgrep(hgDir, sha, scores)
+	return nil
+}
+
+// extractHTMLGraphTrailers parses "htmlgraph-item: <id>" trailers from a commit body.
+func extractHTMLGraphTrailers(body string) []string {
+	var ids []string
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		after, ok := strings.CutPrefix(strings.ToLower(line), "htmlgraph-item:")
+		if !ok {
+			continue
+		}
+		id := strings.TrimSpace(after)
+		// Restore original case — re-cut from original line.
+		orig := strings.TrimSpace(line[len("htmlgraph-item:"):])
+		if orig != "" {
+			ids = append(ids, orig)
+		} else if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// resolveItemHTMLPath finds the HTML file for a work-item ID by checking known subdirs.
+func resolveItemHTMLPath(hgDir, id string) string {
+	subdirs := []string{"features", "bugs", "spikes", "tracks", "plans", "specs", "metrics"}
+	for _, sub := range subdirs {
+		p := filepath.Join(hgDir, sub, id+".html")
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// getOrCreate returns an existing result or inserts a new one in the map.
+func getOrCreate(scores map[string]*relevantResult, node *relevantResult) *relevantResult {
+	if existing, ok := scores[node.ID]; ok {
+		// Update metadata if missing.
+		if existing.Title == "" && node.Title != "" {
+			existing.Title = node.Title
+		}
+		if existing.Type == "" && node.Type != "" {
+			existing.Type = node.Type
+		}
+		if existing.Status == "" && node.Status != "" {
+			existing.Status = node.Status
+		}
+		return existing
+	}
+	r := &relevantResult{
+		ID:     node.ID,
+		Type:   node.Type,
+		Title:  node.Title,
+		Status: node.Status,
+	}
+	scores[node.ID] = r
+	return r
+}
+
+// rankResults sorts results by score descending.
+func rankResults(results []relevantResult) []relevantResult {
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+	return results
+}
+
+// isCommandNotFound returns true when the error indicates a missing executable.
+func isCommandNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var execErr *exec.Error
+	if ok := isExecError(err, &execErr); ok {
+		return execErr.Err == exec.ErrNotFound
+	}
+	return strings.Contains(err.Error(), "executable file not found")
+}
+
+func isExecError(err error, target **exec.Error) bool {
+	if e, ok := err.(*exec.Error); ok {
+		*target = e
+		return true
+	}
+	return false
+}
+
+// min7 returns the min of 7 and len(s).
+func min7(s string) int {
+	if len(s) < 7 {
+		return len(s)
+	}
+	return 7
+}
+
+// printRelevantJSON outputs results as a JSON array.
+func printRelevantJSON(results []relevantResult) error {
+	if results == nil {
+		results = []relevantResult{}
+	}
+	data, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal json: %w", err)
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+// printRelevantText outputs a human-readable ranked list.
+func printRelevantText(results []relevantResult) {
+	if len(results) == 0 {
+		fmt.Println("No matching work items found.")
+		return
+	}
+	fmt.Printf("%-22s  %-8s  %-11s  %5s  %s\n", "ID", "TYPE", "STATUS", "SCORE", "TITLE")
+	fmt.Println(strings.Repeat("-", 80))
+	for _, r := range results {
+		fmt.Printf("%-22s  %-8s  %-11s  %5.1f  %s\n",
+			r.ID, r.Type, r.Status, r.Score, truncate(r.Title, 36))
+		for _, c := range r.Citations {
+			if c.SHA != "" {
+				fmt.Printf("    [%s] %s  %s\n", c.SHA, c.Date, truncate(c.Subject, 60))
+			} else if c.File != "" {
+				fmt.Printf("    %s:%d  %s\n", filepath.Base(c.File), c.Line, c.Snippet)
+			}
+		}
+	}
+	fmt.Printf("\n%d item(s)\n", len(results))
+}

--- a/cmd/htmlgraph/relevant_test.go
+++ b/cmd/htmlgraph/relevant_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sampleFeatureHTML is a minimal valid HtmlGraph feature HTML fixture.
+const sampleFeatureHTML = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Test Feature</title></head>
+<body>
+<article id="feat-aabbccdd"
+         data-type="feature"
+         data-status="in-progress"
+         data-priority="high"
+         data-created="2026-01-01T00:00:00Z"
+         data-updated="2026-04-01T00:00:00Z">
+  <header><h1>Retrieval-first discovery</h1></header>
+  <section data-content>
+    <p>This feature adds a retrieval-first workflow using ripgrep and git log.</p>
+    <p>It is very useful for finding relevant work items by path keyword or sha.</p>
+  </section>
+</article>
+</body>
+</html>`
+
+// makeRelevantFixture creates a temp .htmlgraph directory with one feature HTML file.
+// Returns the .htmlgraph dir path and a cleanup function.
+func makeRelevantFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	hgDir := filepath.Join(dir, ".htmlgraph")
+	featDir := filepath.Join(hgDir, "features")
+	if err := os.MkdirAll(featDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	featPath := filepath.Join(featDir, "feat-aabbccdd.html")
+	if err := os.WriteFile(featPath, []byte(sampleFeatureHTML), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return hgDir
+}
+
+// --- Query auto-detection unit tests ---
+
+func TestDetectQueryType_FilePath(t *testing.T) {
+	cases := []struct {
+		query string
+		want  queryType
+	}{
+		{"cmd/htmlgraph/relevant.go", queryTypeFile},
+		{"internal/models/node.go", queryTypeFile},
+		{"./foo/bar.html", queryTypeFile},
+		{"/absolute/path/to/file.md", queryTypeFile},
+		{"some/dir/", queryTypeFile},
+	}
+	for _, tc := range cases {
+		got := detectQueryType(tc.query)
+		if got != tc.want {
+			t.Errorf("detectQueryType(%q) = %v, want %v", tc.query, got, tc.want)
+		}
+	}
+}
+
+func TestDetectQueryType_GitSHA(t *testing.T) {
+	cases := []string{
+		"abc1234",         // 7 hex chars
+		"abc1234def56789", // longer hex
+		"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", // 40 chars
+	}
+	for _, sha := range cases {
+		got := detectQueryType(sha)
+		if got != queryTypeSHA {
+			t.Errorf("detectQueryType(%q) = %v, want %v", sha, got, queryTypeSHA)
+		}
+	}
+}
+
+func TestDetectQueryType_Keyword(t *testing.T) {
+	cases := []string{
+		"retrieval",
+		"auth middleware",
+		"plan finalize",
+		"xyz123",   // too short/mixed to be SHA
+		"hello world",
+	}
+	for _, kw := range cases {
+		got := detectQueryType(kw)
+		if got != queryTypeKeyword {
+			t.Errorf("detectQueryType(%q) = %v, want %v", kw, got, queryTypeKeyword)
+		}
+	}
+}
+
+func TestDetectQueryType_ExistingFile(t *testing.T) {
+	// A real file that exists should be detected as file-path
+	f, err := os.CreateTemp(t.TempDir(), "testfile*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	got := detectQueryType(f.Name())
+	if got != queryTypeFile {
+		t.Errorf("detectQueryType(existing file %q) = %v, want %v", f.Name(), got, queryTypeFile)
+	}
+}
+
+// --- Keyword ripgrep search ---
+
+func TestRunRelevantKeyword_ReturnsMatch(t *testing.T) {
+	hgDir := makeRelevantFixture(t)
+
+	results, err := runRelevantSearch(hgDir, "retrieval", queryTypeKeyword)
+	if err != nil {
+		t.Fatalf("runRelevantSearch: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least one result for keyword 'retrieval', got 0")
+	}
+
+	// Check that the result has the required fields populated.
+	r := results[0]
+	if r.ID == "" {
+		t.Error("result.ID is empty")
+	}
+	if r.Title == "" {
+		t.Error("result.Title is empty")
+	}
+	if r.Type == "" {
+		t.Error("result.Type is empty")
+	}
+	if r.Status == "" {
+		t.Error("result.Status is empty")
+	}
+}
+
+// --- File-path search ---
+
+func TestRunRelevantFilePath_ReturnsMatchingItems(t *testing.T) {
+	hgDir := makeRelevantFixture(t)
+
+	// The fixture content mentions "ripgrep and git log" — use the HTML file itself as path.
+	// Since we don't have a real git repo here, file-path mode falls back to keyword.
+	// Instead, verify the call path resolves without error.
+	results, err := runRelevantSearch(hgDir, "git log", queryTypeKeyword)
+	if err != nil {
+		t.Fatalf("runRelevantSearch (file path fallback): %v", err)
+	}
+	// Should find the fixture because it contains "git log".
+	if len(results) == 0 {
+		t.Fatal("expected match for 'git log' in content, got 0")
+	}
+}
+
+// --- JSON output shape ---
+
+func TestRelevantResult_JSONShape(t *testing.T) {
+	r := relevantResult{
+		ID:     "feat-aabbccdd",
+		Type:   "feature",
+		Title:  "Retrieval-first discovery",
+		Status: "in-progress",
+		Score:  3.0,
+		Citations: []citation{
+			{File: ".htmlgraph/features/feat-aabbccdd.html", Line: 10, Snippet: "retrieval"},
+		},
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	s := string(data)
+	for _, want := range []string{`"id"`, `"type"`, `"title"`, `"status"`, `"score"`, `"citations"`} {
+		if !strings.Contains(s, want) {
+			t.Errorf("JSON missing field %s: %s", want, s)
+		}
+	}
+}
+
+// --- No results ---
+
+func TestRunRelevantKeyword_NoMatch(t *testing.T) {
+	hgDir := makeRelevantFixture(t)
+
+	results, err := runRelevantSearch(hgDir, "zzz_nomatch_xyz_unlikely", queryTypeKeyword)
+	if err != nil {
+		t.Fatalf("runRelevantSearch: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for non-matching keyword, got %d", len(results))
+	}
+}
+
+// --- Score ordering ---
+
+func TestRankResults_OrderByScore(t *testing.T) {
+	items := []relevantResult{
+		{ID: "feat-aaa", Score: 1.0},
+		{ID: "feat-bbb", Score: 5.0},
+		{ID: "feat-ccc", Score: 3.0},
+	}
+	ranked := rankResults(items)
+	if ranked[0].ID != "feat-bbb" {
+		t.Errorf("first ranked item should be feat-bbb (score 5), got %s", ranked[0].ID)
+	}
+	if ranked[1].ID != "feat-ccc" {
+		t.Errorf("second ranked item should be feat-ccc (score 3), got %s", ranked[1].ID)
+	}
+}

--- a/cmd/htmlgraph/workitem_create.go
+++ b/cmd/htmlgraph/workitem_create.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	dbpkg "github.com/shakestzd/htmlgraph/internal/db"
 	"github.com/shakestzd/htmlgraph/internal/hooks"
@@ -12,14 +13,16 @@ import (
 )
 
 type wiCreateOpts struct {
-	trackID     string
-	priority    string
-	description string
-	files       string
-	steps       string // comma-separated implementation steps
-	start       bool
-	noLink      bool
-	causedBy    string // explicit caused_by feature ID for bugs
+	trackID          string
+	planID           string // feature: link to a plan (alternative to --track)
+	standaloneReason string // feature: explicit standalone reason (e.g. "pre-plan hotfix")
+	priority         string
+	description      string
+	files            string
+	steps            string // comma-separated implementation steps
+	start            bool
+	noLink           bool
+	causedBy         string // explicit caused_by feature ID for bugs
 }
 
 func wiCreateCmd(typeName, _ string) *cobra.Command {
@@ -43,6 +46,10 @@ func wiCreateCmd(typeName, _ string) *cobra.Command {
 	if typeName == "bug" {
 		cmd.Flags().StringVar(&opts.causedBy, "caused-by", "", "feature ID that caused this bug")
 	}
+	if typeName == "feature" {
+		cmd.Flags().StringVar(&opts.planID, "plan", "", "plan ID to link this feature to (e.g. plan-abc12345)")
+		cmd.Flags().StringVar(&opts.standaloneReason, "standalone", "", "reason this feature exists without a plan (e.g. 'hotfix')")
+	}
 	return cmd
 }
 
@@ -57,8 +64,27 @@ func runWiCreate(typeName, title string, o *wiCreateOpts) error {
 	}
 	defer p.Close()
 
+	// Enforce plan hierarchy for features first: require --plan OR --standalone.
+	// Features with an explicit --track but no --plan are also accepted (e.g.
+	// created by automated finalize), so only reject truly bare feature creates.
+	if typeName == "feature" && o.planID == "" && o.standaloneReason == "" && o.trackID == "" {
+		return fmt.Errorf("feature must have a parent plan OR --standalone <reason>.\nRun 'htmlgraph relevant <topic>' to find existing context first.")
+	}
+
 	if err := warnMissingFields(typeName, o); err != nil {
 		return err
+	}
+
+	// When --plan is given, resolve the plan to get its track ID so the feature
+	// is linked to both plan and track.
+	if typeName == "feature" && o.planID != "" && o.trackID == "" {
+		planNode, planErr := p.Plans.Get(o.planID)
+		if planErr != nil {
+			return fmt.Errorf("plan %s not found: %w", o.planID, planErr)
+		}
+		if planNode.TrackID != "" {
+			o.trackID = planNode.TrackID
+		}
 	}
 
 	node, err := createNode(p, typeName, title, o)
@@ -82,6 +108,25 @@ func runWiCreate(typeName, title string, o *wiCreateOpts) error {
 		}
 		if saveErr := edit.Save(); saveErr != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to save metadata: %v\n", saveErr)
+		}
+	}
+
+	// Wire feature → plan (planned_in edge) and record standalone_reason.
+	if typeName == "feature" {
+		if o.planID != "" {
+			p.Features.AddEdge(node.ID, models.Edge{ //nolint:errcheck
+				TargetID:     o.planID,
+				Relationship: models.RelPlannedIn,
+				Title:        o.planID,
+				Since:        time.Now().UTC(),
+			})
+		}
+		if o.standaloneReason != "" {
+			edit := p.Features.Edit(node.ID)
+			edit = edit.SetProperty("standalone_reason", o.standaloneReason)
+			if saveErr := edit.Save(); saveErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to save standalone_reason: %v\n", saveErr)
+			}
 		}
 	}
 

--- a/cmd/htmlgraph/workitem_create.go
+++ b/cmd/htmlgraph/workitem_create.go
@@ -71,12 +71,9 @@ func runWiCreate(typeName, title string, o *wiCreateOpts) error {
 		return fmt.Errorf("feature must have a parent plan OR --standalone <reason>.\nRun 'htmlgraph relevant <topic>' to find existing context first.")
 	}
 
-	if err := warnMissingFields(typeName, o); err != nil {
-		return err
-	}
-
 	// When --plan is given, resolve the plan to get its track ID so the feature
-	// is linked to both plan and track.
+	// is linked to both plan and track. This must run BEFORE warnMissingFields,
+	// otherwise validation rejects --plan-only feature creates for missing --track.
 	if typeName == "feature" && o.planID != "" && o.trackID == "" {
 		planNode, planErr := p.Plans.Get(o.planID)
 		if planErr != nil {
@@ -85,6 +82,10 @@ func runWiCreate(typeName, title string, o *wiCreateOpts) error {
 		if planNode.TrackID != "" {
 			o.trackID = planNode.TrackID
 		}
+	}
+
+	if err := warnMissingFields(typeName, o); err != nil {
+		return err
 	}
 
 	node, err := createNode(p, typeName, title, o)

--- a/cmd/htmlgraph/workitem_edges.go
+++ b/cmd/htmlgraph/workitem_edges.go
@@ -109,7 +109,8 @@ func autoTrackEdges(p *workitem.Project, itemID, typeName, trackID, itemTitle st
 // and specs are exempt from the track requirement.
 func warnMissingFields(typeName string, o *wiCreateOpts) error {
 	// Features and bugs require a track to link to an initiative.
-	if o.trackID == "" && (typeName == "feature" || typeName == "bug") {
+	// Features with an explicit standalone_reason are exempt from the track requirement.
+	if o.trackID == "" && (typeName == "feature" || typeName == "bug") && !(typeName == "feature" && o.standaloneReason != "") {
 		msg := fmt.Sprintf("%s requires --track <trk-id> to link to an initiative.\nRun 'htmlgraph track list' to see existing tracks.\nTo create a new track: htmlgraph track create \"Track Title\"", typeName)
 
 		// For bugs with --files, try to suggest the track via file ownership.
@@ -124,7 +125,9 @@ func warnMissingFields(typeName string, o *wiCreateOpts) error {
 
 	switch typeName {
 	case "bug", "feature":
-		if o.description == "" {
+		// Standalone features (no plan, no track) only need --standalone reason, not --description.
+		isStandaloneFeature := typeName == "feature" && o.standaloneReason != ""
+		if o.description == "" && !isStandaloneFeature {
 			return fmt.Errorf("%s requires --description (captures context for future sessions)\nExample: htmlgraph %s create \"title\" --description \"root cause and context\"", typeName, typeName)
 		}
 	case "spec":

--- a/internal/planyaml/schema.go
+++ b/internal/planyaml/schema.go
@@ -37,19 +37,20 @@ type PlanDesign struct {
 // PlanSlice is a vertical delivery slice with metadata for effort,
 // risk, dependencies, and human approval.
 type PlanSlice struct {
-	ID       string   `yaml:"id"`
-	Num      int      `yaml:"num"`
-	Title    string   `yaml:"title"`
-	What     string   `yaml:"what"`
-	Why      string   `yaml:"why"`
-	Files    []string `yaml:"files"`
-	Deps     []int    `yaml:"deps"`
-	DoneWhen []string `yaml:"done_when"`
-	Effort   string   `yaml:"effort"` // S | M | L
-	Risk     string   `yaml:"risk"`   // Low | Med | High
-	Tests    string   `yaml:"tests"`
-	Approved bool     `yaml:"approved"`
-	Comment  string   `yaml:"comment"`
+	ID        string   `yaml:"id"`
+	FeatureID string   `yaml:"feature_id,omitempty"` // populated after plan finalize
+	Num       int      `yaml:"num"`
+	Title     string   `yaml:"title"`
+	What      string   `yaml:"what"`
+	Why       string   `yaml:"why"`
+	Files     []string `yaml:"files"`
+	Deps      []int    `yaml:"deps"`
+	DoneWhen  []string `yaml:"done_when"`
+	Effort    string   `yaml:"effort"` // S | M | L
+	Risk      string   `yaml:"risk"`   // Low | Med | High
+	Tests     string   `yaml:"tests"`
+	Approved  bool     `yaml:"approved"`
+	Comment   string   `yaml:"comment"`
 }
 
 // PlanQuestion is an open design question with options and an optional answer.

--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -189,7 +189,14 @@ else
         ok "Tagged v$VERSION"
     fi
 
-    git push origin main --tags
+    # Push main branch and only the specific new tag. Pushing --tags broadcasts
+    # every local tag and fails the whole script when historical tags already
+    # exist on the remote (bug-b0264f1b). Push the exact new ref by name.
+    if ! $DOCS_ONLY && [[ -n "$VERSION" ]]; then
+        git push origin main "v$VERSION"
+    else
+        git push origin main
+    fi
     ok "Pushed to origin/main"
 fi
 
@@ -239,7 +246,9 @@ else
     #    No plugin reinstall needed — the marketplace clone update (above)
     #    is sufficient. Reinstalling interferes with dev mode (--plugin-dir).
     if [[ -f "$PROJECT_ROOT/plugin/build.sh" ]]; then
-        sh "$PROJECT_ROOT/plugin/build.sh" 2>&1 | tail -1
+        # Invoke with bash explicitly: build.sh uses `set -o pipefail` which is
+        # a bashism and fails under POSIX sh / dash (bug-364cebb7).
+        bash "$PROJECT_ROOT/plugin/build.sh" 2>&1 | tail -1
         ok "CLI binary rebuilt"
     else
         warn "build.sh not found — skipping CLI rebuild"


### PR DESCRIPTION
## Summary

Closes track **trk-dcde741a** "HtmlGraph self-coherence — binary as source of truth". Three features and two bugs landed across four commits.

- **feat-27f8f9a5** — `htmlgraph relevant` retrieval command. Single tool call returns ranked, cited work items for a file path, git SHA, or keyword. Pipeline: ripgrep over `.htmlgraph/*.html` + `git log` with `htmlgraph-item:` trailer parsing + goquery filtering. No SQLite, no new caches — canonical sources only. ~280 LOC, 9 tests.
- **feat-f0f300c9** — `plan finalize` / `plan reopen` / `plan migrate-orphans` commands, plus `feature create --plan|--standalone` enforcement. Slices stay design artifacts in YAML during authoring; finalize promotes them to real features linked via `planned_in`. Bare `feature create` now errors with a hint to run `htmlgraph relevant` first.
- **bug-32f787d1** — `plan add-slice-yaml` no longer emits fake `feat-XXX` IDs that aren't real work items. Slices print `Slice N added` instead.
- **bug-6979102a** — closed as already resolved by v0.55.2 (no `unusedfunc` warnings remain on main).

Also includes a roborev-driven follow-up commit fixing 3 findings before this PR was opened:
- HIGH: `isOrphanFeature` recognized only `part_of → plan-*`, but `plan finalize` writes `planned_in` — would have misclassified every freshly finalized feature as an orphan. Now matches both edge types.
- MEDIUM: `git log` parsing in `relevant.go` split on `\n`, dropping `htmlgraph-item:` trailers from multi-line commit bodies. Switched to ASCII record/unit separators (`\x1e`/`\x00`).
- LOW: dead-code branch in `rg not found` error path. Reordered checks.

## Commits

```
910d394cf fix(relevant,plan): address roborev findings on trk-dcde741a
3ea0cd63e feat(feature,plan): hierarchy enforcement + fake-ID fix + finalize tests (bug-32f787d1)
88db3b3db feat(plan): finalize, reopen, migrate-orphans commands (feat-f0f300c9)
50414fc45 feat(relevant): add retrieval-first relevant command (feat-27f8f9a5)
```

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — all green
- [x] Smoke: `htmlgraph relevant <path>` / `<sha>` / `<keyword>` — returns ranked results in <500ms
- [x] Smoke: `htmlgraph feature create "bare"` — errors with `--plan|--standalone` hint
- [x] Smoke: `htmlgraph feature create "x" --standalone "reason"` — succeeds
- [x] Smoke: `htmlgraph plan migrate-orphans` (dry run) — lists orphans, no apply
- [x] Roborev branch review (job 1) — addressed 3 findings, closed
- [ ] **One-way door:** `htmlgraph plan migrate-orphans --apply` flagged 1075 features as orphans on dry run. Verify the `pre-enforcement` standalone reason is what you want before running with `--apply` — it touches every legacy feature in the project.

## Notes

- F1 of plan-5de29ea3 (generated agent interfaces, feat-c58a1c1d) was already merged — this PR completes F2 and F3.
- New commands surface in `htmlgraph plan` and `htmlgraph relevant` — help text autogenerates from cobra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)