### PR TITLE
feat(cli): htmlgraph codex subcommand

### DIFF
--- a/cmd/htmlgraph/codex.go
+++ b/cmd/htmlgraph/codex.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// codexMarketplaceRepo is the GitHub repo that hosts the codex marketplace.
+const codexMarketplaceRepo = "shakestzd/htmlgraph"
+
+// codexMarketplaceSparse is the sparse path within the monorepo.
+const codexMarketplaceSparse = "packages/codex-marketplace"
+
+// codexConfigPath returns the path to ~/.codex/config.toml.
+func codexConfigPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".codex", "config.toml")
+}
+
+// codexMarketplaceSection is the TOML key that indicates our marketplace is registered.
+const codexMarketplaceSection = `[marketplaces.htmlgraph]`
+
+// isCodexMarketplaceInstalled returns true if ~/.codex/config.toml contains
+// evidence that the htmlgraph marketplace (or plugin) is already registered.
+// Supports both the [marketplaces.htmlgraph] and [plugins."htmlgraph@htmlgraph"] forms.
+func isCodexMarketplaceInstalled() bool {
+	return isCodexMarketplaceInstalledAt(codexConfigPath())
+}
+
+// isCodexMarketplaceInstalledAt is the testable core that reads the given path.
+func isCodexMarketplaceInstalledAt(configPath string) bool {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return false
+	}
+	content := string(data)
+	return strings.Contains(content, "[marketplaces.htmlgraph]") ||
+		strings.Contains(content, `[plugins."htmlgraph@htmlgraph"]`)
+}
+
+// isCodexHooksEnabled returns true if config.toml already has codex_hooks = true.
+func isCodexHooksEnabled() bool {
+	return isCodexHooksEnabledAt(codexConfigPath())
+}
+
+// isCodexHooksEnabledAt is the testable core.
+func isCodexHooksEnabledAt(configPath string) bool {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "codex_hooks") && strings.Contains(trimmed, "=") {
+			parts := strings.SplitN(trimmed, "=", 2)
+			if len(parts) == 2 && strings.TrimSpace(parts[1]) == "true" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// appendCodexHooksFlag appends [features] codex_hooks = true to config.toml.
+func appendCodexHooksFlag(configPath string) error {
+	f, err := os.OpenFile(configPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", configPath, err)
+	}
+	defer f.Close()
+	_, err = fmt.Fprintln(f, "\n[features]\ncodex_hooks = true")
+	return err
+}
+
+// promptYesNo asks the user a yes/no question and returns true if they answer y/Y/yes.
+// If yes is true (--yes flag), the function returns true without prompting.
+func promptYesNo(question string, yes bool) bool {
+	if yes {
+		return true
+	}
+	fmt.Print(question + " [y/N]: ")
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	answer := strings.TrimSpace(strings.ToLower(line))
+	return answer == "y" || answer == "yes"
+}
+
+// codexCmd returns the cobra command for `htmlgraph codex`.
+func codexCmd() *cobra.Command {
+	var init_, continue_, dev, cleanup, dryRun, yes bool
+	var resumeID string
+
+	cmd := &cobra.Command{
+		Use:   "codex",
+		Short: "Launch Codex CLI with HtmlGraph context",
+		Long: `Launch Codex CLI with HtmlGraph observability context.
+
+Modes:
+  htmlgraph codex                   Launch Codex interactively with HtmlGraph env.
+  htmlgraph codex --init            Install the HtmlGraph Codex marketplace (idempotent).
+  htmlgraph codex --continue        Resume the last Codex session (codex resume --last).
+  htmlgraph codex --resume <id>     Resume a specific Codex session by ID.
+  htmlgraph codex --dev             Register local packages/codex-marketplace/ and launch.
+
+Session IDs come from ~/.codex/session_index.jsonl.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch {
+			case init_:
+				return runCodexInit(yes, dryRun)
+			case dev:
+				return launchCodexDev(resumeID, cleanup, dryRun, args)
+			case continue_:
+				return launchCodexContinue(resumeID, args)
+			default:
+				return launchCodexDefault(resumeID, args)
+			}
+		},
+	}
+
+	cmd.Flags().BoolVar(&init_, "init", false, "Install the HtmlGraph Codex marketplace plugin (idempotent)")
+	cmd.Flags().BoolVar(&continue_, "continue", false, "Resume the last Codex session")
+	cmd.Flags().BoolVar(&dev, "dev", false, "Register local packages/codex-marketplace/ and launch Codex")
+	cmd.Flags().BoolVar(&cleanup, "cleanup", false, "With --dev: unregister the local marketplace on exit")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print what would happen without executing")
+	cmd.Flags().BoolVar(&yes, "yes", false, "Answer yes to all prompts (non-interactive)")
+	cmd.Flags().StringVar(&resumeID, "resume", "", "Resume a specific Codex session by ID")
+
+	return cmd
+}
+
+// runCodexInit installs the HtmlGraph Codex marketplace plugin, idempotently.
+// Corresponds to: htmlgraph codex --init
+func runCodexInit(yes, dryRun bool) error {
+	configPath := codexConfigPath()
+
+	// Idempotency check — skip if already installed.
+	if isCodexMarketplaceInstalledAt(configPath) {
+		fmt.Println("HtmlGraph Codex marketplace is already installed.")
+		fmt.Println("To launch: htmlgraph codex")
+		return nil
+	}
+
+	addArgs := []string{
+		"marketplace", "add",
+		codexMarketplaceRepo,
+		"--sparse", codexMarketplaceSparse,
+	}
+	fmt.Printf("Installing HtmlGraph Codex marketplace...\n")
+	fmt.Printf("  repo: %s  sparse: %s\n", codexMarketplaceRepo, codexMarketplaceSparse)
+
+	if dryRun {
+		fmt.Printf("[dry-run] codex %s\n", strings.Join(addArgs, " "))
+	} else {
+		if out, err := exec.Command("codex", addArgs...).CombinedOutput(); err != nil {
+			return fmt.Errorf("codex marketplace add failed: %w\n%s", err, strings.TrimSpace(string(out)))
+		}
+		fmt.Println("HtmlGraph Codex marketplace installed.")
+	}
+
+	// Optionally enable codex_hooks feature flag.
+	if !isCodexHooksEnabledAt(configPath) {
+		if promptYesNo("Enable the codex_hooks feature flag in ~/.codex/config.toml?", yes) {
+			if dryRun {
+				fmt.Println("[dry-run] would append [features] codex_hooks = true to ~/.codex/config.toml")
+			} else {
+				if err := appendCodexHooksFlag(configPath); err != nil {
+					fmt.Fprintf(os.Stderr, "warning: could not enable codex_hooks: %v\n", err)
+				} else {
+					fmt.Println("codex_hooks feature flag enabled.")
+				}
+			}
+		}
+	} else {
+		fmt.Println("codex_hooks feature flag is already enabled.")
+	}
+
+	fmt.Println()
+	fmt.Println("Setup complete. Run: htmlgraph codex")
+	return nil
+}
+
+// launchCodexDefault launches Codex interactively with HtmlGraph env injection.
+// Corresponds to: htmlgraph codex
+func launchCodexDefault(resumeID string, extraArgs []string) error {
+	projectRoot, _ := resolveProjectRoot()
+	fmt.Println("Launching Codex CLI with HtmlGraph context...")
+	return execCodex(codexLaunchOpts{
+		ResumeID:    resumeID,
+		ExtraArgs:   extraArgs,
+		ProjectRoot: projectRoot,
+	})
+}
+
+// launchCodexContinue resumes the last Codex session.
+// Corresponds to: htmlgraph codex --continue
+func launchCodexContinue(resumeID string, extraArgs []string) error {
+	projectRoot, _ := resolveProjectRoot()
+	fmt.Println("Resuming last Codex session...")
+	return execCodex(codexLaunchOpts{
+		ResumeLast:  resumeID == "", // only pass --last when no specific ID
+		ResumeID:    resumeID,
+		ExtraArgs:   extraArgs,
+		ProjectRoot: projectRoot,
+	})
+}
+
+// launchCodexDev registers the local packages/codex-marketplace/ and launches Codex.
+// Corresponds to: htmlgraph codex --dev [--cleanup]
+func launchCodexDev(resumeID string, cleanup, dryRun bool, extraArgs []string) error {
+	// Resolve the local marketplace path relative to the project root.
+	localMarketplace, err := resolveLocalCodexMarketplace()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Launching Codex CLI in dev mode...\n")
+	fmt.Printf("  Local marketplace: %s\n", localMarketplace)
+
+	// Register the local marketplace if not already registered.
+	configPath := codexConfigPath()
+	if !isCodexMarketplaceInstalledAt(configPath) {
+		addArgs := []string{"marketplace", "add", localMarketplace}
+		if dryRun {
+			fmt.Printf("[dry-run] codex %s\n", strings.Join(addArgs, " "))
+		} else {
+			if out, err := exec.Command("codex", addArgs...).CombinedOutput(); err != nil {
+				return fmt.Errorf("registering local marketplace failed: %w\n%s", err, strings.TrimSpace(string(out)))
+			}
+			fmt.Println("Local marketplace registered.")
+		}
+	} else {
+		fmt.Println("Marketplace already registered — skipping re-add.")
+	}
+
+	projectRoot, _ := resolveProjectRoot()
+
+	if dryRun {
+		fmt.Printf("[dry-run] would exec: codex (resume=%q) in %s\n", resumeID, projectRoot)
+		return nil
+	}
+
+	err = execCodex(codexLaunchOpts{
+		ResumeID:    resumeID,
+		ExtraArgs:   extraArgs,
+		ProjectRoot: projectRoot,
+	})
+
+	// --cleanup: unregister the local marketplace after session ends.
+	if cleanup && !dryRun {
+		fmt.Println("Cleaning up local marketplace registration...")
+		removeArgs := []string{"marketplace", "remove", localMarketplace}
+		if out, rmErr := exec.Command("codex", removeArgs...).CombinedOutput(); rmErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: marketplace remove failed: %v (%s)\n",
+				rmErr, strings.TrimSpace(string(out)))
+		}
+	}
+
+	return err
+}
+
+// resolveLocalCodexMarketplace returns the absolute path to packages/codex-marketplace/
+// by walking up from CWD to find the project root (directory containing .htmlgraph/).
+// Returns an error if no project root is found or the marketplace directory is missing.
+func resolveLocalCodexMarketplace() (string, error) {
+	htmlgraphDir, err := findHtmlgraphDir()
+	if err != nil {
+		return "", fmt.Errorf("could not find project root (.htmlgraph/ directory not found)\n" +
+			"Run from the HtmlGraph project directory, or use htmlgraph codex --init for the marketplace version")
+	}
+	projectRoot := filepath.Dir(htmlgraphDir)
+	marketplacePath := filepath.Join(projectRoot, "packages", "codex-marketplace")
+	if _, statErr := os.Stat(marketplacePath); os.IsNotExist(statErr) {
+		return "", fmt.Errorf("packages/codex-marketplace/ not found at %s\n"+
+			"Run from the HtmlGraph repo root, or use htmlgraph codex --init for the marketplace version",
+			marketplacePath)
+	}
+	abs, err := filepath.Abs(marketplacePath)
+	if err != nil {
+		return "", fmt.Errorf("resolving absolute path for %s: %w", marketplacePath, err)
+	}
+	return abs, nil
+}
+
+// codexLaunchOpts controls how Codex is launched.
+type codexLaunchOpts struct {
+	// ResumeLast, when true, passes "resume --last" to codex.
+	ResumeLast bool
+	// ResumeID, if non-empty, passes "resume <id>" to codex.
+	// Takes precedence over ResumeLast.
+	ResumeID string
+	// ExtraArgs are forwarded to the codex process.
+	ExtraArgs []string
+	// ProjectRoot is the absolute path to the project root.
+	// When set, Codex is started with this as the working directory, and
+	// HTMLGRAPH_PROJECT_DIR env var is injected.
+	ProjectRoot string
+}
+
+// execCodex builds the codex argv and execs it, replacing the current process.
+// Returns only on exec error.
+func execCodex(opts codexLaunchOpts) error {
+	codexPath, err := exec.LookPath("codex")
+	if err != nil {
+		return fmt.Errorf("codex not found in PATH: %w\nInstall Codex CLI first: https://github.com/openai/codex", err)
+	}
+
+	var codexArgs []string
+
+	// Determine if we're resuming.
+	if opts.ResumeID != "" {
+		codexArgs = append(codexArgs, "resume", opts.ResumeID)
+	} else if opts.ResumeLast {
+		codexArgs = append(codexArgs, "resume", "--last")
+	}
+
+	codexArgs = append(codexArgs, opts.ExtraArgs...)
+
+	c := exec.Command(codexPath, codexArgs...)
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+
+	// Inject HTMLGRAPH_PROJECT_DIR so htmlgraph CLI and hooks resolve to the
+	// correct project root regardless of CWD.
+	if opts.ProjectRoot != "" {
+		c.Env = append(os.Environ(), "HTMLGRAPH_PROJECT_DIR="+opts.ProjectRoot)
+		c.Dir = opts.ProjectRoot
+	}
+
+	if err := c.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ExitCode())
+		}
+		return err
+	}
+	return nil
+}

--- a/cmd/htmlgraph/codex.go
+++ b/cmd/htmlgraph/codex.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/spf13/cobra"
 )
 
@@ -67,15 +68,84 @@ func isCodexHooksEnabledAt(configPath string) bool {
 	return false
 }
 
-// appendCodexHooksFlag appends [features] codex_hooks = true to config.toml.
-func appendCodexHooksFlag(configPath string) error {
-	f, err := os.OpenFile(configPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+// getCodexMarketplacePathAt parses config.toml and returns the registered htmlgraph
+// marketplace path, or empty string if not found.
+func getCodexMarketplacePathAt(configPath string) string {
+	data, err := os.ReadFile(configPath)
 	if err != nil {
-		return fmt.Errorf("opening %s: %w", configPath, err)
+		return ""
 	}
-	defer f.Close()
-	_, err = fmt.Fprintln(f, "\n[features]\ncodex_hooks = true")
-	return err
+
+	tree := make(map[string]interface{})
+	if err := toml.Unmarshal(data, &tree); err != nil {
+		return ""
+	}
+
+	// Check [marketplaces.htmlgraph]
+	if mkts, ok := tree["marketplaces"].(map[string]interface{}); ok {
+		if hg, ok := mkts["htmlgraph"].(map[string]interface{}); ok {
+			if source, ok := hg["source"].(string); ok {
+				return source
+			}
+			if path, ok := hg["path"].(string); ok {
+				return path
+			}
+		}
+	}
+
+	// Check [plugins."htmlgraph@htmlgraph"]
+	if plugins, ok := tree["plugins"].(map[string]interface{}); ok {
+		if hg, ok := plugins["htmlgraph@htmlgraph"].(map[string]interface{}); ok {
+			if source, ok := hg["source"].(string); ok {
+				return source
+			}
+			if path, ok := hg["path"].(string); ok {
+				return path
+			}
+		}
+	}
+
+	return ""
+}
+
+// ensureCodexHooksEnabled parses the config.toml file, merges codex_hooks = true
+// into the [features] table (creating the section if absent), and writes it back.
+// This is idempotent: if codex_hooks = true is already set, it's a no-op after
+// re-serialization.
+func ensureCodexHooksEnabled(configPath string) error {
+	// Read existing config, if any
+	data, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading %s: %w", configPath, err)
+	}
+
+	// Parse or create the TOML tree
+	tree := make(map[string]interface{})
+	if err == nil && len(data) > 0 {
+		if err := toml.Unmarshal(data, &tree); err != nil {
+			return fmt.Errorf("parsing %s: %w", configPath, err)
+		}
+	}
+
+	// Ensure [features] table exists and set codex_hooks = true
+	features, ok := tree["features"].(map[string]interface{})
+	if !ok {
+		features = make(map[string]interface{})
+		tree["features"] = features
+	}
+	features["codex_hooks"] = true
+
+	// Marshal back to TOML and write
+	newData, err := toml.Marshal(tree)
+	if err != nil {
+		return fmt.Errorf("marshaling TOML: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, newData, 0644); err != nil {
+		return fmt.Errorf("writing %s: %w", configPath, err)
+	}
+
+	return nil
 }
 
 // promptYesNo asks the user a yes/no question and returns true if they answer y/Y/yes.
@@ -136,40 +206,42 @@ Session IDs come from ~/.codex/session_index.jsonl.`,
 
 // runCodexInit installs the HtmlGraph Codex marketplace plugin, idempotently.
 // Corresponds to: htmlgraph codex --init
+// Phase 1: Install / verify marketplace (idempotent).
+// Phase 2: Check codex_hooks — prompt user if not set.
 func runCodexInit(yes, dryRun bool) error {
 	configPath := codexConfigPath()
 
-	// Idempotency check — skip if already installed.
-	if isCodexMarketplaceInstalledAt(configPath) {
-		fmt.Println("HtmlGraph Codex marketplace is already installed.")
-		fmt.Println("To launch: htmlgraph codex")
-		return nil
-	}
-
-	addArgs := []string{
-		"marketplace", "add",
-		codexMarketplaceRepo,
-		"--sparse", codexMarketplaceSparse,
-	}
-	fmt.Printf("Installing HtmlGraph Codex marketplace...\n")
-	fmt.Printf("  repo: %s  sparse: %s\n", codexMarketplaceRepo, codexMarketplaceSparse)
-
-	if dryRun {
-		fmt.Printf("[dry-run] codex %s\n", strings.Join(addArgs, " "))
-	} else {
-		if out, err := exec.Command("codex", addArgs...).CombinedOutput(); err != nil {
-			return fmt.Errorf("codex marketplace add failed: %w\n%s", err, strings.TrimSpace(string(out)))
+	// Phase 1: Install or verify marketplace.
+	marketplaceInstalled := isCodexMarketplaceInstalledAt(configPath)
+	if !marketplaceInstalled {
+		addArgs := []string{
+			"marketplace", "add",
+			codexMarketplaceRepo,
+			"--sparse", codexMarketplaceSparse,
 		}
-		fmt.Println("HtmlGraph Codex marketplace installed.")
+		fmt.Printf("Installing HtmlGraph Codex marketplace...\n")
+		fmt.Printf("  repo: %s  sparse: %s\n", codexMarketplaceRepo, codexMarketplaceSparse)
+
+		if dryRun {
+			fmt.Printf("[dry-run] codex %s\n", strings.Join(addArgs, " "))
+		} else {
+			if out, err := exec.Command("codex", addArgs...).CombinedOutput(); err != nil {
+				return fmt.Errorf("codex marketplace add failed: %w\n%s", err, strings.TrimSpace(string(out)))
+			}
+			fmt.Println("HtmlGraph Codex marketplace installed.")
+		}
+	} else {
+		fmt.Println("HtmlGraph Codex marketplace is already installed.")
 	}
 
-	// Optionally enable codex_hooks feature flag.
+	// Phase 2: Check and optionally enable codex_hooks feature flag.
+	// This runs on every --init so partial setups can be repaired.
 	if !isCodexHooksEnabledAt(configPath) {
 		if promptYesNo("Enable the codex_hooks feature flag in ~/.codex/config.toml?", yes) {
 			if dryRun {
-				fmt.Println("[dry-run] would append [features] codex_hooks = true to ~/.codex/config.toml")
+				fmt.Println("[dry-run] would enable codex_hooks = true in ~/.codex/config.toml")
 			} else {
-				if err := appendCodexHooksFlag(configPath); err != nil {
+				if err := ensureCodexHooksEnabled(configPath); err != nil {
 					fmt.Fprintf(os.Stderr, "warning: could not enable codex_hooks: %v\n", err)
 				} else {
 					fmt.Println("codex_hooks feature flag enabled.")
@@ -212,6 +284,8 @@ func launchCodexContinue(resumeID string, extraArgs []string) error {
 
 // launchCodexDev registers the local packages/codex-marketplace/ and launches Codex.
 // Corresponds to: htmlgraph codex --dev [--cleanup]
+// If a mismatched marketplace is already registered (e.g., from a prior --init),
+// it is removed and replaced with the local path.
 func launchCodexDev(resumeID string, cleanup, dryRun bool, extraArgs []string) error {
 	// Resolve the local marketplace path relative to the project root.
 	localMarketplace, err := resolveLocalCodexMarketplace()
@@ -222,9 +296,30 @@ func launchCodexDev(resumeID string, cleanup, dryRun bool, extraArgs []string) e
 	fmt.Printf("Launching Codex CLI in dev mode...\n")
 	fmt.Printf("  Local marketplace: %s\n", localMarketplace)
 
-	// Register the local marketplace if not already registered.
+	// Ensure the local marketplace is registered (replace mismatched registrations).
 	configPath := codexConfigPath()
-	if !isCodexMarketplaceInstalledAt(configPath) {
+	registeredPath := getCodexMarketplacePathAt(configPath)
+
+	// Convert to absolute paths for comparison
+	localAbs, _ := filepath.Abs(localMarketplace)
+	registeredAbs, _ := filepath.Abs(registeredPath)
+
+	if registeredAbs != "" && registeredAbs != localAbs {
+		// Mismatched registration: remove the old one
+		fmt.Printf("Replacing mismatched marketplace registration (%s)\n", registeredPath)
+		removeArgs := []string{"marketplace", "remove", registeredPath}
+		if dryRun {
+			fmt.Printf("[dry-run] codex %s\n", strings.Join(removeArgs, " "))
+		} else {
+			if out, err := exec.Command("codex", removeArgs...).CombinedOutput(); err != nil {
+				return fmt.Errorf("removing mismatched marketplace failed: %w\n%s", err, strings.TrimSpace(string(out)))
+			}
+		}
+		registeredPath = "" // Force re-add
+	}
+
+	// Add the local marketplace if not already registered at the correct path
+	if registeredAbs != localAbs {
 		addArgs := []string{"marketplace", "add", localMarketplace}
 		if dryRun {
 			fmt.Printf("[dry-run] codex %s\n", strings.Join(addArgs, " "))
@@ -235,7 +330,7 @@ func launchCodexDev(resumeID string, cleanup, dryRun bool, extraArgs []string) e
 			fmt.Println("Local marketplace registered.")
 		}
 	} else {
-		fmt.Println("Marketplace already registered — skipping re-add.")
+		fmt.Println("Local marketplace already registered — proceeding.")
 	}
 
 	projectRoot, _ := resolveProjectRoot()

--- a/cmd/htmlgraph/codex_test.go
+++ b/cmd/htmlgraph/codex_test.go
@@ -187,36 +187,160 @@ func TestPromptYesNo(t *testing.T) {
 	}
 }
 
-// TestAppendCodexHooksFlag verifies appending the hooks flag to config.
-func TestAppendCodexHooksFlag(t *testing.T) {
+// TestEnsureCodexHooksEnabledIdempotent verifies that ensureCodexHooksEnabled
+// is idempotent — calling it twice produces identical output.
+func TestEnsureCodexHooksEnabledIdempotent(t *testing.T) {
 	tmpdir := t.TempDir()
 	configPath := filepath.Join(tmpdir, "config.toml")
 
-	// Create a config file with some content
-	initialContent := "[other]\nkey = value\n"
-	err := os.WriteFile(configPath, []byte(initialContent), 0644)
-	if err != nil {
+	// First call: create and enable
+	if err := ensureCodexHooksEnabled(configPath); err != nil {
+		t.Fatalf("first ensureCodexHooksEnabled: %v", err)
+	}
+	data1, _ := os.ReadFile(configPath)
+
+	// Second call: should be idempotent
+	if err := ensureCodexHooksEnabled(configPath); err != nil {
+		t.Fatalf("second ensureCodexHooksEnabled: %v", err)
+	}
+	data2, _ := os.ReadFile(configPath)
+
+	if string(data1) != string(data2) {
+		t.Errorf("second call changed the output:\nFirst:\n%s\nSecond:\n%s", string(data1), string(data2))
+	}
+}
+
+// TestCodexHooksUpsertPreservesExistingFeaturesTable verifies that enabling
+// codex_hooks merges into an existing [features] table without duplicating it.
+func TestCodexHooksUpsertPreservesExistingFeaturesTable(t *testing.T) {
+	tmpdir := t.TempDir()
+	configPath := filepath.Join(tmpdir, "config.toml")
+
+	// Create a config with existing [features] section and other keys
+	initialContent := "[features]\nother_flag = true\n"
+	if err := os.WriteFile(configPath, []byte(initialContent), 0644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	// Append the hooks flag
-	err = appendCodexHooksFlag(configPath)
-	if err != nil {
-		t.Fatalf("appendCodexHooksFlag: %v", err)
+	// Call ensureCodexHooksEnabled
+	if err := ensureCodexHooksEnabled(configPath); err != nil {
+		t.Fatalf("ensureCodexHooksEnabled: %v", err)
 	}
 
-	// Verify the content was appended
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	}
+	// Verify the config has both keys in a single [features] table
+	data, _ := os.ReadFile(configPath)
 	content := string(data)
-	if !strings.Contains(content, "codex_hooks = true") {
-		t.Errorf("expected appended codex_hooks = true not found in config:\n%s", content)
+
+	// Count [features] sections (should be exactly one)
+	featuresSectionCount := strings.Count(content, "[features]")
+	if featuresSectionCount != 1 {
+		t.Errorf("expected exactly 1 [features] section, got %d:\n%s", featuresSectionCount, content)
 	}
 
-	// Verify the original content is still there
-	if !strings.Contains(content, "key = value") {
-		t.Errorf("original content was not preserved")
+	// Verify both keys are present
+	if !strings.Contains(content, "codex_hooks") {
+		t.Errorf("codex_hooks not found in output")
+	}
+	if !strings.Contains(content, "other_flag") {
+		t.Errorf("other_flag not preserved in output")
+	}
+}
+
+// TestEnsureCodexHooksEnabledCreatesFromEmpty verifies that ensureCodexHooksEnabled
+// can create a new config file with just the [features] section.
+func TestEnsureCodexHooksEnabledCreatesFromEmpty(t *testing.T) {
+	tmpdir := t.TempDir()
+	configPath := filepath.Join(tmpdir, "config.toml")
+
+	// Enable codex_hooks on a non-existent file
+	if err := ensureCodexHooksEnabled(configPath); err != nil {
+		t.Fatalf("ensureCodexHooksEnabled: %v", err)
+	}
+
+	// Verify the file was created with codex_hooks enabled
+	data, _ := os.ReadFile(configPath)
+	content := string(data)
+
+	if !strings.Contains(content, "codex_hooks") {
+		t.Errorf("codex_hooks not found in newly created config")
+	}
+	if !isCodexHooksEnabledAt(configPath) {
+		t.Errorf("codex_hooks = true check failed after ensureCodexHooksEnabled")
+	}
+}
+
+// TestCodexDevReplacesMismatchedMarketplace verifies that --dev mode detects
+// a mismatched marketplace registration and replaces it.
+func TestCodexDevReplacesMismatchedMarketplace(t *testing.T) {
+	tmpdir := t.TempDir()
+	configPath := filepath.Join(tmpdir, "config.toml")
+
+	// Seed a config with a mismatched marketplace pointing elsewhere
+	initialContent := `[marketplaces.htmlgraph]
+source = "/some/other/path"
+`
+	if err := os.WriteFile(configPath, []byte(initialContent), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Verify the mismatched path is detected
+	detected := getCodexMarketplacePathAt(configPath)
+	if detected != "/some/other/path" {
+		t.Errorf("expected to detect /some/other/path, got %q", detected)
+	}
+
+	// In a real scenario, launchCodexDev would now detect the mismatch
+	// and run marketplace remove + add. For testing, we just verify the detection.
+	// A full integration test would mock exec.Command.
+}
+
+// TestGetCodexMarketplacePathAt verifies marketplace path detection from TOML.
+func TestGetCodexMarketplacePathAt(t *testing.T) {
+	tmpdir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "no config file",
+			content: "",
+			want:    "",
+		},
+		{
+			name: "marketplaces.htmlgraph with source",
+			content: "[marketplaces.htmlgraph]\n" +
+				"source = \"/path/to/marketplace\"\n",
+			want: "/path/to/marketplace",
+		},
+		{
+			name: "marketplaces.htmlgraph with path",
+			content: "[marketplaces.htmlgraph]\n" +
+				"path = \"/alt/path\"\n",
+			want: "/alt/path",
+		},
+		{
+			name: "plugins variant",
+			content: "[plugins]\n" +
+				"\"htmlgraph@htmlgraph\" = {source = \"/plugin/path\"}\n",
+			want: "/plugin/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(tmpdir, tt.name+".toml")
+			if tt.content != "" {
+				if err := os.WriteFile(configPath, []byte(tt.content), 0644); err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+			}
+
+			got := getCodexMarketplacePathAt(configPath)
+			if got != tt.want {
+				t.Errorf("getCodexMarketplacePathAt: want %q, got %q", tt.want, got)
+			}
+		})
 	}
 }

--- a/cmd/htmlgraph/codex_test.go
+++ b/cmd/htmlgraph/codex_test.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCodexHelpRenders verifies that codexCmd().Execute() with --help
+// doesn't error and prints help text.
+func TestCodexHelpRenders(t *testing.T) {
+	cmd := codexCmd()
+	cmd.SetArgs([]string{"--help"})
+
+	// Capture output to avoid printing during test
+	outBuf := &strings.Builder{}
+	cmd.SetOut(outBuf)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("codexCmd().Execute() with --help: %v", err)
+	}
+
+	output := outBuf.String()
+	if !strings.Contains(output, "Launch Codex CLI") {
+		t.Errorf("help output missing expected text. Got:\n%s", output)
+	}
+}
+
+// TestCodexParsingFlags verifies that codex command flags are parsed correctly.
+// We only test flags that don't trigger external commands (like codex.exe or marketplace ops).
+func TestCodexParsingFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantInit bool
+	}{
+		{
+			name:     "--init with --dry-run",
+			args:     []string{"--init", "--dry-run", "--yes"},
+			wantInit: true,
+		},
+		{
+			name:     "--help",
+			args:     []string{"--help"},
+			wantInit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := codexCmd()
+			cmd.SetArgs(tt.args)
+
+			// Suppress stdout/stderr for testing.
+			cmd.SetOut(&strings.Builder{})
+			cmd.SetErr(&strings.Builder{})
+
+			// Note: --help causes Execute to return nil without running the command,
+			// so it's safe to test. Commands that try to exec codex (no flags, or
+			// --continue/--resume/--dev without --dry-run) will fail during tests
+			// because codex binary is not available. Those are integration tests.
+			err := cmd.Execute()
+			if err != nil {
+				t.Logf("Execute returned: %v (expected for --help or --init --dry-run)", err)
+			}
+		})
+	}
+}
+
+// TestIsCodexMarketplaceInstalledAt verifies the marketplace detection logic.
+func TestIsCodexMarketplaceInstalledAt(t *testing.T) {
+	tmpdir := t.TempDir()
+	configPath := filepath.Join(tmpdir, "config.toml")
+
+	// Test 1: File does not exist — should return false
+	if isCodexMarketplaceInstalledAt(configPath) {
+		t.Errorf("expected false when config file does not exist")
+	}
+
+	// Test 2: File exists but does not contain the marketplace section
+	err := os.WriteFile(configPath, []byte("[other]\nkey = value\n"), 0644)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if isCodexMarketplaceInstalledAt(configPath) {
+		t.Errorf("expected false when marketplace not in config")
+	}
+
+	// Test 3: File contains the marketplace section
+	err = os.WriteFile(configPath, []byte("[marketplaces.htmlgraph]\nrepo = \"shakestzd/htmlgraph\"\n"), 0644)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if !isCodexMarketplaceInstalledAt(configPath) {
+		t.Errorf("expected true when marketplace section exists")
+	}
+
+	// Test 4: File contains the plugin section variant
+	err = os.WriteFile(configPath, []byte(`[plugins."htmlgraph@htmlgraph"]`+"\n"), 0644)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if !isCodexMarketplaceInstalledAt(configPath) {
+		t.Errorf("expected true when plugin section exists")
+	}
+}
+
+// TestIsCodexHooksEnabledAt verifies the hooks feature flag detection logic.
+func TestIsCodexHooksEnabledAt(t *testing.T) {
+	tmpdir := t.TempDir()
+	configPath := filepath.Join(tmpdir, "config.toml")
+
+	// Test 1: File does not exist
+	if isCodexHooksEnabledAt(configPath) {
+		t.Errorf("expected false when config file does not exist")
+	}
+
+	// Test 2: File exists but no codex_hooks line
+	err := os.WriteFile(configPath, []byte("[other]\nkey = value\n"), 0644)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if isCodexHooksEnabledAt(configPath) {
+		t.Errorf("expected false when codex_hooks not in config")
+	}
+
+	// Test 3: File has codex_hooks = true
+	err = os.WriteFile(configPath, []byte("[features]\ncodex_hooks = true\n"), 0644)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if !isCodexHooksEnabledAt(configPath) {
+		t.Errorf("expected true when codex_hooks = true")
+	}
+
+	// Test 4: File has codex_hooks = false
+	err = os.WriteFile(configPath, []byte("[features]\ncodex_hooks = false\n"), 0644)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if isCodexHooksEnabledAt(configPath) {
+		t.Errorf("expected false when codex_hooks = false")
+	}
+
+	// Test 5: File has codex_hooks with spaces around =
+	err = os.WriteFile(configPath, []byte("[features]\ncodex_hooks  =  true\n"), 0644)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if !isCodexHooksEnabledAt(configPath) {
+		t.Errorf("expected true when codex_hooks has spaces around =")
+	}
+}
+
+// TestPromptYesNo verifies the yes/no prompt logic.
+func TestPromptYesNo(t *testing.T) {
+	tests := []struct {
+		name      string
+		autoYes   bool
+		wantResp  bool
+		question  string
+	}{
+		{
+			name:     "auto-yes returns true immediately",
+			autoYes:  true,
+			wantResp: true,
+			question: "Enable feature?",
+		},
+		{
+			name:     "auto-yes=false still returns true (no stdin)",
+			autoYes:  false,
+			wantResp: false, // will be false because we have no stdin input
+			question: "Enable feature?",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// When yes=true, promptYesNo returns immediately without reading stdin
+			resp := promptYesNo(tt.question, tt.autoYes)
+			if tt.autoYes && !resp {
+				t.Errorf("promptYesNo(..., true) should return true immediately")
+			}
+		})
+	}
+}
+
+// TestAppendCodexHooksFlag verifies appending the hooks flag to config.
+func TestAppendCodexHooksFlag(t *testing.T) {
+	tmpdir := t.TempDir()
+	configPath := filepath.Join(tmpdir, "config.toml")
+
+	// Create a config file with some content
+	initialContent := "[other]\nkey = value\n"
+	err := os.WriteFile(configPath, []byte(initialContent), 0644)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Append the hooks flag
+	err = appendCodexHooksFlag(configPath)
+	if err != nil {
+		t.Fatalf("appendCodexHooksFlag: %v", err)
+	}
+
+	// Verify the content was appended
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "codex_hooks = true") {
+		t.Errorf("expected appended codex_hooks = true not found in config:\n%s", content)
+	}
+
+	// Verify the original content is still there
+	if !strings.Contains(content, "key = value") {
+		t.Errorf("original content was not preserved")
+	}
+}

--- a/cmd/htmlgraph/help_test.go
+++ b/cmd/htmlgraph/help_test.go
@@ -237,6 +237,7 @@ var internalPlumbingAllowlist = map[string]bool{
 	"serve-child":   true,
 	"hook":          true,
 	"claude":        true,
+	"codex":         true,
 	"orchestrator":  true,
 	"install-hooks": true,
 	"report":        true,

--- a/cmd/htmlgraph/main.go
+++ b/cmd/htmlgraph/main.go
@@ -221,6 +221,7 @@ func buildRoot() *cobra.Command {
 	root.AddCommand(serveChildCmd())
 	root.AddCommand(hookCmd())
 	root.AddCommand(claudeCmd())
+	root.AddCommand(codexCmd())
 	root.AddCommand(orchestratorCmd())
 	root.AddCommand(installHooksCmd())
 	root.AddCommand(reportCmd())

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
+	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/pelletier/go-toml/v2 v2.3.0 h1:k59bC/lIZREW0/iVaQR8nDHxVq8OVlIzYCOJf421CaM=
+github.com/pelletier/go-toml/v2 v2.3.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
## Summary

Adds `htmlgraph codex` subcommand for launching Codex CLI with HtmlGraph context injection.

- **htmlgraph codex** — interactive launch with HTMLGRAPH_PROJECT_DIR env injection
- **htmlgraph codex --init** — install shakestzd/htmlgraph Codex marketplace (idempotent), optionally enable codex_hooks feature flag
- **htmlgraph codex --continue** — resume last Codex session via `codex resume --last`
- **htmlgraph codex --resume <id>** — resume specific session by ID
- **htmlgraph codex --dev** — register local packages/codex-marketplace/ and launch, with optional `--cleanup` to unregister on exit

End-user install:
```bash
htmlgraph codex --init
htmlgraph codex
```

Mirrors the existing `htmlgraph claude` subcommand pattern (launch modes, session injection, environment context).

## Test plan

- [x] `go build ./...` passes — no compilation errors
- [x] `go vet ./...` passes — no static analysis warnings
- [x] `go test ./...` passes — all unit tests including new codex tests
- [x] `htmlgraph codex --help` renders without error
- [x] `htmlgraph codex --init --dry-run --yes` prints expected dry-run output
- [ ] Reviewer: test `--init` against a clean `~/.codex/config.toml` (requires codex CLI installed)
- [ ] Reviewer: test `--resume <id>` with a real Codex session ID (requires active Codex workspace)
- [ ] Reviewer: test `--dev` from htmlgraph repo root with local marketplace (requires packages/codex-marketplace/ present)

Related: feat-d5db7ad8, track trk-a7ee6791
