### PR TITLE
fix(cli-codex): replace non-existent codex marketplace remove with direct config.toml edit

### DIFF
--- a/cmd/htmlgraph/codex.go
+++ b/cmd/htmlgraph/codex.go
@@ -132,13 +132,11 @@ func removeCodexHtmlgraphRegistrations(configPath string) (bool, error) {
 
 	removed := false
 
-	// Remove from [plugins] — any "htmlgraph@..." entry
+	// Remove from [plugins] — only the exact "htmlgraph@htmlgraph" entry
 	if plugins, ok := tree["plugins"].(map[string]interface{}); ok {
-		for key := range plugins {
-			if strings.HasPrefix(key, "htmlgraph@") || key == "htmlgraph" {
-				delete(plugins, key)
-				removed = true
-			}
+		if _, exists := plugins["htmlgraph@htmlgraph"]; exists {
+			delete(plugins, "htmlgraph@htmlgraph")
+			removed = true
 		}
 		// If [plugins] is now empty, remove the whole section
 		if len(plugins) == 0 {

--- a/cmd/htmlgraph/codex.go
+++ b/cmd/htmlgraph/codex.go
@@ -108,6 +108,74 @@ func getCodexMarketplacePathAt(configPath string) string {
 	return ""
 }
 
+// removeCodexHtmlgraphRegistrations removes any HtmlGraph marketplace or plugin
+// registrations from the given config.toml file. It is idempotent — if the file
+// does not exist or contains no htmlgraph entries, it is a no-op.
+// Returns (removed bool, error). removed=true indicates at least one entry was deleted.
+func removeCodexHtmlgraphRegistrations(configPath string) (bool, error) {
+	// Read existing config, if any
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil // file doesn't exist; no-op
+		}
+		return false, fmt.Errorf("reading %s: %w", configPath, err)
+	}
+
+	// Parse the TOML tree
+	tree := make(map[string]interface{})
+	if len(data) > 0 {
+		if err := toml.Unmarshal(data, &tree); err != nil {
+			return false, fmt.Errorf("parsing %s: %w", configPath, err)
+		}
+	}
+
+	removed := false
+
+	// Remove from [plugins] — any "htmlgraph@..." entry
+	if plugins, ok := tree["plugins"].(map[string]interface{}); ok {
+		for key := range plugins {
+			if strings.HasPrefix(key, "htmlgraph@") || key == "htmlgraph" {
+				delete(plugins, key)
+				removed = true
+			}
+		}
+		// If [plugins] is now empty, remove the whole section
+		if len(plugins) == 0 {
+			delete(tree, "plugins")
+		}
+	}
+
+	// Remove from [marketplaces] — the "htmlgraph" entry
+	if mkts, ok := tree["marketplaces"].(map[string]interface{}); ok {
+		if _, exists := mkts["htmlgraph"]; exists {
+			delete(mkts, "htmlgraph")
+			removed = true
+		}
+		// If [marketplaces] is now empty, remove the whole section
+		if len(mkts) == 0 {
+			delete(tree, "marketplaces")
+		}
+	}
+
+	// If nothing was removed, no need to rewrite the file
+	if !removed {
+		return false, nil
+	}
+
+	// Marshal back to TOML and write
+	newData, err := toml.Marshal(tree)
+	if err != nil {
+		return false, fmt.Errorf("marshaling TOML: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, newData, 0644); err != nil {
+		return false, fmt.Errorf("writing %s: %w", configPath, err)
+	}
+
+	return true, nil
+}
+
 // ensureCodexHooksEnabled parses the config.toml file, merges codex_hooks = true
 // into the [features] table (creating the section if absent), and writes it back.
 // This is idempotent: if codex_hooks = true is already set, it's a no-op after
@@ -305,14 +373,21 @@ func launchCodexDev(resumeID string, cleanup, dryRun bool, extraArgs []string) e
 	registeredAbs, _ := filepath.Abs(registeredPath)
 
 	if registeredAbs != "" && registeredAbs != localAbs {
-		// Mismatched registration: remove the old one
-		fmt.Printf("Replacing mismatched marketplace registration (%s)\n", registeredPath)
-		removeArgs := []string{"marketplace", "remove", registeredPath}
+		// Mismatched registration: remove the old one via direct TOML editing
+		oldPathDisplay := registeredPath
+		if oldPathDisplay == "" {
+			oldPathDisplay = "(unknown previous path)"
+		}
+		fmt.Printf("Replacing mismatched marketplace registration (%s)\n", oldPathDisplay)
 		if dryRun {
-			fmt.Printf("[dry-run] codex %s\n", strings.Join(removeArgs, " "))
+			fmt.Printf("[dry-run] would remove HtmlGraph registrations from %s\n", configPath)
 		} else {
-			if out, err := exec.Command("codex", removeArgs...).CombinedOutput(); err != nil {
-				return fmt.Errorf("removing mismatched marketplace failed: %w\n%s", err, strings.TrimSpace(string(out)))
+			removed, rmErr := removeCodexHtmlgraphRegistrations(configPath)
+			if rmErr != nil {
+				return fmt.Errorf("removing mismatched marketplace from %s: %w", configPath, rmErr)
+			}
+			if removed {
+				fmt.Println("Mismatched registration removed from config.toml.")
 			}
 		}
 		registeredPath = "" // Force re-add
@@ -349,10 +424,11 @@ func launchCodexDev(resumeID string, cleanup, dryRun bool, extraArgs []string) e
 	// --cleanup: unregister the local marketplace after session ends.
 	if cleanup && !dryRun {
 		fmt.Println("Cleaning up local marketplace registration...")
-		removeArgs := []string{"marketplace", "remove", localMarketplace}
-		if out, rmErr := exec.Command("codex", removeArgs...).CombinedOutput(); rmErr != nil {
-			fmt.Fprintf(os.Stderr, "warning: marketplace remove failed: %v (%s)\n",
-				rmErr, strings.TrimSpace(string(out)))
+		removed, rmErr := removeCodexHtmlgraphRegistrations(configPath)
+		if rmErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not remove marketplace registration: %v\n", rmErr)
+		} else if !removed {
+			fmt.Println("No HtmlGraph registrations found to clean up.")
 		}
 	}
 

--- a/cmd/htmlgraph/codex_test.go
+++ b/cmd/htmlgraph/codex_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -342,5 +343,117 @@ func TestGetCodexMarketplacePathAt(t *testing.T) {
 				t.Errorf("getCodexMarketplacePathAt: want %q, got %q", tt.want, got)
 			}
 		})
+	}
+}
+
+// TestRemoveCodexHtmlgraphRegistrations verifies that removeCodexHtmlgraphRegistrations
+// correctly deletes htmlgraph entries while preserving other config sections.
+func TestRemoveCodexHtmlgraphRegistrations(t *testing.T) {
+	tmpdir := t.TempDir()
+	configPath := filepath.Join(tmpdir, "config.toml")
+
+	// Create a realistic config with htmlgraph entries plus other unrelated config
+	initialContent := `[plugins]
+"htmlgraph@htmlgraph" = {source = "/old/path"}
+"github@openai-curated" = {source = "https://github.com/openai/curated"}
+
+[marketplaces]
+htmlgraph = {source = "/also/old/path"}
+other_marketplace = {source = "https://other.com"}
+
+[mcp_servers]
+my_server = {command = "/path/to/server"}
+
+[features]
+some_feature = true
+`
+	if err := os.WriteFile(configPath, []byte(initialContent), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Call removeCodexHtmlgraphRegistrations
+	removed, err := removeCodexHtmlgraphRegistrations(configPath)
+	if err != nil {
+		t.Fatalf("removeCodexHtmlgraphRegistrations: %v", err)
+	}
+	if !removed {
+		t.Errorf("expected removed=true, got false")
+	}
+
+	// Read the result and verify
+	data, _ := os.ReadFile(configPath)
+	content := string(data)
+
+	// htmlgraph entries should be gone
+	if strings.Contains(content, `"htmlgraph@htmlgraph"`) {
+		t.Errorf("htmlgraph@htmlgraph should be removed but is still present")
+	}
+	if strings.Contains(content, "htmlgraph = ") {
+		t.Errorf("[marketplaces.htmlgraph] should be removed but is still present")
+	}
+
+	// Other entries must be preserved
+	if !strings.Contains(content, "github@openai-curated") {
+		t.Errorf("github@openai-curated plugin should be preserved but was removed")
+	}
+	if !strings.Contains(content, "other_marketplace") {
+		t.Errorf("other_marketplace should be preserved but was removed")
+	}
+	if !strings.Contains(content, "mcp_servers") {
+		t.Errorf("[mcp_servers] section should be preserved but was removed")
+	}
+	if !strings.Contains(content, "some_feature") {
+		t.Errorf("[features] section should be preserved but was removed")
+	}
+}
+
+// TestRemoveCodexHtmlgraphRegistrationsNoop verifies that removeCodexHtmlgraphRegistrations
+// returns removed=false and preserves file content byte-for-byte when no htmlgraph entries exist.
+func TestRemoveCodexHtmlgraphRegistrationsNoop(t *testing.T) {
+	tmpdir := t.TempDir()
+	configPath := filepath.Join(tmpdir, "config.toml")
+
+	// Create a config with no htmlgraph entries
+	initialContent := `[plugins]
+"github@openai-curated" = {source = "https://github.com/openai/curated"}
+
+[mcp_servers]
+my_server = {command = "/path/to/server"}
+`
+	if err := os.WriteFile(configPath, []byte(initialContent), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Read the original content for comparison
+	originalData, _ := os.ReadFile(configPath)
+
+	// Call removeCodexHtmlgraphRegistrations
+	removed, err := removeCodexHtmlgraphRegistrations(configPath)
+	if err != nil {
+		t.Fatalf("removeCodexHtmlgraphRegistrations: %v", err)
+	}
+	if removed {
+		t.Errorf("expected removed=false (no htmlgraph entries), got true")
+	}
+
+	// Verify the file was not modified
+	finalData, _ := os.ReadFile(configPath)
+	if !bytes.Equal(originalData, finalData) {
+		t.Errorf("file was modified when it should have been left unchanged.\nOriginal:\n%s\nFinal:\n%s",
+			string(originalData), string(finalData))
+	}
+}
+
+// TestRemoveCodexHtmlgraphRegistrationsNonexistentFile verifies that removeCodexHtmlgraphRegistrations
+// gracefully handles a non-existent config file.
+func TestRemoveCodexHtmlgraphRegistrationsNonexistentFile(t *testing.T) {
+	configPath := "/nonexistent/path/config.toml"
+
+	removed, err := removeCodexHtmlgraphRegistrations(configPath)
+	if err != nil {
+		t.Fatalf("removeCodexHtmlgraphRegistrations on non-existent file: %v", err)
+	}
+	if removed {
+		t.Errorf("expected removed=false for non-existent file, got true")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes `htmlgraph codex --dev` which fails with `error: unrecognized subcommand 'remove'` in codex-cli 0.121.0.

- **Root cause:** `codex-cli` dropped support for `codex marketplace remove` (only `add` and `help` are valid).
- **Solution:** Replace shell-out with direct TOML editing of `~/.codex/config.toml` using `github.com/pelletier/go-toml/v2`.
- **Idempotent:** Works whether htmlgraph entries are present or absent.
- **Preserves:** Other marketplace registrations and unrelated config sections (`mcp_servers`, `features`, etc.).
- **Banner fix:** Empty parenthetical `()`  now shows actual old path or fallback message.

## Test Plan

- [x] All existing Codex tests pass (TestCodexHelpRenders, TestCodexParsingFlags, marketplace detection)
- [x] New removal tests added:
  - `TestRemoveCodexHtmlgraphRegistrations` — deletes htmlgraph entries, preserves others
  - `TestRemoveCodexHtmlgraphRegistrationsNoop` — file unchanged when no entries present
  - `TestRemoveCodexHtmlgraphRegistrationsNonexistentFile` — handles missing config gracefully
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./cmd/htmlgraph/... -run Codex` passes (all tests)

Fixes bug-a83cf96b.
