### PR TITLE
feat(gemini-subtree): CI pipeline to split gemini extension for distribution

### DIFF
--- a/.github/workflows/gemini-subtree.yml
+++ b/.github/workflows/gemini-subtree.yml
@@ -7,15 +7,16 @@ name: Gemini Extension — Subtree Split
 #   gemini extensions install shakestzd/htmlgraph --ref gemini-extension-vX.Y.Z
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to tag (e.g. v0.55.6). Defaults to the tag that triggered the event."
-        required: false
-        default: ""
+        description: 'Version tag (e.g. v0.55.6)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -42,16 +43,18 @@ jobs:
       - name: Resolve version
         id: version
         run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            VERSION="${{ inputs.version }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ inputs.version }}"
           else
-            # release event: github.event.release.tag_name is the release tag (e.g. v0.55.6)
-            VERSION="${{ github.event.release.tag_name }}"
+            # push event: github.ref_name is the tag (e.g. v0.55.6)
+            version="${{ github.ref_name }}"
           fi
-          # Ensure leading 'v'
-          if [[ "$VERSION" != v* ]]; then VERSION="v${VERSION}"; fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Resolved version: ${VERSION}"
+          if [ -z "$version" ] || [ "$version" = "v" ]; then
+            echo "ERROR: version is empty or invalid" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: ${version}"
 
       - name: Run subtree-split script
         id: split

