### PR TITLE
fix(codex-marketplace): declare skills path in plugin.json

### DIFF
--- a/internal/pluginbuild/codex.go
+++ b/internal/pluginbuild/codex.go
@@ -165,6 +165,7 @@ type codexPluginJSON struct {
 	Repository  string             `json:"repository,omitempty"`
 	License     string             `json:"license,omitempty"`
 	Keywords    []string           `json:"keywords,omitempty"`
+	Skills      string             `json:"skills,omitempty"`
 	Interface   codexInterfaceJSON `json:"interface"`
 }
 
@@ -196,6 +197,7 @@ func writeCodexManifest(m *Manifest, path string) error {
 		Repository: m.Repository,
 		License:    m.License,
 		Keywords:   m.Keywords,
+		Skills:     "./skills/",
 		Interface: codexInterfaceJSON{
 			DisplayName:      "HtmlGraph",
 			ShortDescription: m.Description,

--- a/internal/pluginbuild/codex_test.go
+++ b/internal/pluginbuild/codex_test.go
@@ -206,3 +206,24 @@ func TestCodexMarketplaceSourcePathForNestedSubdir(t *testing.T) {
 		t.Errorf("expected plugin manifest at nested path %q: %v", pluginManifest, err)
 	}
 }
+
+// TestCodexPluginJSONDeclaresSkillsPath verifies that the generated plugin.json
+// includes the "skills": "./skills/" field, which tells Codex's TUI where to find
+// SKILL.md files for mention autocomplete (e.g., $htmlgraph or $skill-name).
+func TestCodexPluginJSONDeclaresSkillsPath(t *testing.T) {
+	repoRoot := t.TempDir()
+	seedAssets(t, repoRoot)
+	outDir := filepath.Join(repoRoot, "packages", "codex-marketplace")
+
+	if err := (codexAdapter{}).Emit(fixtureManifest(), repoRoot, outDir); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	pluginManifest := filepath.Join(outDir, ".agents", "plugins", "htmlgraph", ".codex-plugin", "plugin.json")
+	var plug codexPluginJSON
+	readJSON(t, pluginManifest, &plug)
+
+	if plug.Skills != "./skills/" {
+		t.Errorf("plugin.json skills field = %q, want %q", plug.Skills, "./skills/")
+	}
+}

--- a/packages/codex-marketplace/.agents/plugins/htmlgraph/.codex-plugin/plugin.json
+++ b/packages/codex-marketplace/.agents/plugins/htmlgraph/.codex-plugin/plugin.json
@@ -20,6 +20,7 @@
     "git-based",
     "offline-first"
   ],
+  "skills": "./skills/",
   "interface": {
     "displayName": "HtmlGraph",
     "shortDescription": "Local-first observability and coordination platform for AI-assisted development. Go binary hooks for near-zero cold start.",


### PR DESCRIPTION
## Summary
- Codex's plugin.json emitter was missing the `"skills": "./skills/"` field. Without it, Codex's TUI never discovers our shipped SKILL.md files, so `$htmlgraph` / `$<skill-name>` mention autocomplete returns nothing.
- Reference: openai-curated github plugin declares `"skills": "./skills/"` in its plugin.json (confirmed in ~/.codex/plugins/cache/openai-curated/github/.../plugin.json:22).
- This fixes bug-11c09d46 (user-reported symptom in bug-06e6eca3: "/htmlgraph: does not autocomplete in Codex"). Note that Codex uses `$skill-name` mention syntax, not `/namespace:command` slash syntax — the latter is Claude Code-specific.

## Changes
- **internal/pluginbuild/codex.go**: Added `Skills` field to `codexPluginJSON` struct with `json:"skills,omitempty"` tag and set it to `"./skills/"` in `writeCodexManifest()`
- **internal/pluginbuild/codex_test.go**: Added `TestCodexPluginJSONDeclaresSkillsPath()` to verify the field is emitted with the correct value
- **packages/codex-marketplace**: Regenerated plugin.json now includes `"skills": "./skills/"` on line 23

## Test plan
- [x] go build / vet / test pass (all 19 test suites)
- [x] Regenerated plugin.json contains `"skills": "./skills/"` (verified in plugin.json line 23)
- [x] New TestCodexPluginJSONDeclaresSkillsPath asserts the field is present and correct
- [x] Skills directory verified to contain 8 SKILL.md files (agent-context, code-quality-skill, deploy, diagnose, execute, orchestrator-directives-skill, plan, strategic-planning)
- [ ] Reviewer: Codex TUI skill autocomplete for `$htmlgraph` or `$<skill-name>` should now populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
