### PR TITLE
docs: add security review findings for local server exposure

### DIFF
--- a/docs/security-review-2026-04-15.md
+++ b/docs/security-review-2026-04-15.md
@@ -1,0 +1,59 @@
+# Security Review (2026-04-15)
+
+This document captures **glaring** security issues identified from a quick code audit.
+
+## 1) Cross-origin access + no auth on local HTTP API (High)
+
+### Why this matters
+The dashboard server enables permissive CORS (`*`) for all routes via a shared middleware, and multiple routes include state-changing operations (POST).
+
+In practice, any website opened in the same browser can issue requests to `http://localhost:<port>` and read responses. Because there is no auth boundary, this can expose local project/session data and trigger mutations.
+
+### Evidence
+- CORS is globally permissive: `Access-Control-Allow-Origin: *` for all wrapped handlers.
+- Mutating APIs exist (e.g. session ingest POST) and are wrapped with that middleware.
+
+### Recommendations
+- Default-bind API to loopback (already done) **and** require same-origin checks for mutating endpoints.
+- Replace wildcard CORS with explicit allowlist (or disable CORS entirely for non-embed mode).
+- Add CSRF protections for mutating endpoints.
+- Consider a per-process random bearer token printed at startup for dashboard use.
+
+## 2) Entire `.htmlgraph` directory is web-accessible (High)
+
+### Why this matters
+The server exposes `.htmlgraph/` through `/htmlgraph/` using `http.FileServer`. This likely includes:
+- `htmlgraph.db` (full indexed session/event history)
+- logs
+- plans and internal artifacts
+
+Combined with permissive CORS, a malicious webpage can exfiltrate local project metadata/transcripts from the running dashboard server.
+
+### Evidence
+- `/htmlgraph/` is directly mapped to the on-disk `.htmlgraph` directory with no file allowlist.
+
+### Recommendations
+- Remove raw directory serving in production mode.
+- If needed for legacy UI, replace with explicit allowlist endpoints for specific safe files only.
+- Block access to `*.db`, `logs/`, and other sensitive/internal files.
+
+## 3) Project metadata leakage in global mode API (Medium)
+
+### Why this matters
+`/api/projects` returns each project's absolute local path (`Dir`) and `GitRemoteURL`. If CORS remains permissive, a third-party web page can read this and fingerprint repositories, organization names, or private infrastructure naming.
+
+### Evidence
+- The JSON response includes local `Dir` and `GitRemoteURL` directly from registry entries.
+
+### Recommendations
+- Do not return absolute paths by default; provide only opaque IDs + display names.
+- Gate remote URL exposure behind an explicit flag.
+- Restrict CORS / require auth before returning registry metadata.
+
+---
+
+## Risk summary
+- **High:** cross-origin unauthenticated API access and raw `.htmlgraph` file serving.
+- **Medium:** metadata overexposure from `/api/projects`.
+
+Together, these issues create a realistic local-data exfiltration path from a normal browser session.


### PR DESCRIPTION
### Motivation
- Add a focused, short security audit capturing glaring risks around the local HTTP dashboard and project exposure to guide follow-up remediation.

### Description
- Add `docs/security-review-2026-04-15.md` which documents three primary issues: globally-permissive CORS enabling cross-origin access to mutating APIs, direct exposure of the entire `.htmlgraph/` directory via `/htmlgraph/`, and metadata overexposure from `/api/projects` (absolute `Dir` and `GitRemoteURL`).

### Testing
- Ran `git diff --check` and `git status --short` to validate the change; both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0039a0a0c8324b344e77db02ab417)