--- a/.github/workflows/gemini-subtree.yml
+++ b/.github/workflows/gemini-subtree.yml
@@ -1,0 +1,114 @@
+name: Gemini Extension — Subtree Split
+
+# Runs on every GitHub Release (published) and can be triggered manually.
+# Splits packages/gemini-extension/ to the gemini-extension-dist branch and
+# creates a per-release tag so end users can install via:
+#
+#   gemini extensions install shakestzd/htmlgraph --ref gemini-extension-vX.Y.Z
+
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag (e.g. v0.55.6). Defaults to the tag that triggered the event."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  # ── Job 1: split and publish the subtree ─────────────────────────────────
+  subtree-split:
+    name: Split & publish gemini-extension-dist
+    runs-on: ubuntu-latest
+    outputs:
+      dist-tag: ${{ steps.split.outputs.dist-tag }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history is required for git subtree split.
+          fetch-depth: 0
+
+      - name: Configure git identity for push
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+          else
+            # release event: github.event.release.tag_name is the release tag (e.g. v0.55.6)
+            VERSION="${{ github.event.release.tag_name }}"
+          fi
+          # Ensure leading 'v'
+          if [[ "$VERSION" != v* ]]; then VERSION="v${VERSION}"; fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: ${VERSION}"
+
+      - name: Run subtree-split script
+        id: split
+        env:
+          # Never skip push in CI — this job owns the distribution branch.
+          SKIP_PUSH: "0"
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          bash scripts/gemini-subtree-split.sh HEAD "${VERSION}"
+          echo "dist-tag=gemini-extension-${VERSION}" >> "$GITHUB_OUTPUT"
+
+  # ── Job 2: smoke-test the published ref ──────────────────────────────────
+  smoke-test:
+    name: Smoke-test gemini-extension-dist
+    runs-on: ubuntu-latest
+    needs: subtree-split
+
+    steps:
+      - name: Verify split ref has expected files via git ls-remote/ls-tree
+        run: |
+          DIST_TAG="${{ needs.subtree-split.outputs.dist-tag }}"
+          REPO="https://github.com/${{ github.repository }}.git"
+
+          echo "Checking remote tag: ${DIST_TAG}"
+
+          # Resolve the tag to a commit SHA.
+          SHA="$(git ls-remote "${REPO}" "refs/tags/${DIST_TAG}" | awk '{print $1}')"
+          if [[ -z "$SHA" ]]; then
+            # Annotated tags: dereference to the commit object.
+            SHA="$(git ls-remote "${REPO}" "refs/tags/${DIST_TAG}^{}" | awk '{print $1}')"
+          fi
+          if [[ -z "$SHA" ]]; then
+            echo "ERROR: Tag '${DIST_TAG}' not found on remote." >&2
+            exit 1
+          fi
+          echo "Tag SHA: ${SHA}"
+
+          # Clone the tag into a temp directory (shallow for speed).
+          TMP="$(mktemp -d)"
+          git clone --depth=1 --branch "${DIST_TAG}" "${REPO}" "${TMP}"
+
+          echo "Root of split branch:"
+          ls -la "${TMP}"
+
+          # Assert the extension manifest is present at the root.
+          if [[ ! -f "${TMP}/gemini-extension.json" ]]; then
+            echo "ERROR: gemini-extension.json missing from split ref root." >&2
+            exit 1
+          fi
+          echo "gemini-extension.json present — contents:"
+          cat "${TMP}/gemini-extension.json"
+
+          # Assert the context file is present (required by Gemini CLI).
+          if [[ ! -f "${TMP}/GEMINI.md" ]]; then
+            echo "ERROR: GEMINI.md (contextFileName) missing from split ref root." >&2
+            exit 1
+          fi
+          echo "GEMINI.md present."
+
+          echo "Smoke-test passed: split ref '${DIST_TAG}' is valid."

--- a/packages/gemini-extension/README.md
+++ b/packages/gemini-extension/README.md
@@ -1,5 +1,31 @@
 # gemini-extension — Generated Gemini CLI extension tree
 
+## Installing the extension (end users)
+
+The extension is distributed via a CI-maintained split branch. Install by pinning to a
+versioned tag published on every release:
+
+```
+gemini extensions install shakestzd/htmlgraph --ref gemini-extension-v<version>
+```
+
+For example, using the latest release:
+
+```
+gemini extensions install shakestzd/htmlgraph --ref gemini-extension-v0.55.5
+```
+
+The tag `gemini-extension-vX.Y.Z` points to a branch root that contains **only** the
+extension tree (no other monorepo paths). This is required because `gemini extensions install`
+has no subpath or sparse-checkout flag — the extension manifest must live at the repo root at
+the referenced ref.
+
+The distribution branch `gemini-extension-dist` and per-release tags are maintained
+automatically by the CI workflow `.github/workflows/gemini-subtree.yml` on every GitHub
+release. You do not need to manage this branch manually.
+
+---
+
 **This tree is generated from `packages/plugin-core/`. Do not hand-edit.**
 
 Regenerate with:

--- a/scripts/gemini-subtree-split.sh
+++ b/scripts/gemini-subtree-split.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# gemini-subtree-split.sh — Split packages/gemini-extension/ to a distribution branch/tag.
+#
+# Usage:
+#   scripts/gemini-subtree-split.sh [REF] [VERSION]
+#
+# Arguments:
+#   REF      Git ref to split from (default: HEAD)
+#   VERSION  Version string for the tag (default: derived from latest v* tag)
+#            Example: "v0.55.6" → tag "gemini-extension-v0.55.6"
+#
+# What it does:
+#   1. Runs `git subtree split` on packages/gemini-extension/ at REF.
+#   2. Force-creates local branch gemini-extension-dist pointing at the split commit.
+#   3. Creates annotated tag gemini-extension-<VERSION> on that commit.
+#   4. Force-pushes branch and tag to origin.
+#
+# Safety:
+#   - Uses --force flags so it is safe to re-run (idempotent for same REF).
+#   - Does NOT push unless called without SKIP_PUSH=1 (useful for local testing).
+#
+# Local test (no push):
+#   SKIP_PUSH=1 scripts/gemini-subtree-split.sh HEAD v0.55.100-test
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+REF="${1:-HEAD}"
+VERSION="${2:-}"
+
+# ── Derive version from latest tag if not provided ──────────────────────────
+if [[ -z "$VERSION" ]]; then
+  VERSION="$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || true)"
+  if [[ -z "$VERSION" ]]; then
+    echo "ERROR: No v* tag found and VERSION not provided. Pass a version as \$2." >&2
+    exit 1
+  fi
+fi
+
+# Strip leading 'v' if caller passed it bare, then normalise tag name.
+# Accepted inputs: "v0.55.6", "0.55.6", "v0.55.6-test"
+# Resulting tag: "gemini-extension-v0.55.6" (always has the leading 'v')
+if [[ "$VERSION" != v* ]]; then
+  VERSION="v${VERSION}"
+fi
+
+DIST_BRANCH="gemini-extension-dist"
+DIST_TAG="gemini-extension-${VERSION}"
+SUBTREE_PREFIX="packages/gemini-extension"
+
+echo "→ Splitting ${SUBTREE_PREFIX} from ref '${REF}' …"
+SPLIT_COMMIT="$(git subtree split --prefix="${SUBTREE_PREFIX}" "${REF}")"
+echo "  Split commit: ${SPLIT_COMMIT}"
+
+echo "→ Creating/updating local branch '${DIST_BRANCH}' …"
+git branch -f "${DIST_BRANCH}" "${SPLIT_COMMIT}"
+
+echo "→ Creating annotated tag '${DIST_TAG}' …"
+git tag -f -a "${DIST_TAG}" "${SPLIT_COMMIT}" \
+  -m "Gemini extension ${VERSION} — subtree split from ${SUBTREE_PREFIX}"
+
+echo "→ Verifying split tree contains gemini-extension.json …"
+if ! git ls-tree "${DIST_BRANCH}" | grep -q "gemini-extension.json"; then
+  echo "ERROR: gemini-extension.json not found at root of split branch '${DIST_BRANCH}'." >&2
+  echo "  git ls-tree output:" >&2
+  git ls-tree "${DIST_BRANCH}" >&2
+  exit 1
+fi
+
+echo "  Tree looks good:"
+git ls-tree "${DIST_BRANCH}"
+
+if [[ "${SKIP_PUSH:-0}" == "1" ]]; then
+  echo ""
+  echo "SKIP_PUSH=1: skipping push to origin."
+  echo "  Branch '${DIST_BRANCH}' created locally."
+  echo "  Tag    '${DIST_TAG}' created locally."
+  echo ""
+  echo "To inspect:"
+  echo "  git log --oneline ${DIST_BRANCH} -3"
+  echo "  git ls-tree ${DIST_BRANCH} | head"
+  exit 0
+fi
+
+echo "→ Pushing branch '${DIST_BRANCH}' to origin …"
+git push origin "${DIST_BRANCH}" --force
+
+echo "→ Pushing tag '${DIST_TAG}' to origin …"
+git push origin "${DIST_TAG}" --force
+
+echo ""
+echo "Done. End-user install:"
+echo "  gemini extensions install shakestzd/htmlgraph --ref ${DIST_TAG}"

--- a/scripts/gemini-subtree-split.sh
+++ b/scripts/gemini-subtree-split.sh
@@ -31,13 +31,10 @@ cd "$PROJECT_ROOT"
 REF="${1:-HEAD}"
 VERSION="${2:-}"
 
-# ── Derive version from latest tag if not provided ──────────────────────────
-if [[ -z "$VERSION" ]]; then
-  VERSION="$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || true)"
-  if [[ -z "$VERSION" ]]; then
-    echo "ERROR: No v* tag found and VERSION not provided. Pass a version as \$2." >&2
-    exit 1
-  fi
+# ── Validate version argument ────────────────────────────────────────────────
+if [ -z "${VERSION:-}" ] || [ "$VERSION" = "v" ]; then
+  echo "ERROR: version argument missing or invalid" >&2
+  exit 1
 fi
 
 # Strip leading 'v' if caller passed it bare, then normalise tag name.


### PR DESCRIPTION
## Summary

- Adds `scripts/gemini-subtree-split.sh` — idempotent script that runs `git subtree split` on `packages/gemini-extension/`, force-pushes the result to `gemini-extension-dist`, and creates an annotated tag `gemini-extension-vX.Y.Z` so end users can install via `gemini extensions install shakestzd/htmlgraph --ref gemini-extension-vX.Y.Z`
- Adds `.github/workflows/gemini-subtree.yml` — CI workflow triggered on `release: [published]` (plus `workflow_dispatch` for backfill/testing); split job + smoke-test job that clones the published tag and asserts `gemini-extension.json` and `GEMINI.md` are present at root
- Updates `packages/gemini-extension/README.md` with an end-user install section explaining the distribution model and why the subpath/subtree approach is needed

## Why

`gemini extensions install <source>` has no `--sparse` or subpath flag — the extension manifest must be at repo root at the referenced ref. The subtree-split distribution branch solves this without needing a separate repo.

## Local test results

- `git subtree split --prefix=packages/gemini-extension HEAD` produced commit `895154d6`
- `git ls-tree gemini-extension-dist` confirms: `gemini-extension.json`, `GEMINI.md`, `agents/`, `commands/`, `config/`, `hooks/`, `skills/`, `static/`, `templates/` — correct layout, no monorepo paths
- Local test branch cleaned up (not pushed to origin)

## Related

- Work item: feat-9eb614f0
- Track: trk-a7ee6791 — End-user install flow for Codex and Gemini

## Test plan

- [x] local subtree-split test produces expected root (`gemini-extension.json` at root, no monorepo paths)
- [x] Go quality gates pass (`go build ./... && go vet ./... && go test ./...`)
- [ ] CI quality-gates job passes on this PR
- [ ] next release triggers the workflow and publishes a real versioned tag (`gemini-extension-vX.Y.Z`)
- [ ] `gemini extensions install shakestzd/htmlgraph --ref gemini-extension-vX.Y.Z` succeeds against published tag

---

Generated with [Claude Code](https://claude.com/claude-code)
