### PR TITLE
trk-787f57d3: execute workflow efficiency + cross-env path drift (11 bugs)

### DIFF
--- a/.htmlgraph/bugs/bug-71fc095f.html
+++ b/.htmlgraph/bugs/bug-71fc095f.html
@@ -40,10 +40,10 @@
 
         <section data-content>
             <h3>Description</h3>
-            <p>Discovered during the parallel-sessions investigation on 2026-04-11. The current htmlgraph session_id (8d53982f-66f2-415b-a645-1886eb8ae438) appears in /Users/shakes/DevProjects/shakestzd/.htmlgraph/htmlgraph.db with 902 events but 0 messages, when it should only exist in /Users/shakes/DevProjects/htmlgraph/.htmlgraph/htmlgraph.db.
+            <p>Discovered during the parallel-sessions investigation on 2026-04-11. The current htmlgraph session_id (8d53982f-66f2-415b-a645-1886eb8ae438) appears in <sibling-repo-root>/.htmlgraph/htmlgraph.db with 902 events but 0 messages, when it should only exist in <repo-root>/.htmlgraph/htmlgraph.db.
 
 Evidence from shakestzd DB query:
-  8d53982f|/Users/shakes/DevProjects/shakestzd|902|0|2026-04-10T17:14:56Z
+  8d53982f|<sibling-repo-root>|902|0|2026-04-10T17:14:56Z
 
 The row has project_dir correctly set to shakestzd, created_at is 2026-04-10T17:14:56Z (several hours into this session), 902 events but ZERO messages. That pattern (events without messages) suggests hook-driven event inserts without any JSONL ingest or live-hook SessionStart to seed the messages table.
 

--- a/.htmlgraph/plans/plan-251676c5.html
+++ b/.htmlgraph/plans/plan-251676c5.html
@@ -1,0 +1,1848 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="htmlgraph-version" content="1.0">
+<title>Plan: Distribution de-bundle, version-sync, and container launchers</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css" id="hljs-dark">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github.min.css" id="hljs-light" disabled>
+<script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/highlight.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/languages/go.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/languages/yaml.min.js"></script>
+<style>
+:root {
+  --bg:#0f0f13; --bg-card:#18181c; --bg-input:#222228; --bg-hover:#2c2c32;
+  --text:#f0f0ed; --text-dim:#d0d0cc; --text-muted:#9898a0; --border:#3a3a42;
+  --accent:#cdff00; --accent-dim:rgba(205,255,0,.1); --accent-glow:rgba(205,255,0,.25);
+  --approved:#22c55e; --revision:#f59e0b; --discuss:#a78bfa; --pending:#6b7280; --blocked:#ef4444;
+  --radius:8px; --radius-sm:5px;
+  --mono:'JetBrains Mono',ui-monospace,'SF Mono','Cascadia Code',monospace;
+  --sans:'DM Sans','Inter',system-ui,-apple-system,sans-serif;
+  --shadow-card:0 2px 8px rgba(0,0,0,.5), 0 0 0 1px var(--border);
+  --shadow-elevated:0 8px 32px rgba(0,0,0,.6), 0 0 0 1px var(--border);
+  --transition:150ms cubic-bezier(.4,0,.2,1);
+}
+[data-theme="light"] {
+  --bg:#f4f3ef; --bg-card:#ffffff; --bg-input:#eeeee8; --bg-hover:#e4e4de;
+  --text:#1a1a1e; --text-dim:#4a4a50; --text-muted:#8a8a90; --border:#d4d4cc;
+  --accent:#4a6e00; --accent-dim:rgba(74,110,0,.08); --accent-glow:rgba(74,110,0,.2);
+  --shadow-card:0 1px 3px rgba(0,0,0,.06), 0 0 0 1px var(--border);
+  --shadow-elevated:0 4px 24px rgba(0,0,0,.1), 0 0 0 1px var(--border);
+}
+[data-theme="light"] .badge-approved{background:rgba(34,197,94,.08);color:#16a34a;border-color:rgba(34,197,94,.2)}
+[data-theme="light"] .badge-revision{background:rgba(245,158,11,.08);color:#d97706;border-color:rgba(245,158,11,.2)}
+[data-theme="light"] .badge-discuss{background:rgba(167,139,250,.08);color:#7c3aed;border-color:rgba(167,139,250,.2)}
+[data-theme="light"] .badge-pending{background:rgba(107,114,128,.08);color:#4b5563;border-color:rgba(107,114,128,.2)}
+[data-theme="light"] .badge-blocked{background:rgba(239,68,68,.08);color:#dc2626;border-color:rgba(239,68,68,.2)}
+[data-theme="light"] .btn-finalize{background:#4a6e00;color:#fff}
+[data-theme="light"] .section-card{--shadow-card:0 1px 2px rgba(0,0,0,.04),0 0 0 1px var(--border)}
+
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{font-size:15px;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);line-height:1.6;margin:0;padding:0;display:grid;grid-template-columns:200px 1fr;min-height:100vh}
+
+/* ── Sidebar ── */
+.plan-sidebar{background:var(--bg-card);border-right:1px solid var(--border);padding:20px 0;display:flex;flex-direction:column;gap:1px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.plan-sidebar .brand{padding:16px 20px 20px;font-weight:700;font-size:1rem;color:var(--accent);text-decoration:none;display:block;border-bottom:1px solid var(--border);margin-bottom:8px;font-family:var(--mono);letter-spacing:-.02em}
+.plan-sidebar a.nav-link{display:flex;align-items:center;gap:10px;padding:9px 20px;color:var(--text-muted);text-decoration:none;font-size:.82rem;font-weight:500;border-right:2px solid transparent;transition:all var(--transition)}
+.plan-sidebar a.nav-link:hover{color:var(--text);background:var(--bg-hover)}
+.plan-sidebar a.nav-link.active{color:var(--accent);background:var(--accent-dim);border-right-color:var(--accent);font-weight:600}
+
+/* ── Plan layout (content + chat sidebar) ── */
+.plan-layout{display:flex;flex:1;min-width:0;overflow:hidden;height:100vh}
+.plan-content{flex:1;min-width:0;padding:32px 40px 80px;overflow-y:auto;max-width:960px}
+
+/* ── Chat sidebar ── */
+.chat-sidebar{width:360px;min-width:280px;max-width:600px;border-left:1px solid var(--border);display:flex;flex-direction:column;background:var(--bg-card);overflow:hidden;height:100%}
+.chat-resize-handle{width:4px;cursor:col-resize;background:transparent;transition:background .15s;flex-shrink:0;position:relative}
+.chat-resize-handle:hover,.chat-resize-handle.dragging{background:var(--accent);opacity:.5}
+.chat-resize-handle::after{content:'';position:absolute;top:50%;left:-4px;width:12px;height:32px;transform:translateY(-50%);border-radius:4px}
+
+/* ── Typography ── */
+h1{font-family:var(--sans);font-size:1.65rem;font-weight:700;color:var(--text);margin-bottom:6px;letter-spacing:-.03em;line-height:1.3}
+h1::first-letter{color:var(--accent)}
+h2{font-family:var(--sans);font-size:1.15rem;font-weight:600;letter-spacing:-.01em}
+h3{font-family:var(--mono);font-size:.72rem;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:10px}
+h4{font-family:var(--sans);font-size:.88rem;font-weight:600;margin-bottom:8px;color:var(--text)}
+p,li{color:var(--text-dim);line-height:1.7;font-size:.95rem}
+ul,ol{padding-left:1.5em;margin:8px 0}
+ul{list-style:disc}
+ol{list-style:decimal}
+li{padding:3px 0}
+li::marker{color:var(--text-muted)}
+code{font-family:var(--mono);font-size:.82em;background:var(--bg-input);padding:2px 6px;border-radius:var(--radius-sm);border:1px solid var(--border)}
+pre{font-family:var(--mono);font-size:.78rem;background:var(--bg-input);border:1px solid var(--border);border-radius:var(--radius);padding:14px 16px;overflow-x:auto;line-height:1.6;color:var(--text);margin:10px 0}
+a{color:var(--accent);text-decoration:none;transition:opacity var(--transition)}
+a:hover{opacity:.8}
+
+/* ── Plan header ── */
+.plan-header{margin-bottom:36px;padding-bottom:20px;border-bottom:1px solid var(--border);position:relative}
+.plan-header::after{content:'';position:absolute;bottom:-1px;left:0;width:120px;height:1px;background:var(--accent);opacity:.5}
+.plan-header .meta{display:flex;gap:12px;flex-wrap:wrap;margin-top:10px;align-items:center}
+
+/* ── Related Work ── */
+.related-work{margin-bottom:24px;padding:16px 20px;background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);display:flex;flex-direction:column;gap:12px}
+.related-track{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+.related-label{font-family:var(--mono);font-size:.72rem;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;min-width:70px}
+.related-link{color:var(--accent);font-weight:600;font-size:.9rem;text-decoration:none}
+.related-link:hover{text-decoration:underline}
+.related-features{display:flex;flex-direction:column;gap:6px}
+.related-feature-list{display:flex;flex-direction:column;gap:4px}
+.related-feature{display:flex;align-items:center;gap:10px;padding:6px 10px;background:var(--bg-input);border:1px solid var(--border);border-radius:var(--radius-sm);text-decoration:none;transition:border-color var(--transition)}
+.related-feature:hover{border-color:var(--accent)}
+.related-feature-id{font-family:var(--mono);font-size:.75rem;color:var(--text-muted);min-width:110px}
+.related-feature-title{flex:1;font-size:.85rem;color:var(--text-dim)}
+.related-feature .badge{flex-shrink:0}
+
+/* ── Badges ── */
+.badge{display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;padding:4px 12px;border-radius:9999px;border:1px solid transparent;transition:all var(--transition)}
+.badge::before{content:'';width:5px;height:5px;border-radius:50%;flex-shrink:0}
+.badge-approved{background:rgba(34,197,94,.1);color:var(--approved);border-color:rgba(34,197,94,.25)}.badge-approved::before{background:var(--approved);box-shadow:0 0 6px var(--approved)}
+.badge-revision{background:rgba(245,158,11,.1);color:var(--revision);border-color:rgba(245,158,11,.25)}.badge-revision::before{background:var(--revision)}
+.badge-discuss{background:rgba(167,139,250,.1);color:var(--discuss);border-color:rgba(167,139,250,.25)}.badge-discuss::before{background:var(--discuss)}
+.badge-pending{background:rgba(107,114,128,.1);color:var(--pending);border-color:rgba(107,114,128,.2)}.badge-pending::before{background:var(--pending)}
+.badge-blocked{background:rgba(239,68,68,.1);color:var(--blocked);border-color:rgba(239,68,68,.25)}.badge-blocked::before{background:var(--blocked)}
+
+/* ── Dependency graph ── */
+.dep-graph{background:var(--bg-card);border-radius:var(--radius);padding:28px;margin-bottom:28px;box-shadow:var(--shadow-card);overflow-x:auto}
+.dep-graph h2{margin-bottom:20px;padding-bottom:12px;border-bottom:1px solid var(--border)}
+.dep-graph svg{display:block;height:auto}
+#dep-graph-svg .node rect{rx:8;ry:8;fill:var(--bg-input);stroke:var(--border);stroke-width:2px}
+#dep-graph-svg .node text{fill:var(--text) !important;font-family:var(--sans);font-size:13px}
+#dep-graph-svg .edgePath path{stroke:var(--text-muted);stroke-dasharray:5 4;fill:none;stroke-width:1.5}
+#dep-graph-svg .edgePath marker path{fill:var(--text-muted)}
+
+/* ── Section cards ── */
+.section-card{background:var(--bg-card);border-radius:var(--radius);margin-bottom:14px;box-shadow:var(--shadow-card);overflow:hidden;transition:box-shadow var(--transition)}
+.section-card:hover{box-shadow:var(--shadow-elevated)}
+.section-card summary{display:flex;align-items:center;gap:12px;padding:16px 24px;cursor:pointer;font-weight:600;font-size:1rem;list-style:none;user-select:none;color:var(--text);font-family:var(--sans);transition:background var(--transition)}
+.section-card summary:hover{background:var(--bg-hover)}
+.section-card summary::-webkit-details-marker{display:none}
+.section-card summary::before{content:'';width:6px;height:6px;border-right:2px solid var(--text-muted);border-bottom:2px solid var(--text-muted);transform:rotate(-45deg);transition:transform .2s ease;flex-shrink:0}
+.section-card[open] summary::before{transform:rotate(45deg)}
+.section-card summary .badge{margin-left:auto}
+.section-body{padding:16px 24px 24px;animation:slideDown .2s ease}
+@keyframes slideDown{from{opacity:0;transform:translateY(-4px)}to{opacity:1;transform:translateY(0)}}
+.sub-section{margin-bottom:20px}.sub-section:last-child{margin-bottom:0}
+
+/* ── Approval row ── */
+.approval-row{display:flex;align-items:center;gap:16px;margin-top:20px;padding-top:16px;border-top:1px solid var(--border)}
+.approval-row label{font-size:.9rem;color:var(--text);cursor:pointer;display:flex;align-items:center;gap:8px;font-weight:500;white-space:nowrap;transition:color var(--transition)}
+.approval-row label:hover{color:var(--accent)}
+.approval-row input[type="checkbox"]{accent-color:var(--approved);width:18px;height:18px;cursor:pointer;border-radius:4px;flex-shrink:0}
+
+/* ── Textarea ── */
+textarea{width:100%;min-height:52px;resize:vertical;background:var(--bg-input);color:var(--text);border:1px solid var(--border);border-radius:var(--radius);padding:10px 12px;font-family:var(--sans);font-size:.84rem;line-height:1.5;transition:border-color var(--transition),box-shadow var(--transition)}
+textarea:focus{outline:none;border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-dim)}
+textarea::placeholder{color:var(--text-muted)}
+
+/* ── Question blocks ── */
+.question-block{margin-bottom:16px;padding:14px 16px;background:var(--bg-input);border-radius:var(--radius);border-left:3px solid var(--discuss)}
+.question-block p{font-size:.88rem;color:var(--text);margin-bottom:8px;font-weight:500}
+.question-block label{display:block;font-size:.84rem;color:var(--text-dim);padding:5px 8px;cursor:pointer;transition:color var(--transition);border-radius:var(--radius-sm)}
+.question-block label:hover{color:var(--text);background:var(--bg-hover)}
+.question-block label.recommended{border-left:2px solid var(--accent);padding-left:10px;background:var(--accent-dim)}
+.question-block input[type="radio"]{accent-color:var(--accent);margin-right:8px;cursor:pointer}
+.rec-tag{font-family:var(--mono);font-size:.65rem;color:var(--accent);text-transform:uppercase;letter-spacing:.05em;margin-left:6px;opacity:.8}
+
+/* ── Slice cards ── */
+.slice-card{background:var(--bg-input);border:1px solid var(--border);border-radius:var(--radius);padding:24px;margin-bottom:16px;transition:border-color var(--transition)}
+.slice-card:hover{border-color:rgba(205,255,0,.2)}
+.slice-header{display:flex;align-items:center;gap:10px;margin-bottom:16px;padding-bottom:12px;border-bottom:1px solid var(--border);flex-wrap:wrap}
+.slice-num{font-family:var(--mono);font-size:.8rem;color:var(--bg);background:var(--accent);padding:3px 9px;border-radius:4px;font-weight:700;min-width:26px;text-align:center}
+.slice-name{font-weight:600;font-size:1rem;font-family:var(--sans);flex:1}
+.slice-meta{font-size:.85rem;color:var(--text-muted);margin-bottom:8px;font-family:var(--mono)}
+.slice-meta span{margin-right:14px}
+.slice-field{margin-bottom:14px;padding-bottom:12px;border-bottom:1px solid rgba(51,51,56,.4)}
+.slice-field:last-of-type{border-bottom:none}
+.slice-field-label{font-family:var(--mono);font-size:.75rem;font-weight:600;color:var(--accent);text-transform:uppercase;letter-spacing:.06em;margin-bottom:6px}
+.slice-field-value{font-size:.92rem;color:var(--text-dim);line-height:1.7}
+.slice-field-value code{font-size:.82rem;word-break:break-all}
+.slice-tests{white-space:pre-line}
+.slice-done-list{list-style:none;padding-left:0;margin:0}
+.slice-done-list li{font-size:.9rem;color:var(--text-dim);padding:4px 0;padding-left:20px;position:relative}
+.slice-done-list li::before{content:'\2713';position:absolute;left:0;color:var(--approved);font-weight:700}
+.slice-deps{font-size:.85rem;color:var(--text-muted);margin-top:8px;font-family:var(--mono)}
+.slice-card .approval-row{margin-top:16px}
+
+/* ── Progress zone ── */
+.progress-zone{background:var(--bg-card);border-radius:var(--radius);padding:24px;margin-top:28px;box-shadow:var(--shadow-card)}
+.progress-bar-track{height:6px;background:var(--bg-input);border-radius:3px;overflow:hidden;margin:12px 0 20px;position:relative}
+.progress-bar-fill{height:100%;background:linear-gradient(90deg,var(--accent),var(--approved));border-radius:3px;transition:width .4s cubic-bezier(.4,0,.2,1);position:relative}
+.progress-bar-fill::after{content:'';position:absolute;right:0;top:-1px;width:8px;height:8px;background:var(--approved);border-radius:50%;box-shadow:0 0 8px var(--approved);opacity:0;transition:opacity .3s}
+.progress-bar-fill[style*="width:100"]::after,.progress-bar-fill[style*="width: 100"]::after{opacity:1}
+.progress-stats{display:flex;gap:24px;flex-wrap:wrap;margin-bottom:16px}
+.progress-stat{font-size:.82rem;color:var(--text-dim);font-family:var(--sans)}.progress-stat strong{color:var(--text);font-size:1.2rem;margin-right:4px;font-weight:700}
+.comments-summary{border-top:1px solid var(--border);padding-top:16px;margin-top:4px}.comments-summary h3{margin-bottom:10px}
+.comment-entry{font-size:.82rem;color:var(--text-dim);padding:6px 0;border-bottom:1px solid var(--border)}
+.comment-entry:last-child{border-bottom:none}
+.comment-entry .comment-source{font-family:var(--mono);color:var(--accent);font-weight:600;margin-right:8px;font-size:.75rem}
+.finalize-area{margin-top:20px;text-align:center}
+.btn-finalize{background:var(--accent);color:#0a0a0a;border:none;border-radius:var(--radius);padding:12px 36px;font-weight:700;font-size:.88rem;cursor:pointer;font-family:var(--sans);letter-spacing:.01em;transition:all var(--transition);box-shadow:0 0 0 0 var(--accent-glow)}
+.btn-finalize:hover:not(:disabled){filter:brightness(.92);box-shadow:0 0 20px var(--accent-glow)}
+.btn-finalize:disabled{opacity:.3;cursor:not-allowed}
+
+/* ── Critique zone lists (badge-aligned, no bullets) ── */
+#critique ul{list-style:none;padding-left:0;margin:0}
+#critique ul li{display:flex;align-items:flex-start;gap:10px;padding:6px 0;border-bottom:1px solid var(--border)}
+#critique ul li:last-child{border-bottom:none}
+#critique ul li .badge{flex-shrink:0;margin-top:2px}
+
+/* ── Questions table ── */
+.q-table{width:100%;font-size:.84rem;border-collapse:collapse}
+.q-table th{text-align:left;padding:8px 10px;border-bottom:1px solid var(--border);color:var(--text-muted);font-family:var(--mono);font-size:.68rem;text-transform:uppercase;letter-spacing:.06em}
+.q-table td{padding:8px 10px;border-bottom:1px solid var(--border)}
+
+/* ── Chat panel (inside sidebar) ── */
+.chat-panel{display:flex;flex-direction:column;flex:1;overflow:hidden;border-radius:0;box-shadow:none;background:transparent}
+.chat-panel h2{padding:16px 20px 12px;margin-bottom:0;font-size:.95rem;border-bottom:1px solid var(--border);flex-shrink:0}
+.chat-messages{flex:1;overflow-y:auto;padding:16px 20px;display:flex;flex-direction:column;gap:8px}
+.chat-bubble{padding:14px 18px;border-radius:12px;max-width:88%;word-wrap:break-word;font-size:.88rem;line-height:1.65;white-space:normal;animation:bubbleIn .2s ease;overflow:visible}
+@keyframes bubbleIn{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
+.chat-bubble[data-role="user"]{background:var(--accent-dim);border:1px solid rgba(205,255,0,.12);margin-left:auto;color:var(--text);border-bottom-right-radius:4px}
+.chat-bubble[data-role="assistant"]{background:var(--bg-input);border:1px solid var(--border);color:var(--text-dim);border-bottom-left-radius:4px}
+.chat-bubble h3,.chat-bubble h4{font-size:.92rem;margin:16px 0 6px;color:var(--text);font-family:var(--sans)}
+.chat-bubble h3:first-child,.chat-bubble h4:first-child,.chat-bubble p:first-child{margin-top:0}
+.chat-bubble p{margin:8px 0;font-size:inherit;color:inherit;line-height:1.65}
+.chat-bubble p:last-child{margin-bottom:0}
+.chat-bubble strong{color:var(--text);font-weight:600}
+.chat-bubble em{font-style:italic}
+.chat-bubble code{font-size:.82em;padding:2px 5px;background:rgba(255,255,255,.06);border-radius:3px}
+.chat-bubble pre{margin:10px 0;padding:12px 14px;font-size:.8rem;border-radius:var(--radius-sm);background:rgba(0,0,0,.2);overflow-x:auto;white-space:pre;line-height:1.5}
+.chat-bubble pre code{background:none;padding:0;font-size:inherit}
+.chat-bubble ul,.chat-bubble ol{margin:8px 0;padding-left:1.4em}
+.chat-bubble li{padding:3px 0;font-size:inherit;line-height:1.6}
+.chat-bubble table{margin:10px 0;font-size:.82rem;border-collapse:collapse;width:100%;display:block;overflow-x:auto}
+.chat-bubble table th{text-align:left;padding:6px 10px;border-bottom:2px solid var(--border);color:var(--text-muted);font-family:var(--mono);font-size:.75rem;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.chat-bubble table td{padding:8px 10px;border-bottom:1px solid var(--border);vertical-align:top}
+.chat-input-area{display:flex;gap:8px;padding:14px 20px;border-top:1px solid var(--border);background:var(--bg-input);flex-shrink:0}
+#chat-input{flex:1;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:var(--radius);padding:10px 12px;resize:none;font-family:var(--sans);font-size:.84rem;line-height:1.5;transition:border-color var(--transition),box-shadow var(--transition)}
+#chat-input:focus{outline:none;border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-dim)}
+#chat-input::placeholder{color:var(--text-muted)}
+#chat-send{background:var(--accent);color:#0a0a0a;border:none;border-radius:var(--radius);padding:10px 18px;cursor:pointer;font-weight:600;font-family:var(--sans);font-size:.84rem;transition:all var(--transition)}
+#chat-send:hover:not(:disabled){box-shadow:0 0 16px var(--accent-glow)}
+#chat-send:disabled{opacity:.3;cursor:not-allowed}
+.chat-notice{font-size:.82rem;color:var(--text-muted);padding:20px;text-align:center;line-height:1.6}
+
+/* ── Amendments ── */
+.amendments-panel{margin-top:28px;background:var(--bg-card);border-radius:var(--radius);padding:20px;box-shadow:var(--shadow-card)}
+.amendments-panel h3{margin:0 0 14px;font-size:.92rem;color:var(--text);font-family:var(--sans);font-weight:600}
+.amendment-item{display:flex;align-items:center;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);transition:background var(--transition)}
+.amendment-item:last-child{border-bottom:none}
+.amendment-item:hover{background:var(--bg-hover);margin:0 -8px;padding-left:8px;padding-right:8px;border-radius:var(--radius-sm)}
+.amendment-desc{flex:1;font-size:.84rem;color:var(--text-dim)}
+.amendment-desc .op{color:var(--accent);font-weight:600;font-family:var(--mono);font-size:.78rem}
+.amendment-desc .field{color:var(--text-muted);font-family:var(--mono);font-size:.78rem}
+.amendment-select{background:var(--bg-input);color:var(--text);border:1px solid var(--border);border-radius:var(--radius-sm);padding:5px 10px;font-size:.8rem;font-family:var(--sans);cursor:pointer;transition:border-color var(--transition)}
+.amendment-select:focus{border-color:var(--accent);outline:none}
+.amendments-summary{font-size:.82rem;color:var(--text-muted);margin-top:14px;font-family:var(--mono);padding-top:10px;border-top:1px solid var(--border)}
+
+/* ── YAML viewer ── */
+.yaml-viewer{margin:20px 0}
+.yaml-viewer summary{cursor:pointer;color:var(--accent);font-weight:600;font-size:.84rem;padding:8px 0;font-family:var(--mono);transition:opacity var(--transition)}
+.yaml-viewer summary:hover{opacity:.7}
+.yaml-viewer pre{background:var(--bg-input);border:1px solid var(--border);border-radius:var(--radius);padding:16px;overflow-x:auto;max-height:500px;overflow-y:auto;font-size:.78rem;line-height:1.5;margin-top:8px}
+.yaml-viewer code{font-family:var(--mono);color:var(--text)}
+
+
+/* ── Print ── */
+@media print{body{background:#fff;color:#111;max-width:100%;display:block}.plan-sidebar{display:none}.section-card,.dep-graph,.progress-zone,.slice-card{border-color:#ccc;background:#fafafa;box-shadow:none}details[open] summary~*{display:block}.btn-finalize,.chat-panel,.amendments-panel{display:none}}
+
+/* ── Responsive ── */
+@media(max-width:1024px){.chat-sidebar{width:300px;min-width:240px}}
+@media(max-width:768px){
+  body{grid-template-columns:1fr}
+  .plan-sidebar{display:none}
+  .plan-layout{flex-direction:column;height:auto}
+  .plan-content{padding:20px 16px 40px;max-width:none}
+  .chat-resize-handle{display:none}
+  .chat-sidebar{width:100% !important;min-width:0;max-width:none;border-left:none;border-top:1px solid var(--border);height:400px;flex-shrink:0}
+}
+
+</style>
+</head>
+<body>
+
+<nav class="plan-sidebar">
+  <a href="/" class="brand">HtmlGraph</a>
+  <a href="#design" class="nav-link active" data-spy="design">Design</a>
+  <a href="#slices" class="nav-link" data-spy="slices">Slices</a>
+  <a href="#questions" class="nav-link" data-spy="questions">Decisions</a>
+  <a href="#critique" class="nav-link" data-spy="critique">Critique</a>
+  <a href="#feedback-summary" class="nav-link" data-spy="feedback-summary">Progress</a>
+  <a href="#chat-panel" class="nav-link" data-spy="chat-panel">Chat</a>
+</nav>
+<div class="plan-layout">
+<div class="plan-content">
+<article id="plan-251676c5" data-plan-id="plan-251676c5" data-feature-id="" data-status="draft">
+
+<!-- Plan Header -->
+<header class="plan-header">
+  <h1>Plan: Distribution de-bundle, version-sync, and container launchers</h1>
+  <p style="color:var(--text-dim)">Four-part architecture change: (A) strip bundled binary from plugin — ship CLI and plugin as two artifacts with shared version; (B) add SessionStart version-check hook + htmlgraph doctor + upgrade messaging to prevent plugin/CLI version skew; (C) curl install script + Homebrew tap for frictionless first install; (D) --container launchers that use a shared devcontainer and skip host-state mutations. Inspired by roborev's binary-first distribution, refined to keep our marketplace presence for discoverability.</p>
+  <div class="meta">
+    <span class="badge badge-pending">Draft</span>
+    <span style="font-size:.75rem;color:var(--text-muted)">v4 · 11 slices · Created 2026-04-21</span>
+  </div>
+</header>
+<button id="themeToggle" style="position:fixed;top:16px;right:16px;z-index:100;background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:6px 12px;color:var(--text);font-family:var(--mono);font-size:0.75rem;cursor:pointer;">
+  &#9728; Light
+</button>
+
+<!-- Related Work -->
+
+
+<!-- Plan YAML source (collapsible) -->
+<details class="yaml-viewer" id="yaml-viewer">
+    <summary>View Plan YAML</summary>
+    <pre><code class="language-yaml" id="yaml-content">Loading&#x2026;</code></pre>
+</details>
+
+<!-- ZONE 1: Dependency Graph -->
+<section class="dep-graph" data-zone="dependency-graph">
+  <h2>Dependency Graph</h2>
+  <div id="graph-data" style="display:none">
+    <div data-node="1" data-name="Delete plugin/hooks/bin/ and update build script to stop copying there" data-status="pending" data-deps="" data-files="7"></div>
+    <div data-node="2" data-name="Add post-build assertion to plugin build-ports verifying binary-free hook commands" data-status="pending" data-deps="1" data-files="1"></div>
+    <div data-node="3" data-name="Split deploy-all.sh into binary-release and plugin-release artifacts with shared version file" data-status="pending" data-deps="1,2" data-files="4"></div>
+    <div data-node="4" data-name="Refactor version-check into shared decision function and add missing-CLI block path to SessionStart" data-status="pending" data-deps="1" data-files="2"></div>
+    <div data-node="5" data-name="Add htmlgraph doctor subcommand with cross-harness version matrix" data-status="pending" data-deps="4" data-files="3"></div>
+    <div data-node="6" data-name="Extend htmlgraph upgrade to print post-upgrade plugin-update instructions" data-status="pending" data-deps="5" data-files="2"></div>
+    <div data-node="7" data-name="Add env-var escape hatches to install.sh (HTMLGRAPH_INSTALL_DIR, HTMLGRAPH_NO_MODIFY_PATH, HTMLGRAPH_VERSION)" data-status="pending" data-deps="3" data-files="1"></div>
+    <div data-node="8" data-name="Publish Homebrew tap formula and wire version bump into deploy pipeline" data-status="pending" data-deps="3" data-files="3"></div>
+    <div data-node="9" data-name="Add internal/launcher/container/ package: preflight, wrap, paths" data-status="pending" data-deps="1" data-files="4"></div>
+    <div data-node="10" data-name="Add --container flag to claude/codex/gemini/yolo and wire HTMLGRAPH_DEVCONTAINER=1" data-status="pending" data-deps="9" data-files="5"></div>
+    <div data-node="11" data-name="Add .devcontainer/Dockerfile and wire postCreateCommand to install htmlgraph CLI" data-status="pending" data-deps="9,10" data-files="3"></div>
+    
+    <!--PLAN_GRAPH_NODES-->
+  </div>
+  <svg id="dep-graph-svg" width="100%"></svg>
+</section>
+
+<!-- ZONE 2: Interactive Sections -->
+
+<!-- Design -->
+<details id="design" class="section-card" open data-phase="design" data-status="pending">
+  <summary><span>Design</span><span class="badge badge-pending" data-badge-for="design">Pending</span></summary>
+  <div class="section-body">
+    <h4>Problem</h4>
+<div data-markdown>HtmlGraph currently bundles the CLI binary inside the Claude Code plugin tree (`plugin/hooks/bin/`), bloating the marketplace artifact with per-arch binaries and coupling plugin versioning to CLI versioning. When a user updates the plugin via the marketplace while running an older CLI (or vice versa), hooks resolve to the wrong binary with no runtime detection — silent version skew with no recovery path. There is no first-run install story beyond `claude plugin install`: no curl script, no Homebrew tap, no `htmlgraph doctor` to surface mismatches. The `--dev` launcher mutates host `~/.claude/plugins/` state (remove/reinstall marketplace plugin) that bleeds across machines when users sync dotfiles, and fails outright in a container where the host state is ephemeral or absent. These four pain points — bundle bloat, version skew, install friction, host mutation — are the concrete problems this plan resolves.
+</div>
+<h4>Goals</h4>
+<ol>
+<li data-markdown>**Binary de-bundled** — plugin artifact ships zero binaries; size reduction &gt;80% for the marketplace tarball</li>
+<li data-markdown>**Version skew detected** — SessionStart hook blocks (exit 2) on missing CLI and warns (exit 1) on mismatch, with actionable remediation message surfaced in-session</li>
+<li data-markdown>**Frictionless first install** — a single `curl | bash` command installs the CLI binary; `htmlgraph doctor` reports plugin-vs-CLI alignment across all three harnesses</li>
+<li data-markdown>**Stable version contract** — `plugin.json` version and `htmlgraph --version` are read by the same hook code; any divergence is caught by the version-check handler and by `htmlgraph doctor`</li>
+<li data-markdown>**Container-safe launchers** — `--container` flag (and `HTMLGRAPH_DEVCONTAINER=1` auto-detect) skips all host-state mutations; yolo `--container` implies `--no-worktree`</li>
+<li data-markdown>**Two-artifact deploy** — `deploy-all.sh` emits binary release (GitHub Releases + Homebrew tap) and plugin release (marketplace) as separate, version-tagged artifacts from the same commit</li>
+</ol>
+<h4>Constraints</h4>
+<ul>
+<li data-markdown>Must retain Claude Code marketplace presence — discoverability via marketplace is a deliberate divergence from roborev&#39;s binary-only model; the plugin cannot become marketplace-free</li>
+<li data-markdown>Must not break existing installs — the SessionStart version-check must degrade to a non-blocking warning (exit 1, not exit 2) for users on older CLIs that pre-date de-bundling, never a hard block that kills their session</li>
+<li data-markdown>Cross-platform coverage limited to macOS (arm64, x86_64) and Linux (arm64, x86_64) — Windows is out of scope for v1; install script must not silently fail on Windows, it must error clearly</li>
+<li data-markdown>Install script must respect corporate shell constraints — `HTMLGRAPH_NO_MODIFY_PATH` skips PATH edits, `HTMLGRAPH_INSTALL_DIR` overrides install location, `HTMLGRAPH_VERSION` pins a specific release; mirrors roborev&#39;s escape-hatch pattern</li>
+<li data-markdown>Plugin must remain functional in all three harnesses — Claude Code, Codex CLI, and Gemini CLI all consume generated trees from `plugin/` and `packages/plugin-core/manifest.json`; de-bundling and port generation must be harness-neutral</li>
+<li data-markdown>Workstream D (container launchers) is strictly gated on A — the container image can only `go install` from source or curl the binary; it must not depend on a bundled binary that no longer exists after A lands</li>
+<li data-markdown>Plugin and CLI versions are tagged and published atomically by a single release workflow. Mid-release skew is bounded to job duration; the SessionStart version check must tolerate this window by emitting only a warning (exit 1), never a hard block (exit 2) on minor/patch divergence.</li>
+</ul>
+
+    <div class="approval-row">
+      <label><input type="checkbox" data-section="design" data-action="approve"> Approve design</label>
+      <textarea data-section="design" data-comment-for="design" placeholder="Comments on design decisions..."></textarea>
+    </div>
+  </div>
+</details>
+
+
+<!-- Structure Outline (hidden when empty) -->
+
+
+<!-- Slices -->
+<details id="slices" class="section-card" open data-phase="slices" data-status="pending">
+  <summary><span>Slices</span><span class="badge badge-pending" data-badge-for="slices">Pending</span></summary>
+  <div class="section-body">
+    <div class="slice-card" data-slice="1" data-slice-name="slice-1" data-status="pending">
+  <div class="slice-header">
+    <span class="slice-num">#1</span>
+    <span class="slice-name">Delete plugin/hooks/bin/ and update build script to stop copying there</span>
+    <span class="badge badge-pending">S</span>
+    <span class="badge badge-revision">Med</span>
+    <span class="badge badge-pending" data-badge-for="slice-1">Pending</span>
+  </div>
+  
+  <div class="slice-field"><div class="slice-field-label">What</div><div class="slice-field-value" data-markdown="">Remove the bundled binary from the Claude Code plugin tree. Specifically: delete `plugin/hooks/bin/htmlgraph`, `plugin/hooks/bin/htmlgraph-dev`, `plugin/hooks/bin/bootstrap.sh`, and `plugin/hooks/bin/install-binary.sh` from source control. Update `plugin/build.sh` (invoked by `htmlgraph build`) to stop installing the binary into `plugin/hooks/bin/`. Update `cmd/htmlgraph/build.go` to remove the walk-up path that resolves the binary from `plugin/hooks/bin/htmlgraph` (the `os.Executable()` two-level walk-up at line 111). Update `cmd/htmlgraph/serve.go` comment at line 159 that refers to `plugin/hooks/bin/htmlgraph`. All hook commands in `plugin/hooks/hooks.json` already use `htmlgraph hook &lt;handler&gt;` via PATH — confirm no hook still references the bin/ path. The `htmlgraph build` output path becomes only the PATH-installed binary (e.g. `~/.local/bin/htmlgraph`).
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Why</div><div class="slice-field-value" data-markdown="">The bundled binary in `plugin/hooks/bin/` is the root cause of plugin artifact bloat and the CLI/plugin version-skew problem. Removing it is the prerequisite for workstreams B (version-check hook), C (install UX), and D (container launchers). Without this slice the marketplace artifact stays oversized and the hook-via-PATH model is not the sole truth.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>plugin/hooks/bin/htmlgraph, plugin/hooks/bin/htmlgraph-dev, plugin/hooks/bin/bootstrap.sh, plugin/hooks/bin/install-binary.sh, plugin/build.sh, cmd/htmlgraph/build.go, cmd/htmlgraph/serve.go</code></div></div>
+  <div class="slice-field"><div class="slice-field-label">Done when</div><ul class="slice-done-list"><li data-markdown="">`plugin/hooks/bin/` directory no longer exists in source control</li><li data-markdown="">`git ls-files plugin/hooks/bin/` returns empty</li><li data-markdown="">`htmlgraph build` succeeds without writing anything to `plugin/hooks/bin/`</li><li data-markdown="">`go build ./...` and `go vet ./...` pass with no errors</li><li data-markdown="">The marketplace plugin directory (sans bin/) is under 10 MB</li><li data-markdown="">`htmlgraph build` resolves its own binary and build.sh location without relying on `plugin/hooks/bin/` parentage — uses `os.Executable()` for the binary path and a known repo-root discovery (walk-up to `.htmlgraph/` directory) for build.sh</li></ul></div>
+  
+  <div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-tests" data-markdown="">Unit: TestResolveBuildScript in cmd/htmlgraph (update or add) — assert that
+  the walk-up strategy does not reference a hooks/bin path, and that
+  CLAUDE_PLUGIN_ROOT still resolves correctly.
+Integration: Run `htmlgraph build` in the devcontainer, confirm binary lands
+  in ~/.local/bin/htmlgraph and plugin/hooks/bin/ is absent.
+Regression: All existing go test ./... must pass. Confirm `htmlgraph hook
+  session-start` resolves from PATH (not bin/) after build.
+</div></div>
+  <div class="slice-deps">Dependencies: none</div>
+  <div class="approval-row">
+    <label><input type="checkbox" data-section="slice-1" data-action="approve"> Approve slice</label>
+    <textarea data-section="slice-1" data-comment-for="slice-1" placeholder="Comments on slice 1..."></textarea>
+  </div>
+</div>
+<div class="slice-card" data-slice="2" data-slice-name="slice-2" data-status="pending">
+  <div class="slice-header">
+    <span class="slice-num">#2</span>
+    <span class="slice-name">Add post-build assertion to plugin build-ports verifying binary-free hook commands</span>
+    <span class="badge badge-pending">S</span>
+    <span class="badge badge-pending">Low</span>
+    <span class="badge badge-pending" data-badge-for="slice-2">Pending</span>
+  </div>
+  
+  <div class="slice-field"><div class="slice-field-label">What</div><div class="slice-field-value" data-markdown="">`htmlgraph plugin build-ports` is already registered in `cmd/htmlgraph/plugin_build_ports.go` (line 47) and current adapter code contains no binary copy logic — the de-bundle for Codex and Gemini trees is already functionally complete. This slice adds a correctness guard: add a post-build assertion in `pluginBuildPortsCmd` (in `plugin_build_ports.go`) that iterates all generated hook command strings across the three output trees (`plugin/hooks/hooks.json`, `packages/codex-marketplace/.agents/plugins/htmlgraph/hooks.json`, `packages/gemini-extension/hooks.json`) and fails with a clear error if any command references a path containing `plugin/hooks/bin/` or any other local filesystem path. The assertion must match the pattern `^htmlgraph hook ` for all hook commands and reject anything else. This prevents future regressions where a manifest edit accidentally reintroduces a local-path hook reference.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Why</div><div class="slice-field-value" data-markdown="">The current build-ports adapters already emit binary-free trees, but there is no guard preventing a future manifest edit from reintroducing a local binary path. The assertion is a zero-overhead regression gate — it runs at build time, costs nothing at runtime, and makes the binary-free invariant machine-enforceable rather than convention-based.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>cmd/htmlgraph/plugin_build_ports.go</code></div></div>
+  <div class="slice-field"><div class="slice-field-label">Done when</div><ul class="slice-done-list"><li data-markdown="">`find packages/ -name &#39;bin&#39; -type d` returns empty after `htmlgraph plugin build-ports`</li><li data-markdown="">Every hook command in all three `hooks.json` files matches `^htmlgraph hook `</li><li data-markdown="">`htmlgraph plugin build-ports` exits non-zero and prints a clear error if any generated hook command contains `plugin/hooks/bin/` or a local file path</li><li data-markdown="">`htmlgraph plugin build-ports` exits 0 and prints no warnings about binary paths on a clean tree</li><li data-markdown="">`go test ./cmd/htmlgraph/...` passes including any new assertion unit tests</li></ul></div>
+  
+  <div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-tests" data-markdown="">Unit: Add TestBuildPortsAssertionFails — inject a fake hooks.json with a local-path command into a temp dir, assert pluginBuildPortsCmd returns a non-nil error containing &#34;plugin/hooks/bin/&#34;. Add TestBuildPortsAssertionPasses — clean tree exits 0.
+Integration: Run `htmlgraph plugin build-ports` in the devcontainer, then
+  grep all generated hooks.json files for local paths — expect zero matches.
+Regression: Existing plugin_build_ports tests (if any) must still pass.
+  `go build ./...` clean.
+</div></div>
+  <div class="slice-deps">Dependencies: slices 1</div>
+  <div class="approval-row">
+    <label><input type="checkbox" data-section="slice-2" data-action="approve"> Approve slice</label>
+    <textarea data-section="slice-2" data-comment-for="slice-2" placeholder="Comments on slice 2..."></textarea>
+  </div>
+</div>
+<div class="slice-card" data-slice="3" data-slice-name="slice-3" data-status="pending">
+  <div class="slice-header">
+    <span class="slice-num">#3</span>
+    <span class="slice-name">Split deploy-all.sh into binary-release and plugin-release artifacts with shared version file</span>
+    <span class="badge badge-revision">M</span>
+    <span class="badge badge-blocked">High</span>
+    <span class="badge badge-pending" data-badge-for="slice-3">Pending</span>
+  </div>
+  
+  <div class="slice-field"><div class="slice-field-label">What</div><div class="slice-field-value" data-markdown="">Refactor `scripts/deploy-all.sh` into two independently runnable phases within the same script (or two separate scripts called from a thin orchestrator): (a) `deploy-binary` — bumps Go version via ldflags, pushes git tag,
+    triggers GoReleaser via `release-go.yml`, updates the Homebrew formula
+    SHA values in `packages/homebrew/update-formula.sh`;
+(b) `deploy-plugin` — bumps `plugin/.claude-plugin/plugin.json` version,
+    regenerates port trees via `htmlgraph plugin build-ports`, pulls and
+    updates `~/.claude/plugins/marketplaces/htmlgraph` marketplace clone.
+Introduce a single shared version source — the `version` field in `packages/plugin-core/manifest.json` (already present at version 0.55.5) — that both phases read. This field is the canonical version; the CLI binary receives it via ldflags at build time, and `plugin.json` is updated from it during `deploy-plugin`. Both phases must read the same version string so CLI binary and plugin artifact always share a version. Add `--binary-only` and `--plugin-only` flags so CI can run each phase independently. Both phases are triggered by a single GitHub Actions workflow run on the same tag and commit, bounding the skew window to the job duration (&lt;2 min).
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Why</div><div class="slice-field-value" data-markdown="">Currently `deploy-all.sh` is a monolith that updates both artifacts in one run. The curl install script (slice 7) and Homebrew tap (slice 8) need to reference stable binary release URLs that are published before the marketplace plugin is updated — or the user can be left with a mismatched install. Splitting into two phases with a shared version file is also the prerequisite for automating the plugin-only release in CI.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>scripts/deploy-all.sh, packages/homebrew/update-formula.sh, packages/homebrew/htmlgraph.rb, packages/plugin-core/manifest.json</code></div></div>
+  <div class="slice-field"><div class="slice-field-label">Done when</div><ul class="slice-done-list"><li data-markdown="">`./scripts/deploy-all.sh 0.99.0 --binary-only --dry-run` exits 0 and prints only binary-related steps</li><li data-markdown="">`./scripts/deploy-all.sh 0.99.0 --plugin-only --dry-run` exits 0 and prints only plugin-related steps</li><li data-markdown="">Both phases read version from `packages/plugin-core/manifest.json` (no hard-coded version in two places)</li><li data-markdown="">`./scripts/deploy-all.sh 0.99.0 --no-confirm --dry-run` (full run) exits 0</li><li data-markdown="">Release pipeline publishes binary and plugin within a single GitHub Actions workflow run (same tag, same commit); skew window is bounded to job duration (&lt;2 min)</li></ul></div>
+  
+  <div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-tests" data-markdown="">Unit: Bash unit tests (bats or inline assertions) for argument parsing —
+  --binary-only and --plugin-only flags are mutually exclusive, VERSION
+  validation rejects non-semver strings.
+Integration: Run `./scripts/deploy-all.sh 0.99.0 --dry-run --no-confirm`
+  in CI, assert both phases print correct step lists without executing.
+Regression: Existing `./scripts/deploy-all.sh --build-only` must still
+  work. GoReleaser workflow (`release-go.yml`) trigger path unchanged.
+</div></div>
+  <div class="slice-deps">Dependencies: slices 1,2</div>
+  <div class="approval-row">
+    <label><input type="checkbox" data-section="slice-3" data-action="approve"> Approve slice</label>
+    <textarea data-section="slice-3" data-comment-for="slice-3" placeholder="Comments on slice 3..."></textarea>
+  </div>
+</div>
+<div class="slice-card" data-slice="4" data-slice-name="slice-4" data-status="pending">
+  <div class="slice-header">
+    <span class="slice-num">#4</span>
+    <span class="slice-name">Refactor version-check into shared decision function and add missing-CLI block path to SessionStart</span>
+    <span class="badge badge-revision">M</span>
+    <span class="badge badge-revision">Med</span>
+    <span class="badge badge-pending" data-badge-for="slice-4">Pending</span>
+  </div>
+  
+  <div class="slice-field"><div class="slice-field-label">What</div><div class="slice-field-value" data-markdown="">The version-check logic already partially exists: `internal/hooks/version_check.go` has `readPluginVersion()`, `versionMismatchWarning()`, and `CLIVersion`. `internal/hooks/session_start.go` (line 226) already calls `versionMismatchWarning()`. The dispatch layer is `cmd/htmlgraph/hook.go` (cobra `hookSubcmd`), not `internal/hooks/runner.go`. This slice makes two targeted changes: (1) Add a new exported function `CheckVersionAlignment(pluginVersion, cliVersion string) (status string, message string)` in `internal/hooks/version_check.go` that returns one of (&#34;ok&#34;, &#34;warn&#34;, &#34;block&#34;) and an accompanying message. &#34;block&#34; is returned when cliVersion is empty (CLI missing). &#34;warn&#34; is returned on minor/patch divergence. &#34;ok&#34; is returned on match or dev builds. This function is the single comparison logic reused by both the session_start handler (slice 4) and `htmlgraph doctor` (slice 5). (2) Extend the existing session_start handler in `internal/hooks/session_start.go` to call `CheckVersionAlignment` and, when the result is &#34;block&#34; (CLI missing), return a `BlockExit2Error` (the pattern already used in hook.go lines 195-198) with JSON `{&#34;decision&#34;:&#34;block&#34;,&#34;reason&#34;:&#34;htmlgraph CLI not found. Install: curl -fsSL https://raw.githubusercontent.com/shakestzd/htmlgraph/main/install.sh | sh&#34;}`. Do NOT add a second SessionStart hook entry. One handler, one path. Remove `internal/hooks/runner.go` from scope — the dispatch layer is hook.go.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Why</div><div class="slice-field-value" data-markdown="">Without a SessionStart gate for the missing-CLI case, a user can install the plugin from the marketplace and run Claude Code with no CLI installed — all hooks silently fail. The shared `CheckVersionAlignment` function eliminates duplication between the hook handler and `htmlgraph doctor`, ensuring consistent comparison semantics across both surfaces.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>internal/hooks/version_check.go, internal/hooks/session_start.go</code></div></div>
+  <div class="slice-field"><div class="slice-field-label">Done when</div><ul class="slice-done-list"><li data-markdown="">`CheckVersionAlignment(&#34;&#34;, &#34;dev&#34;)` returns (&#34;block&#34;, ...) — missing CLI case</li><li data-markdown="">`CheckVersionAlignment(&#34;0.55.5&#34;, &#34;0.55.5&#34;)` returns (&#34;ok&#34;, &#34;&#34;) — match case</li><li data-markdown="">`CheckVersionAlignment(&#34;0.55.4&#34;, &#34;0.55.5&#34;)` returns (&#34;warn&#34;, ...) — mismatch case</li><li data-markdown="">Session_start handler calls CheckVersionAlignment and returns BlockExit2Error when status is &#34;block&#34;</li><li data-markdown="">No second SessionStart entry added to hooks.json or manifest.json</li><li data-markdown="">`go test ./internal/hooks/...` passes including new TestCheckVersionAlignment tests</li></ul></div>
+  
+  <div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-tests" data-markdown="">Unit: TestCheckVersionAlignment_Missing, TestCheckVersionAlignment_Match,
+  TestCheckVersionAlignment_Mismatch in internal/hooks/version_check_test.go —
+  test all three return paths with table-driven cases.
+Integration: Install the rebuilt plugin in a devcontainer with a deliberate
+  version mismatch, start a Claude Code session, verify the additionalContext
+  message appears in the conversation.
+Regression: Existing TestVersionMismatchWarning and TestStripGitDescribeSuffix
+  in version_check_test.go must still pass. session_start_test.go must still pass.
+</div></div>
+  <div class="slice-deps">Dependencies: slices 1</div>
+  <div class="approval-row">
+    <label><input type="checkbox" data-section="slice-4" data-action="approve"> Approve slice</label>
+    <textarea data-section="slice-4" data-comment-for="slice-4" placeholder="Comments on slice 4..."></textarea>
+  </div>
+</div>
+<div class="slice-card" data-slice="5" data-slice-name="slice-5" data-status="pending">
+  <div class="slice-header">
+    <span class="slice-num">#5</span>
+    <span class="slice-name">Add htmlgraph doctor subcommand with cross-harness version matrix</span>
+    <span class="badge badge-revision">M</span>
+    <span class="badge badge-pending">Low</span>
+    <span class="badge badge-pending" data-badge-for="slice-5">Pending</span>
+  </div>
+  
+  <div class="slice-field"><div class="slice-field-label">What</div><div class="slice-field-value" data-markdown="">Add `cmd/htmlgraph/doctor.go` implementing `htmlgraph doctor` as a new Cobra subcommand registered in `cmd/htmlgraph/main.go`. The command queries: (a) CLI binary version — accessed directly via the `version` package-level var in `cmd/htmlgraph/main.go` (set via ldflags; doctor.go is in the same package so it can read it directly without an internal/version package); (b) Claude Code plugin version — read `~/.claude/plugins/marketplaces/htmlgraph`
+    or `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`;
+(c) Codex plugin version — read
+    `~/.codex/plugins/htmlgraph/` (equivalent path, probe for a `plugin.json` or
+    `htmlgraph.json` manifest);
+(d) Gemini extension version — read
+    `~/.gemini/extensions/htmlgraph/gemini-extension.json`.
+For each, output a row: harness name, installed path, installed version, match/mismatch vs CLI version. Reuse `readPluginVersion()` from `internal/hooks/version_check.go` (refactor to accept an arbitrary path) and reuse `CheckVersionAlignment()` from slice 4 for consistent comparison logic. Print the matrix as a plain-text table (no external dependency). Exit 1 if any harness has a mismatch; exit 0 if all match or are not installed. Note: `internal/version/version.go` does NOT exist; the version string lives as `var version string` in `cmd/htmlgraph/main.go` — access it directly from the same package.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Why</div><div class="slice-field-value" data-markdown="">Slice 4 handles the automated SessionStart gate; `htmlgraph doctor` gives humans an explicit diagnostic surface for debugging installs across all three harnesses — especially useful after `htmlgraph upgrade` or a marketplace update. Pattern mirrors roborev&#39;s `roborev skills` matrix. Reusing `CheckVersionAlignment` from slice 4 ensures consistent comparison semantics.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>cmd/htmlgraph/doctor.go, cmd/htmlgraph/main.go, internal/hooks/version_check.go</code></div></div>
+  <div class="slice-field"><div class="slice-field-label">Done when</div><ul class="slice-done-list"><li data-markdown="">`htmlgraph doctor` prints a table with at least three rows (claude, codex, gemini)</li><li data-markdown="">`htmlgraph doctor` exits 1 when any harness version does not match the CLI version</li><li data-markdown="">`htmlgraph doctor` exits 0 when all detected harness versions match or none are installed</li><li data-markdown="">`go test ./cmd/htmlgraph/...` passes including TestDoctorCmd</li><li data-markdown="">doctor.go uses the `version` var from main.go directly (no internal/version package)</li><li data-markdown="">doctor.go calls CheckVersionAlignment from slice 4 for all comparison logic</li></ul></div>
+  
+  <div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-tests" data-markdown="">Unit: TestDoctorCmd in cmd/htmlgraph/doctor_test.go — stub plugin manifest
+  files under a temp home dir, assert table rows and exit code.
+Integration: Run `htmlgraph doctor` in the devcontainer after a fresh build,
+  confirm at least the claude row populates with a version.
+Regression: `go build ./...` clean. Existing plugin_ensure_test.go must pass
+  (doctor and plugin_ensure share version-reading helpers).
+</div></div>
+  <div class="slice-deps">Dependencies: slices 4</div>
+  <div class="approval-row">
+    <label><input type="checkbox" data-section="slice-5" data-action="approve"> Approve slice</label>
+    <textarea data-section="slice-5" data-comment-for="slice-5" placeholder="Comments on slice 5..."></textarea>
+  </div>
+</div>
+<div class="slice-card" data-slice="6" data-slice-name="slice-6" data-status="pending">
+  <div class="slice-header">
+    <span class="slice-num">#6</span>
+    <span class="slice-name">Extend htmlgraph upgrade to print post-upgrade plugin-update instructions</span>
+    <span class="badge badge-pending">S</span>
+    <span class="badge badge-pending">Low</span>
+    <span class="badge badge-pending" data-badge-for="slice-6">Pending</span>
+  </div>
+  
+  <div class="slice-field"><div class="slice-field-label">What</div><div class="slice-field-value" data-markdown="">Edit `cmd/htmlgraph/upgrade_cmd.go` function `runUpgrade`. After the self-test at line 120 confirms the new binary runs, append to stdout: &#34;CLI upgraded to vX.Y.Z. To sync the plugin, run:
+  /plugin marketplace htmlgraph   (inside Claude Code)
+Then run: htmlgraph doctor   to verify all harnesses are in sync.&#34; Also add a `--check` output line that prints plugin versions detected by the same logic used in slice 5 (`htmlgraph doctor` can be called internally). No new flags — this is purely additive output.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Why</div><div class="slice-field-value" data-markdown="">After `htmlgraph upgrade` the CLI binary is at the new version but the marketplace plugin is at the old version until the user manually updates it. Without the reminder, users are left in the skewed state that slice 4 detects. Closing the loop here makes the version-sync story end-to-end.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>cmd/htmlgraph/upgrade_cmd.go, cmd/htmlgraph/upgrade_cmd_test.go</code></div></div>
+  <div class="slice-field"><div class="slice-field-label">Done when</div><ul class="slice-done-list"><li data-markdown="">`htmlgraph upgrade --check` output includes a line mentioning `/plugin marketplace htmlgraph`</li><li data-markdown="">After `htmlgraph upgrade` (mocked), stdout includes `htmlgraph doctor`</li><li data-markdown="">`go test ./cmd/htmlgraph/... -run TestUpgrade` passes</li></ul></div>
+  
+  <div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-tests" data-markdown="">Unit: TestUpgradePostMessage in upgrade_cmd_test.go — mock the HTTP version
+  fetch and binary replace, assert stdout contains the post-upgrade message.
+Integration: Run `htmlgraph upgrade --check` in devcontainer, confirm new
+  message lines appear.
+Regression: Existing TestUpgradeCmd* tests must still pass.
+</div></div>
+  <div class="slice-deps">Dependencies: slices 5</div>
+  <div class="approval-row">
+    <label><input type="checkbox" data-section="slice-6" data-action="approve"> Approve slice</label>
+    <textarea data-section="slice-6" data-comment-for="slice-6" placeholder="Comments on slice 6..."></textarea>
+  </div>
+</div>
+<div class="slice-card" data-slice="7" data-slice-name="slice-7" data-status="pending">
+  <div class="slice-header">
+    <span class="slice-num">#7</span>
+    <span class="slice-name">Add env-var escape hatches to install.sh (HTMLGRAPH_INSTALL_DIR, HTMLGRAPH_NO_MODIFY_PATH, HTMLGRAPH_VERSION)</span>
+    <span class="badge badge-pending">S</span>
+    <span class="badge badge-pending">Low</span>
+    <span class="badge badge-pending" data-badge-for="slice-7">Pending</span>
+  </div>
+  
+  <div class="slice-field"><div class="slice-field-label">What</div><div class="slice-field-value" data-markdown="">Edit `install.sh` to honour three environment variables that override CLI flags when set: - `HTMLGRAPH_INSTALL_DIR` — overrides `--install-dir` (current default
+  `~/.local/bin`); used by corporate-managed shells and CI.
+- `HTMLGRAPH_NO_MODIFY_PATH` — when set to `1`, skip the shell-rc PATH
+  modification block unconditionally.
+- `HTMLGRAPH_VERSION` — when set, install that version instead of
+  fetching the latest GitHub release; overrides `--version` flag if both
+  are set (env takes precedence for scriptability).
+The existing `--install-dir` and `--version` flags must still work as before. Add a `--help` section documenting all three env vars. No other changes to install.sh logic.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Why</div><div class="slice-field-value" data-markdown="">Corporate environments and CI pipelines need deterministic, non-interactive installs without shell-rc mutation. These are the exact escape hatches roborev ships (`ROBOREV_INSTALL_DIR`, `ROBOREV_NO_MODIFY_PATH`). Without them, `curl | sh` is not safe to run in CI. Slice 8 (Homebrew tap) is independent; slices 7 and 8 together complete the install UX story.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>install.sh</code></div></div>
+  <div class="slice-field"><div class="slice-field-label">Done when</div><ul class="slice-done-list"><li data-markdown="">`HTMLGRAPH_INSTALL_DIR=/tmp/testbin sh install.sh` installs binary to `/tmp/testbin/htmlgraph`</li><li data-markdown="">`HTMLGRAPH_NO_MODIFY_PATH=1 sh install.sh` does not modify ~/.bashrc or ~/.zshrc</li><li data-markdown="">`HTMLGRAPH_VERSION=0.35.0 sh install.sh` downloads version 0.35.0 regardless of latest</li><li data-markdown="">All three env vars are documented in `install.sh --help` output</li></ul></div>
+  
+  <div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-tests" data-markdown="">Unit: Bash test (bats or inline) — set each env var in isolation,
+  mock the download step, assert correct install path / version / rc mutation.
+Integration: Run `HTMLGRAPH_INSTALL_DIR=/tmp/hg-test sh install.sh` in
+  the devcontainer, verify binary appears at /tmp/hg-test/htmlgraph.
+Regression: Existing `--install-dir` and `--version` flag tests (if any)
+  must still pass. Default install to ~/.local/bin must still work.
+</div></div>
+  <div class="slice-deps">Dependencies: slices 3</div>
+  <div class="approval-row">
+    <label><input type="checkbox" data-section="slice-7" data-action="approve"> Approve slice</label>
+    <textarea data-section="slice-7" data-comment-for="slice-7" placeholder="Comments on slice 7..."></textarea>
+  </div>
+</div>
+<div class="slice-card" data-slice="8" data-slice-name="slice-8" data-status="pending">
+  <div class="slice-header">
+    <span class="slice-num">#8</span>
+    <span class="slice-name">Publish Homebrew tap formula and wire version bump into deploy pipeline</span>
+    <span class="badge badge-revision">M</span>
+    <span class="badge badge-pending">Low</span>
+    <span class="badge badge-pending" data-badge-for="slice-8">Pending</span>
+  </div>
+  
+  <div class="slice-field"><div class="slice-field-label">What</div><div class="slice-field-value" data-markdown="">Create or update the external tap repo `shakestzd/homebrew-htmlgraph` so that `brew install shakestzd/htmlgraph/htmlgraph` works. The formula template already exists at `packages/homebrew/htmlgraph.rb`. Steps: (a) Confirm the tap repo exists at github.com/shakestzd/homebrew-htmlgraph
+    (create if not); its only required file is `Formula/htmlgraph.rb`.
+(b) Update `packages/homebrew/update-formula.sh` to accept the new version
+    and SHA256 values as arguments (already partially implemented), compute
+    SHA256 from the GoReleaser-published `.tar.gz` assets on GitHub Releases,
+    patch `Formula/htmlgraph.rb` in the tap repo, and push a commit.
+(c) Wire `update-formula.sh` into `scripts/deploy-all.sh`&#39;s `deploy-binary`
+    phase (slice 3) so formula is bumped automatically on every binary release.
+Document the one-time tap repo setup in `packages/homebrew/README.md`.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Why</div><div class="slice-field-value" data-markdown="">`brew install` is the default install path for macOS developers. Without a tap the Homebrew formula placeholder in `packages/homebrew/htmlgraph.rb` has SHA256 stubs and is not installable. Closing this gap completes the install UX workstream for macOS users and is required for public release.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>packages/homebrew/htmlgraph.rb, packages/homebrew/update-formula.sh, scripts/deploy-all.sh</code></div></div>
+  <div class="slice-field"><div class="slice-field-label">Done when</div><ul class="slice-done-list"><li data-markdown="">Tap repo `shakestzd/homebrew-htmlgraph` exists with an initial `Formula/htmlgraph.rb` and PAT-based push credentials are configured in this repo&#39;s GitHub Actions secrets (prereq — must be satisfied before this slice can complete)</li><li data-markdown="">`brew install shakestzd/htmlgraph/htmlgraph` succeeds on macOS (arm64 and amd64)</li><li data-markdown="">`packages/homebrew/update-formula.sh 0.99.0` patches version and SHA256 placeholders</li><li data-markdown="">`scripts/deploy-all.sh --binary-only` invokes update-formula.sh as a step</li><li data-markdown="">Formula file contains no SHA256 placeholder strings after a dry-run update</li></ul></div>
+  
+  <div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-tests" data-markdown="">Unit: Bash test for update-formula.sh — mock curl SHA256 fetch, assert
+  Formula/htmlgraph.rb is patched with correct version and SHA256.
+Integration: Run update-formula.sh against a real GitHub release asset,
+  confirm SHA256 matches `shasum -a 256` output.
+Regression: deploy-all.sh --build-only must still pass (formula update skipped).
+</div></div>
+  <div class="slice-deps">Dependencies: slices 3</div>
+  <div class="approval-row">
+    <label><input type="checkbox" data-section="slice-8" data-action="approve"> Approve slice</label>
+    <textarea data-section="slice-8" data-comment-for="slice-8" placeholder="Comments on slice 8..."></textarea>
+  </div>
+</div>
+<div class="slice-card" data-slice="9" data-slice-name="slice-9" data-status="pending">
+  <div class="slice-header">
+    <span class="slice-num">#9</span>
+    <span class="slice-name">Add internal/launcher/container/ package: preflight, wrap, paths</span>
+    <span class="badge badge-pending">S</span>
+    <span class="badge badge-pending">Low</span>
+    <span class="badge badge-pending" data-badge-for="slice-9">Pending</span>
+  </div>
+  
+  <div class="slice-field"><div class="slice-field-label">What</div><div class="slice-field-value" data-markdown="">Create package `internal/launcher/container/` with three files: - `preflight.go` — exports `IsDevcontainer() bool` that returns true when
+  `HTMLGRAPH_DEVCONTAINER=1` is set OR `/workspaces` exists on the
+  filesystem (VS Code devcontainer convention). Also exports
+  `MustHaveBinaryInContainer() error` that checks the binary is on PATH
+  inside the container and returns a human-readable error if not.
+- `paths.go` — exports `PluginRoots() []string` returning the container-local
+  paths for Claude, Codex, and Gemini config dirs (e.g.
+  `/home/vscode/.claude`, `/home/vscode/.codex`, `/home/vscode/.gemini`).
+- `wrap.go` — exports `WrapArgs(args []string) []string` that prepends
+  any container-specific environment setup (e.g. ensuring PATH includes
+  `/home/vscode/.local/bin`) before the underlying command args. Initially
+  this may be a no-op pass-through; the structure is what matters for the
+  subsequent slice.
+Write unit tests in `internal/launcher/container/container_test.go`.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Why</div><div class="slice-field-value" data-markdown="">Workstream D (slices 9-11) depends on a clean abstraction layer that the launcher commands (claude.go, codex.go, gemini.go, yolo.go) can import without duplicating devcontainer detection logic. This slice creates that layer; slice 10 wires it into the launcher commands.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>internal/launcher/container/preflight.go, internal/launcher/container/paths.go, internal/launcher/container/wrap.go, internal/launcher/container/container_test.go</code></div></div>
+  <div class="slice-field"><div class="slice-field-label">Done when</div><ul class="slice-done-list"><li data-markdown="">`IsDevcontainer()` returns true when HTMLGRAPH_DEVCONTAINER=1 is set</li><li data-markdown="">`IsDevcontainer()` returns true in a devcontainer where `/workspaces` exists</li><li data-markdown="">`IsDevcontainer()` returns false in a normal host environment</li><li data-markdown="">`go test ./internal/launcher/container/...` passes</li><li data-markdown="">`go vet ./internal/launcher/container/...` clean</li></ul></div>
+  
+  <div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-tests" data-markdown="">Unit: TestIsDevcontainer_EnvSet, TestIsDevcontainer_WorkspacesPath,
+  TestIsDevcontainer_HostEnv, TestPluginRoots, TestWrapArgs in container_test.go.
+Integration: Run `go test` inside the devcontainer — TestIsDevcontainer_WorkspacesPath
+  should pass automatically.
+Regression: `go build ./...` clean. No other internal packages affected.
+</div></div>
+  <div class="slice-deps">Dependencies: slices 1</div>
+  <div class="approval-row">
+    <label><input type="checkbox" data-section="slice-9" data-action="approve"> Approve slice</label>
+    <textarea data-section="slice-9" data-comment-for="slice-9" placeholder="Comments on slice 9..."></textarea>
+  </div>
+</div>
+<div class="slice-card" data-slice="10" data-slice-name="slice-10" data-status="pending">
+  <div class="slice-header">
+    <span class="slice-num">#10</span>
+    <span class="slice-name">Add --container flag to claude/codex/gemini/yolo and wire HTMLGRAPH_DEVCONTAINER=1</span>
+    <span class="badge badge-revision">M</span>
+    <span class="badge badge-revision">Med</span>
+    <span class="badge badge-pending" data-badge-for="slice-10">Pending</span>
+  </div>
+  
+  <div class="slice-field"><div class="slice-field-label">What</div><div class="slice-field-value" data-markdown="">Edit `cmd/htmlgraph/claude.go`, `cmd/htmlgraph/codex.go`, `cmd/htmlgraph/gemini.go`, `cmd/htmlgraph/yolo.go`, and `cmd/htmlgraph/dev.go` to add a `--container` boolean flag. When `--container` is true (or `HTMLGRAPH_DEVCONTAINER=1` is set), the launcher must apply the following, scoped to only those launchers where the mutation actually exists: (1) In `claude.go` and `yolo.go` (the only launchers that call `removeMarketplaceHtmlgraph()`): skip the `removeMarketplaceHtmlgraph()` call. Also skip `setPluginEnabled()` calls that modify `~/.claude/settings.json`, the `os.RemoveAll` calls that wipe `~/.claude/plugins/marketplaces/htmlgraph` and `~/.claude/plugins/cache/`, and any `installOrUpdatePlugin()` call. List of actual mutations to skip in claude.go: removeMarketplaceHtmlgraph() (line 161), setPluginEnabled() (line 249), os.RemoveAll on plugin cache dirs (lines 123-130). (2) In `codex.go` and `gemini.go`: `--container` is a no-op stub flag (accepted, ignored, clearly documented in code comments) — these launchers have no host-mutation calls equivalent to removeMarketplaceHtmlgraph, so there is nothing to skip. Do not claim to skip mutations that do not exist. (3) Call `container.IsDevcontainer()` from slice 9 to auto-detect the flag when the env var is set in all launchers. (4) In `yolo.go`, when `--container` is active, force `noWorktree=true` and log a single message &#34;container mode: worktree creation skipped&#34;. (5) In `dev.go`, default `container` to `container.IsDevcontainer()` so the devcontainer auto-applies container mode.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Why</div><div class="slice-field-value" data-markdown="">In a devcontainer the host filesystem is bind-mounted; `removeMarketplaceHtmlgraph` and the associated cache-wipe calls in claude.go mutate host paths that may be volume-mounted or non-writable. Skipping those specific mutations when `--container` prevents errors and unexpected side effects. `--container` also makes yolo safe to run inside the devcontainer without worktree isolation (which requires host git). Codex and gemini launchers have no equivalent host mutations, so stub-only is the honest scope.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>cmd/htmlgraph/claude.go, cmd/htmlgraph/codex.go, cmd/htmlgraph/gemini.go, cmd/htmlgraph/yolo.go, cmd/htmlgraph/dev.go</code></div></div>
+  <div class="slice-field"><div class="slice-field-label">Done when</div><ul class="slice-done-list"><li data-markdown="">`htmlgraph claude --container` starts without calling removeMarketplaceHtmlgraph, setPluginEnabled, or os.RemoveAll on plugin cache dirs</li><li data-markdown="">`htmlgraph yolo --container` logs &#39;container mode: worktree creation skipped&#39; and sets noWorktree</li><li data-markdown="">`HTMLGRAPH_DEVCONTAINER=1 htmlgraph yolo` behaves identically to `htmlgraph yolo --container`</li><li data-markdown="">codex.go and gemini.go accept `--container` without error but document it as a no-op in code comments</li><li data-markdown="">`go test ./cmd/htmlgraph/...` passes</li></ul></div>
+  
+  <div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-tests" data-markdown="">Unit: TestContainerFlagSkipsMarketplace in claude_test.go (or new file) —
+  mock removeMarketplaceHtmlgraph, assert it is not called when --container.
+  TestYoloContainerNoWorktree — assert noWorktree=true when --container.
+  TestCodexContainerFlagNoOp — assert codex.go accepts --container without error.
+Integration: Run `htmlgraph claude --container --dry-run` (if dry-run exists)
+  in devcontainer, confirm no marketplace operations are attempted.
+Regression: Existing codex_test.go, gemini_test.go, yolo_test.go must pass.
+  Default (non-container) behavior unchanged.
+</div></div>
+  <div class="slice-deps">Dependencies: slices 9</div>
+  <div class="approval-row">
+    <label><input type="checkbox" data-section="slice-10" data-action="approve"> Approve slice</label>
+    <textarea data-section="slice-10" data-comment-for="slice-10" placeholder="Comments on slice 10..."></textarea>
+  </div>
+</div>
+<div class="slice-card" data-slice="11" data-slice-name="slice-11" data-status="pending">
+  <div class="slice-header">
+    <span class="slice-num">#11</span>
+    <span class="slice-name">Add .devcontainer/Dockerfile and wire postCreateCommand to install htmlgraph CLI</span>
+    <span class="badge badge-pending">S</span>
+    <span class="badge badge-pending">Low</span>
+    <span class="badge badge-pending" data-badge-for="slice-11">Pending</span>
+  </div>
+  
+  <div class="slice-field"><div class="slice-field-label">What</div><div class="slice-field-value" data-markdown="">Edit `.devcontainer/Dockerfile` (already exists) to add a layer that runs `go install ./cmd/htmlgraph/` so the CLI binary is available at container creation time without requiring a manual `htmlgraph build`. If the project is bind-mounted (not baked into the image), the `postCreateCommand` in `.devcontainer/devcontainer.json` (currently `bash .devcontainer/post-create.sh`) handles the install instead — add `go install ./cmd/htmlgraph/` as a step in `post-create.sh` before the existing htmlgraph references at line 28. Ensure `GOBIN` is set to `/home/vscode/.local/bin` in the Dockerfile ENV so the installed binary lands on PATH. Update `post-create.sh` to verify `htmlgraph version` runs after install and bail with a clear error if it does not.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Why</div><div class="slice-field-value" data-markdown="">Currently the devcontainer relies on `htmlgraph build` being run manually after `post-create.sh`. If the binary is missing, every htmlgraph CLI call in `post-create.sh` (line 75&#43;) silently fails. Auto-provisioning via `go install` makes the container self-contained and is the recommended devcontainer pattern for Go projects.
+</div></div>
+  <div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>.devcontainer/Dockerfile, .devcontainer/post-create.sh, .devcontainer/devcontainer.json</code></div></div>
+  <div class="slice-field"><div class="slice-field-label">Done when</div><ul class="slice-done-list"><li data-markdown="">Rebuilding the devcontainer from scratch results in `htmlgraph version` succeeding without manual steps</li><li data-markdown="">`which htmlgraph` inside the container returns `/home/vscode/.local/bin/htmlgraph`</li><li data-markdown="">`post-create.sh` exits non-zero with a clear error if `htmlgraph version` fails after install</li></ul></div>
+  
+  <div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-tests" data-markdown="">Unit: No Go unit tests — bash assertion in post-create.sh itself is the gate.
+Integration: Rebuild the devcontainer in CI (GitHub Actions devcontainer-verify
+  workflow if it exists, or add one), assert `htmlgraph version` exits 0.
+Regression: Existing `scripts/devcontainer-verify.sh` must still pass.
+  post-create.sh must not break for existing volume-mount setups.
+</div></div>
+  <div class="slice-deps">Dependencies: slices 9,10</div>
+  <div class="approval-row">
+    <label><input type="checkbox" data-section="slice-11" data-action="approve"> Approve slice</label>
+    <textarea data-section="slice-11" data-comment-for="slice-11" placeholder="Comments on slice 11..."></textarea>
+  </div>
+</div>
+
+    <!--PLAN_SLICE_CARDS-->
+  </div>
+</details>
+
+<!-- Design Decisions -->
+<details id="questions" class="section-card" data-phase="questions" data-status="pending">
+  <summary><span>Design Decisions</span><span class="badge badge-pending" data-badge-for="questions">Pending</span></summary>
+  <div class="section-body">
+    
+    <div class="question-block" id="q-install-url">
+      <p>Should the curl install script use a dedicated domain or GitHub&#39;s raw content URL?</p>
+      
+      
+      <label><input type="radio" name="q-install-url" data-question="q-install-url" value="A: Dedicated Domain — Buy htmlgraph.{dev,io,sh}, point to GitHub Pages, matches roborev.io precedent"> A: Dedicated Domain — Buy htmlgraph.{dev,io,sh}, point to GitHub Pages, matches roborev.io precedent</label>
+      
+      <label class="recommended"><input type="radio" name="q-install-url" data-question="q-install-url" value="B: GitHub Raw URL — Zero cost, clunkier but functional, migratable to domain later"> B: GitHub Raw URL — Zero cost, clunkier but functional, migratable to domain later <span class="rec-tag">recommended</span></label>
+      
+      <textarea data-section="questions" data-question-rationale="q-install-url" placeholder="Rationale for q-install-url..."></textarea>
+    </div>
+    
+    <div class="question-block" id="q-version-skew-severity">
+      <p>How strictly should SessionStart block or warn when plugin and CLI versions don&#39;t match?</p>
+      
+      
+      <label><input type="radio" name="q-version-skew-severity" data-question="q-version-skew-severity" value="A: Warn Only — Exit 1, render additionalContext, session proceeds with known mismatch"> A: Warn Only — Exit 1, render additionalContext, session proceeds with known mismatch</label>
+      
+      <label class="recommended"><input type="radio" name="q-version-skew-severity" data-question="q-version-skew-severity" value="B: Block on Major Mismatch — Exit 2 if major versions differ, warn on minor/patch"> B: Block on Major Mismatch — Exit 2 if major versions differ, warn on minor/patch <span class="rec-tag">recommended</span></label>
+      
+      <label><input type="radio" name="q-version-skew-severity" data-question="q-version-skew-severity" value="C: Block Any Mismatch — Exit 2 on any version difference, roborev&#39;s strict model"> C: Block Any Mismatch — Exit 2 on any version difference, roborev&#39;s strict model</label>
+      
+      <textarea data-section="questions" data-question-rationale="q-version-skew-severity" placeholder="Rationale for q-version-skew-severity..."></textarea>
+    </div>
+    
+    <div class="question-block" id="q-binary-distribution-channels">
+      <p>Which install channels should ship in v1: curl only, or curl &#43; homebrew?</p>
+      
+      
+      <label><input type="radio" name="q-binary-distribution-channels" data-question="q-binary-distribution-channels" value="A: Curl Only — Ship install.sh, defer brew/go-install to later"> A: Curl Only — Ship install.sh, defer brew/go-install to later</label>
+      
+      <label class="recommended"><input type="radio" name="q-binary-distribution-channels" data-question="q-binary-distribution-channels" value="B: Curl &#43; Brew — curl script &#43; homebrew tap, matches roborev&#39;s coverage"> B: Curl &#43; Brew — curl script &#43; homebrew tap, matches roborev&#39;s coverage <span class="rec-tag">recommended</span></label>
+      
+      <label><input type="radio" name="q-binary-distribution-channels" data-question="q-binary-distribution-channels" value="C: All Three — curl, homebrew, and go install, maximum coverage"> C: All Three — curl, homebrew, and go install, maximum coverage</label>
+      
+      <textarea data-section="questions" data-question-rationale="q-binary-distribution-channels" placeholder="Rationale for q-binary-distribution-channels..."></textarea>
+    </div>
+    
+    <div class="question-block" id="q-container-image-base">
+      <p>Which base image for .devcontainer/Dockerfile: official Go, DevContainers base, or Claude Code prebuilt?</p>
+      
+      
+      <label><input type="radio" name="q-container-image-base" data-question="q-container-image-base" value="A: Official Go Image — golang:1.24-bookworm, then install CLIs"> A: Official Go Image — golang:1.24-bookworm, then install CLIs</label>
+      
+      <label class="recommended"><input type="radio" name="q-container-image-base" data-question="q-container-image-base" value="B: DevContainers Base — mcr.microsoft.com/devcontainers/base:bookworm, current approach"> B: DevContainers Base — mcr.microsoft.com/devcontainers/base:bookworm, current approach <span class="rec-tag">recommended</span></label>
+      
+      <label><input type="radio" name="q-container-image-base" data-question="q-container-image-base" value="C: Claude Code Prebuilt — anthropic/claude-code:latest (not yet published)"> C: Claude Code Prebuilt — anthropic/claude-code:latest (not yet published)</label>
+      
+      <textarea data-section="questions" data-question-rationale="q-container-image-base" placeholder="Rationale for q-container-image-base..."></textarea>
+    </div>
+    
+    <div class="question-block" id="q-hook-event-ingestion-scope">
+      <p>Should this plan include ingesting new Claude Code hook events (WorktreeCreate, FileChanged, etc.)?</p>
+      
+      
+      <label class="recommended"><input type="radio" name="q-hook-event-ingestion-scope" data-question="q-hook-event-ingestion-scope" value="A: Out of Scope — Defer to separate plan, keep this plan focused on distribution"> A: Out of Scope — Defer to separate plan, keep this plan focused on distribution <span class="rec-tag">recommended</span></label>
+      
+      <label><input type="radio" name="q-hook-event-ingestion-scope" data-question="q-hook-event-ingestion-scope" value="B: Include Worktree Events — Add WorktreeCreate/Remove since yolo depends on worktrees"> B: Include Worktree Events — Add WorktreeCreate/Remove since yolo depends on worktrees</label>
+      
+      <label><input type="radio" name="q-hook-event-ingestion-scope" data-question="q-hook-event-ingestion-scope" value="C: Include All New Events — Opportunistic ingestion of all new hook events"> C: Include All New Events — Opportunistic ingestion of all new hook events</label>
+      
+      <textarea data-section="questions" data-question-rationale="q-hook-event-ingestion-scope" placeholder="Rationale for q-hook-event-ingestion-scope..."></textarea>
+    </div>
+    
+    <div class="question-block" id="q-plugin-json-version-source">
+      <p>Where should the CLI read the expected plugin version for the version-check hook?</p>
+      
+      
+      <label><input type="radio" name="q-plugin-json-version-source" data-question="q-plugin-json-version-source" value="A: Embedded at Build Time — Write version into Go string via build flag, fast but couples builds"> A: Embedded at Build Time — Write version into Go string via build flag, fast but couples builds</label>
+      
+      <label class="recommended"><input type="radio" name="q-plugin-json-version-source" data-question="q-plugin-json-version-source" value="B: Read from Plugin Root — Read ${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json at runtime"> B: Read from Plugin Root — Read ${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json at runtime <span class="rec-tag">recommended</span></label>
+      
+      <label><input type="radio" name="q-plugin-json-version-source" data-question="q-plugin-json-version-source" value="C: Fetch from GitHub — Network call to check latest, slow and offline-hostile"> C: Fetch from GitHub — Network call to check latest, slow and offline-hostile</label>
+      
+      <textarea data-section="questions" data-question-rationale="q-plugin-json-version-source" placeholder="Rationale for q-plugin-json-version-source..."></textarea>
+    </div>
+    
+    <div class="question-block" id="q-shared-version-source">
+      <p>What should be the canonical shared version source for both CLI binary and plugin artifact?</p>
+      
+      
+      <label><input type="radio" name="q-shared-version-source" data-question="q-shared-version-source" value="A: New VERSION file — plain text at repo root, read by ldflags and build-ports"> A: New VERSION file — plain text at repo root, read by ldflags and build-ports</label>
+      
+      <label><input type="radio" name="q-shared-version-source" data-question="q-shared-version-source" value="B: plugin.json canonical — plugin.json as version source, but it is generated from manifest"> B: plugin.json canonical — plugin.json as version source, but it is generated from manifest</label>
+      
+      <label class="recommended"><input type="radio" name="q-shared-version-source" data-question="q-shared-version-source" value="C: manifest.json canonical — packages/plugin-core/manifest.json version field is authoritative; everything derives from it"> C: manifest.json canonical — packages/plugin-core/manifest.json version field is authoritative; everything derives from it <span class="rec-tag">recommended</span></label>
+      
+      <textarea data-section="questions" data-question-rationale="q-shared-version-source" placeholder="Rationale for q-shared-version-source..."></textarea>
+    </div>
+    
+    <table class="q-table">
+      <thead><tr><th>Question</th><th>Selected</th><th>Status</th></tr></thead>
+      <tbody id="questionsRecap">
+        
+        <tr data-recap-for="q-install-url">
+          <td>Should the curl install script use a dedicated domain or GitHub&#39;s raw content URL?</td>
+          <td class="recap-answer">&mdash;</td>
+          <td><span class="badge badge-pending">Pending</span></td>
+        </tr>
+        
+        <tr data-recap-for="q-version-skew-severity">
+          <td>How strictly should SessionStart block or warn when plugin and CLI versions don&#39;t match?</td>
+          <td class="recap-answer">&mdash;</td>
+          <td><span class="badge badge-pending">Pending</span></td>
+        </tr>
+        
+        <tr data-recap-for="q-binary-distribution-channels">
+          <td>Which install channels should ship in v1: curl only, or curl &#43; homebrew?</td>
+          <td class="recap-answer">&mdash;</td>
+          <td><span class="badge badge-pending">Pending</span></td>
+        </tr>
+        
+        <tr data-recap-for="q-container-image-base">
+          <td>Which base image for .devcontainer/Dockerfile: official Go, DevContainers base, or Claude Code prebuilt?</td>
+          <td class="recap-answer">&mdash;</td>
+          <td><span class="badge badge-pending">Pending</span></td>
+        </tr>
+        
+        <tr data-recap-for="q-hook-event-ingestion-scope">
+          <td>Should this plan include ingesting new Claude Code hook events (WorktreeCreate, FileChanged, etc.)?</td>
+          <td class="recap-answer">&mdash;</td>
+          <td><span class="badge badge-pending">Pending</span></td>
+        </tr>
+        
+        <tr data-recap-for="q-plugin-json-version-source">
+          <td>Where should the CLI read the expected plugin version for the version-check hook?</td>
+          <td class="recap-answer">&mdash;</td>
+          <td><span class="badge badge-pending">Pending</span></td>
+        </tr>
+        
+        <tr data-recap-for="q-shared-version-source">
+          <td>What should be the canonical shared version source for both CLI binary and plugin artifact?</td>
+          <td class="recap-answer">&mdash;</td>
+          <td><span class="badge badge-pending">Pending</span></td>
+        </tr>
+        
+      </tbody>
+    </table>
+  </div>
+</details>
+
+
+
+<details id="critique" class="section-card" data-phase="critique" data-status="pending">
+  <summary><span>Critique</span><span class="badge badge-pending" data-badge-for="critique">Review</span></summary>
+  <div class="section-body">
+
+    
+    <div class="sub-section">
+      <h4>Assumption Verification</h4>
+      
+      <div style="display:flex;align-items:flex-start;gap:10px;margin-bottom:8px;padding:8px;background:var(--bg-input);border-radius:var(--radius)">
+        <span class="badge badge-approved">verified</span>
+        <div>
+          <p style="margin:0;font-size:.9rem">plugin/hooks/bin/ contains bundled binaries that bloat the marketplace artifact</p>
+          <p style="margin:4px 0 0;font-size:.8rem;color:var(--text-muted)">Directory exists in source control with htmlgraph, htmlgraph-dev, bootstrap.sh, install-binary.sh — confirmed by git ls-files</p>
+        </div>
+      </div>
+      
+      <div style="display:flex;align-items:flex-start;gap:10px;margin-bottom:8px;padding:8px;background:var(--bg-input);border-radius:var(--radius)">
+        <span class="badge badge-approved">verified</span>
+        <div>
+          <p style="margin:0;font-size:.9rem">All hook commands currently use `htmlgraph hook &lt;handler&gt;` via PATH</p>
+          <p style="margin:4px 0 0;font-size:.8rem;color:var(--text-muted)">Inspection of plugin/hooks/hooks.json shows hook commands reference bare `htmlgraph` binary, not the bin/ path</p>
+        </div>
+      </div>
+      
+      <div style="display:flex;align-items:flex-start;gap:10px;margin-bottom:8px;padding:8px;background:var(--bg-input);border-radius:var(--radius)">
+        <span class="badge badge-blocked">falsified</span>
+        <div>
+          <p style="margin:0;font-size:.9rem">htmlgraph plugin build-ports is not yet registered or contains binary copy logic</p>
+          <p style="margin:4px 0 0;font-size:.8rem;color:var(--text-muted)">cmd/htmlgraph/plugin_build_ports.go line 47 shows command is already registered; grepping adapters shows NO binary copy logic — current trees are already binary-free</p>
+        </div>
+      </div>
+      
+      <div style="display:flex;align-items:flex-start;gap:10px;margin-bottom:8px;padding:8px;background:var(--bg-input);border-radius:var(--radius)">
+        <span class="badge badge-blocked">falsified</span>
+        <div>
+          <p style="margin:0;font-size:.9rem">Version-check handler requires a new internal/hooks/runner.go dispatch layer</p>
+          <p style="margin:4px 0 0;font-size:.8rem;color:var(--text-muted)">Dispatch layer is cmd/htmlgraph/hook.go (cobra hookSubcmd); internal/hooks/session_start.go:226 already calls versionMismatchWarning(); runner.go is not the dispatch layer</p>
+        </div>
+      </div>
+      
+      <div style="display:flex;align-items:flex-start;gap:10px;margin-bottom:8px;padding:8px;background:var(--bg-input);border-radius:var(--radius)">
+        <span class="badge badge-blocked">falsified</span>
+        <div>
+          <p style="margin:0;font-size:.9rem">Version string lives in internal/version/version.go</p>
+          <p style="margin:4px 0 0;font-size:.8rem;color:var(--text-muted)">internal/version/version.go does not exist; var version string is in cmd/htmlgraph/main.go, set via ldflags — doctor.go can access it directly as same package</p>
+        </div>
+      </div>
+      
+      <div style="display:flex;align-items:flex-start;gap:10px;margin-bottom:8px;padding:8px;background:var(--bg-input);border-radius:var(--radius)">
+        <span class="badge badge-blocked">falsified</span>
+        <div>
+          <p style="margin:0;font-size:.9rem">codex.go and gemini.go have equivalent removeMarketplaceHtmlgraph() blocks to claude.go</p>
+          <p style="margin:4px 0 0;font-size:.8rem;color:var(--text-muted)">grep of codex.go and gemini.go shows no removeMarketplaceHtmlgraph call; only claude.go:161 and yolo.go:295 call it — codex/gemini have different plugin registration patterns</p>
+        </div>
+      </div>
+      
+      <div style="display:flex;align-items:flex-start;gap:10px;margin-bottom:8px;padding:8px;background:var(--bg-input);border-radius:var(--radius)">
+        <span class="badge badge-approved">verified</span>
+        <div>
+          <p style="margin:0;font-size:.9rem">deploy-all.sh is a monolith that must be split into binary and plugin phases</p>
+          <p style="margin:4px 0 0;font-size:.8rem;color:var(--text-muted)">scripts/deploy-all.sh reviewed — single script with no --binary-only/--plugin-only flags; refactor required</p>
+        </div>
+      </div>
+      
+    </div>
+    
+
+    
+    <div class="sub-section" style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
+      
+      <div>
+        <h4>Haiku (design review)</h4>
+        <div style="font-size:.85rem;color:var(--text-dim)"><h5>Slice Assessment</h5>
+<ul>
+  <li><span class="badge badge-success">S1</span> Slice 1 correctly identifies the root cause and the files to delete. Risk rating Med is appropriate — removing walk-up path logic requires care.</li>
+  <li><span class="badge badge-warn">S2</span> Slice 2 framing was wrong: build-ports is already registered and adapters already produce binary-free trees. Slice must pivot to a post-build assertion guard, not a removal operation.</li>
+  <li><span class="badge badge-warn">S4</span> Slice 4 listed internal/hooks/runner.go as dispatch layer — incorrect. Dispatch is cmd/htmlgraph/hook.go. Also proposed a second SessionStart entry which contradicts one-handler-one-path principle.</li>
+  <li><span class="badge badge-danger">S5</span> Slice 5 referenced internal/version/version.go which does not exist. Doctor must read the version var from cmd/htmlgraph/main.go directly (same package). Filing this as falsified assumption A5.</li>
+  <li><span class="badge badge-danger">S10</span> Slice 10 claimed codex.go and gemini.go have equivalent removeMarketplaceHtmlgraph blocks — they do not. Only claude.go and yolo.go have this call. Scope must be corrected to enumerate actual mutations per launcher.</li>
+  <li><span class="badge badge-info">S3</span> Slice 3 correctly identifies the deploy monolith problem but must name manifest.json as the shared version source (not a generic &#39;shared version file&#39;).</li>
+</ul>
+<h5>Gaps &amp; Missing Considerations</h5>
+<ul>
+  <li><span class="badge badge-warn">GAP</span> No question defined the canonical shared version source path. Three options exist (VERSION file, plugin.json, manifest.json) — plan must pick one. Added as q-shared-version-source.</li>
+  <li><span class="badge badge-warn">GAP</span> Slice 1 done_when did not address how htmlgraph build locates build.sh without the hooks/bin/ walk-up anchor. Added explicit criterion about os.Executable() + repo-root discovery.</li>
+  <li><span class="badge badge-info">GAP</span> Slice 8 Homebrew tap prerequisite (tap repo existence + PAT credentials) was not the first done_when item, making it easy to miss as a blocker.</li>
+  <li><span class="badge badge-info">GAP</span> Slice 6 had no deps despite requiring doctor logic from slice 5 for its --check enrichment. Added deps: [5].</li>
+</ul>
+<h5>Alternative Approaches</h5>
+<ul>
+  <li><span class="badge badge-info">ALT</span> Version source: a VERSION file at repo root is simpler to grep and requires no YAML parsing at build time. Tradeoff vs manifest-canonical is one extra file vs coupling to YAML format.</li>
+  <li><span class="badge badge-info">ALT</span> CheckVersionAlignment could be in a separate internal/hooks/version_alignment.go to keep version_check.go focused on reading plugin.json. Consolidating in version_check.go is simpler for this scope.</li>
+  <li><span class="badge badge-info">ALT</span> Slice 4 could use a separate cobra subcommand (htmlgraph hook version-check) rather than extending the existing session_start handler. Extending the existing handler is lower surface area and avoids manifest changes.</li>
+  <li><span class="badge badge-info">ALT</span> Container detection could use REMOTE_CONTAINERS env var (set by VS Code) in addition to HTMLGRAPH_DEVCONTAINER=1 and /workspaces path check — more robust but more magic.</li>
+</ul>
+</div>
+      </div>
+      
+      
+      <div>
+        <h4>Sonnet (feasibility)</h4>
+        <div style="font-size:.85rem;color:var(--text-dim)"><h5>What Exists to Leverage</h5>
+<ul>
+  <li><span class="badge badge-success">EXIST</span> internal/hooks/version_check.go: readPluginVersion(), versionMismatchWarning(), CLIVersion — refactor path for CheckVersionAlignment is already ~60% done.</li>
+  <li><span class="badge badge-success">EXIST</span> internal/hooks/session_start.go:226 already calls versionMismatchWarning() — adding the block path for missing CLI is an extension, not a new handler.</li>
+  <li><span class="badge badge-success">EXIST</span> cmd/htmlgraph/plugin_build_ports.go is already registered (line 47) and adapters produce binary-free output — slice 2 is purely additive (assertion only).</li>
+  <li><span class="badge badge-success">EXIST</span> packages/plugin-core/manifest.json has a version field at 0.55.5 — making it canonical for slice 3 requires no new file, just convention.</li>
+</ul>
+<h5>What the Plan Gets Wrong</h5>
+<ul>
+  <li><span class="badge badge-danger">WRONG</span> Slice 4 files list included internal/hooks/runner.go — this file is not the dispatch layer and should not be modified for hook dispatch.</li>
+  <li><span class="badge badge-danger">WRONG</span> Slice 5 files list included internal/version/version.go — file does not exist; version var is in cmd/htmlgraph/main.go.</li>
+  <li><span class="badge badge-danger">WRONG</span> Slice 10 claimed equivalent host mutations in codex.go and gemini.go — neither file contains removeMarketplaceHtmlgraph or equivalent. Scope was overstated.</li>
+  <li><span class="badge badge-warn">WRONG</span> Slice 2 framed the work as removing binary copy logic that does not exist in adapters. The real work is adding an assertion guard.</li>
+</ul>
+<h5>Prior Art &amp; Examples</h5>
+<ul>
+  <li><span class="badge badge-info">ART</span> roborev distribution model: binary-first, no marketplace — HtmlGraph deliberately diverges by keeping marketplace for discoverability. The version-check hook is HtmlGraph-specific compensation.</li>
+  <li><span class="badge badge-info">ART</span> BlockExit2Error pattern in cmd/htmlgraph/hook.go lines 195-198 — already established for blocking hooks; slice 4&#39;s missing-CLI block should reuse this pattern.</li>
+  <li><span class="badge badge-info">ART</span> roborev escape hatches (ROBOREV_INSTALL_DIR, ROBOREV_NO_MODIFY_PATH) — slice 7 mirrors these directly, reducing design risk.</li>
+  <li><span class="badge badge-info">ART</span> packages/homebrew/update-formula.sh is &#39;already partially implemented&#39; per plan — slice 8 is an extension not a greenfield build.</li>
+</ul>
+</div>
+      </div>
+      
+    </div>
+    
+
+    
+    <div class="sub-section">
+      <h4>Synthesis</h4>
+      <div style="font-size:.85rem;color:var(--text-dim)">The dual critique (Haiku design + Sonnet feasibility) falsified four assumptions and identified two high-severity risks that required plan rewrites. Slice 2 was reframed from removing non-existent binary copy logic to adding a post-build assertion guard; slice 4 was rewritten to extend the existing session_start handler (not add a new dispatch path) and to introduce CheckVersionAlignment as a shared exported function; slice 5 was corrected to read the version var from cmd/htmlgraph/main.go directly rather than a non-existent internal/version package; slice 10 was scoped to only the launchers with actual host mutations (claude.go and yolo.go) and codex/gemini get honest no-op stubs. Beyond the four rewrites, slice 1 gained an explicit build.sh relocation criterion, slice 3 gained a release atomicity done_when and now names manifest.json as the canonical version source, slice 6 gained a dep on slice 5, and slice 8 gained the Homebrew tap prereq as its first done_when. A new question (q-shared-version-source) was added — the human must decide between VERSION file, plugin.json, and manifest.json as canonical; the recommendation is manifest.json since it already exists and is already authoritative. A new design constraint on release atomicity and version-check warn-not-block semantics was added to protect against the skew window risk. Slices 7, 9, and 11 were unchanged.
+</div>
+    </div>
+    
+
+    
+    <div class="sub-section">
+      <h4>Risk Assessment</h4>
+      <table class="q-table">
+        <thead><tr><th>Risk</th><th>Severity</th><th>Mitigation</th></tr></thead>
+        <tbody>
+          
+          <tr>
+            <td>R1 / Release skew window — binary and plugin released in separate CI steps; user who installs between steps gets a mismatched state</td>
+            <td><span class="badge badge-blocked">High</span></td>
+            <td>Both phases run in a single GitHub Actions workflow on the same tag/commit; skew window bounded to job duration (&lt;2 min). SessionStart version check uses warn (exit 1) not block (exit 2) on minor/patch divergence. Added as design constraint.</td>
+          </tr>
+          
+          <tr>
+            <td>R2 / Plugin artifact size regression — future manifest edit reintroduces binary paths</td>
+            <td><span class="badge badge-revision">Medium</span></td>
+            <td>Post-build assertion in slice 2 fails the build if any generated hook command contains a local path. Machine-enforceable guard, not convention.</td>
+          </tr>
+          
+          <tr>
+            <td>R3 / Walk-up binary resolution breaks after removing hooks/bin/</td>
+            <td><span class="badge badge-revision">Medium</span></td>
+            <td>Slice 1 done_when now explicitly requires os.Executable() &#43; repo-root discovery (walk up to .htmlgraph/) to replace the hooks/bin/ walk-up. TestResolveBuildScript covers this.</td>
+          </tr>
+          
+          <tr>
+            <td>R4 / CheckVersionAlignment semantics diverge between hook and doctor</td>
+            <td><span class="badge badge-revision">Medium</span></td>
+            <td>Single exported function in version_check.go used by both paths — same code path, cannot diverge. Covered by TestCheckVersionAlignment unit tests.</td>
+          </tr>
+          
+          <tr>
+            <td>R5 / Homebrew tap prerequisite missing — tap repo or PAT not yet set up</td>
+            <td><span class="badge badge-blocked">High</span></td>
+            <td>Tap repo existence and PAT credentials are now the FIRST done_when criterion for slice 8 — it is a hard prereq, not an afterthought. Flagged for human review.</td>
+          </tr>
+          
+          <tr>
+            <td>R6 / Container mode skips mutations that do not exist in codex/gemini — false sense of coverage</td>
+            <td><span class="badge badge-revision">Medium</span></td>
+            <td>Slice 10 rewritten to enumerate only ACTUAL mutations in claude.go and yolo.go. codex.go and gemini.go get a no-op stub flag with explicit code comments documenting the intentional no-op.</td>
+          </tr>
+          
+        </tbody>
+      </table>
+    </div>
+    
+
+    
+
+  </div>
+</details>
+
+
+
+
+
+<!-- ZONE 3: Feedback Summary -->
+<section id="feedback-summary" class="progress-zone" data-zone="feedback-summary">
+  <h2>Feedback Summary</h2>
+  <div class="progress-stats">
+    <div class="progress-stat"><strong id="approvedCount">0</strong> approved</div>
+    <div class="progress-stat"><strong id="totalSections">12</strong> sections</div>
+    <div class="progress-stat"><strong id="pendingCount">12</strong> pending</div>
+  </div>
+  <div class="progress-bar-track"><div class="progress-bar-fill" id="progressFill" style="width:0%"></div></div>
+  <div class="comments-summary">
+    <h3>Decisions &amp; Comments</h3>
+    <div id="commentsFeed"><p style="font-size:.8rem;color:var(--text-muted);font-style:italic">No comments yet.</p></div>
+  </div>
+  <div class="finalize-area">
+    <button class="btn-finalize" id="finalizeBtn" disabled>Finalize Plan</button>
+    <p style="font-size:.75rem;color:var(--text-muted);margin-top:6px">All sections must be approved before finalizing.</p>
+  </div>
+</section>
+
+</article>
+</div><!-- /.plan-content -->
+
+<!-- Drag handle for resizing chat sidebar -->
+<div class="chat-resize-handle" id="chat-resize-handle"></div>
+
+<!-- Chat sidebar -->
+<aside class="chat-sidebar" id="chat-sidebar">
+  <section id="chat-panel" class="chat-panel" data-zone="chat">
+    <h2>Plan Discussion</h2>
+    <div id="chat-messages" class="chat-messages">
+      <p class="chat-notice" id="chat-empty">Ask about the plan design, slices, risks, or tradeoffs.</p>
+    </div>
+    <div class="chat-input-area">
+      <textarea id="chat-input" placeholder="Ask about the plan..." rows="2"></textarea>
+      <button id="chat-send">Send</button>
+    </div>
+  </section>
+
+  <!-- Amendments Panel -->
+  <div id="amendments-panel" class="amendments-panel" style="display:none">
+    <h3>Amendments</h3>
+    <div id="amendments-list"></div>
+    <div id="amendments-summary" class="amendments-summary"></div>
+  </div>
+</aside>
+</div><!-- /.plan-layout -->
+
+<script src="https://d3js.org/d3.v7.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dagre-d3@0.6.4/dist/dagre-d3.min.js"></script>
+<script>
+// Plan base path — derived from window.location.pathname so the same
+// rendered HTML works whether the file is served at the legacy
+// /plans/<id>.html path (single-project server) or at /p/<id>/plans/<id>.html
+// (via the parent-doorway reverse proxy). Every fetch() on this page
+// prefixes window.htmlgraphPlanBase, which is '' at the root and
+// '/p/<id>' under the proxy. This is the per-project routing fix for
+// the multi-project hardening re-architecture (plan-237fb251).
+window.htmlgraphPlanBase = (function() {
+  var p = window.location.pathname || '';
+  if (p.indexOf('/p/') !== 0) return '';
+  var segs = p.split('/').filter(function(s) { return s !== ''; });
+  if (segs.length >= 2 && segs[0] === 'p') return '/p/' + segs[1];
+  return '';
+})();
+</script>
+<script>
+// Theme toggle (skip when embedded — dashboard manages its own theme)
+(function(){
+  var themeBtn = document.getElementById('themeToggle');
+  if (!themeBtn) return;
+  var html = document.documentElement;
+
+  var saved = localStorage.getItem('crispi-theme');
+  function syncHljsTheme(theme) {
+    var dark = document.getElementById('hljs-dark');
+    var light = document.getElementById('hljs-light');
+    if (theme === 'light') {
+      dark.disabled = true; light.disabled = false;
+    } else {
+      dark.disabled = false; light.disabled = true;
+    }
+  }
+
+  if (saved) {
+    html.dataset.theme = saved;
+    themeBtn.textContent = saved === 'light' ? '\u263E Dark' : '\u2600 Light';
+    syncHljsTheme(saved);
+  } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
+    html.dataset.theme = 'light';
+    themeBtn.textContent = '\u263E Dark';
+    syncHljsTheme('light');
+  }
+
+  themeBtn.addEventListener('click', function() {
+    var current = html.dataset.theme || 'dark';
+    var next = current === 'dark' ? 'light' : 'dark';
+    html.dataset.theme = next;
+    localStorage.setItem('crispi-theme', next);
+    themeBtn.textContent = next === 'light' ? '\u263E Dark' : '\u2600 Light';
+    syncHljsTheme(next);
+  });
+
+  hljs.highlightAll();
+})();
+
+// Global plan ID — accessible to all script blocks when embedded
+var planId=(function(){var a=document.querySelector('article[id]');return a?a.id:null;})();
+
+(function(){
+  'use strict';
+  var SECTIONS=/*PLAN_SECTIONS_JSON*/["design","slice-1","slice-2","slice-3","slice-4","slice-5","slice-6","slice-7","slice-8","slice-9","slice-10","slice-11"]/*END_PLAN_SECTIONS_JSON*/;
+
+  function setBadge(el,ok){
+    el.className='badge badge-'+(ok?'approved':'pending');
+    el.textContent=ok?'Approved':'Pending';
+  }
+
+  function escHtml(s){var d=document.createElement('div');d.textContent=s;return d.innerHTML}
+
+  document.querySelectorAll('input[data-action="approve"]').forEach(function(cb){
+    cb.addEventListener('change',function(){
+      var sec=this.dataset.section;
+      var badge=document.querySelector('[data-badge-for="'+sec+'"]');
+      if(badge) setBadge(badge,this.checked);
+      var details=this.closest('details[data-phase]');
+      if(details) details.dataset.status=this.checked?'approved':'pending';
+      if(sec.startsWith('slice-')){
+        var n=sec.split('-')[1];
+        var node=document.getElementById('node-'+n);
+        if(node) node.dataset.status=this.checked?'approved':'pending';
+        var all=document.querySelectorAll('input[data-section^="slice-"][data-action="approve"]');
+        var allOk=Array.prototype.every.call(all,function(c){return c.checked});
+        var sb=document.querySelector('[data-badge-for="slices"]');
+        if(sb) setBadge(sb,allOk);
+        var sd=document.querySelector('[data-phase="slices"]');
+        if(sd) sd.dataset.status=allOk?'approved':'pending';
+      }
+      updateProgress();
+      if(planId){
+        fetch((window.htmlgraphPlanBase||'')+'/api/plans/'+planId+'/feedback',{
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify({section:sec,action:'approve',value:String(this.checked),question_id:''})
+        });
+      }
+    });
+  });
+
+  document.querySelectorAll('input[type="radio"][data-question]').forEach(function(r){
+    r.addEventListener('change',function(){
+      var row=document.querySelector('[data-recap-for="'+this.dataset.question+'"]');
+      if(row){
+        var c=row.querySelector('.recap-answer');
+        if(c) c.textContent=this.value.charAt(0).toUpperCase()+this.value.slice(1);
+        var badge=row.querySelector('.badge');
+        if(badge) setBadge(badge,true);
+      }
+      var allRows=document.querySelectorAll('[data-recap-for]');
+      var allAnswered=Array.prototype.every.call(allRows,function(r){
+        var b=r.querySelector('.badge');
+        return b&&b.className.indexOf('badge-approved')>=0;
+      });
+      var headerBadge=document.querySelector('[data-badge-for="questions"]');
+      if(headerBadge) setBadge(headerBadge,allAnswered);
+      var details=document.querySelector('[data-phase="questions"]');
+      if(details) details.dataset.status=allAnswered?'approved':'pending';
+      if(planId){
+        fetch((window.htmlgraphPlanBase||'')+'/api/plans/'+planId+'/feedback',{
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify({section:'questions',action:'answer',value:this.value,question_id:this.dataset.question})
+        });
+      }
+    });
+  });
+
+  document.querySelectorAll('input[type="radio"][data-question]:checked').forEach(function(r){
+    var row=document.querySelector('[data-recap-for="'+r.dataset.question+'"]');
+    if(row){
+      var badge=row.querySelector('.badge');
+      if(badge) setBadge(badge,true);
+    }
+  });
+  var allRows=document.querySelectorAll('[data-recap-for]');
+  var allAnswered=Array.prototype.every.call(allRows,function(r){
+    var b=r.querySelector('.badge');
+    return b&&b.className.indexOf('badge-approved')>=0;
+  });
+  var qBadge=document.querySelector('[data-badge-for="questions"]');
+  if(qBadge) setBadge(qBadge,allAnswered);
+  var qDetails=document.querySelector('[data-phase="questions"]');
+  if(qDetails) qDetails.dataset.status=allAnswered?'approved':'pending';
+
+  function updateProgress(){
+    var approved=0;
+    SECTIONS.forEach(function(sec){
+      var cb=document.querySelector('input[data-section="'+sec+'"][data-action="approve"]');
+      if(cb&&cb.checked) approved++;
+    });
+    document.getElementById('approvedCount').textContent=approved;
+    document.getElementById('pendingCount').textContent=SECTIONS.length-approved;
+    document.getElementById('progressFill').style.width=Math.round(approved/SECTIONS.length*100)+'%';
+    document.getElementById('finalizeBtn').disabled=(approved<SECTIONS.length);
+    updateComments();
+  }
+
+  function updateComments(){
+    var feed=document.getElementById('commentsFeed'),html='';
+    SECTIONS.forEach(function(sec){
+      var ta=document.querySelector('textarea[data-section="'+sec+'"]');
+      if(ta&&ta.value.trim()) html+='<div class="comment-entry"><span class="comment-source">'+sec+'</span>'+escHtml(ta.value.trim())+'</div>';
+    });
+    feed.innerHTML=html||'<p style="font-size:.8rem;color:var(--text-muted);font-style:italic">No comments yet.</p>';
+  }
+
+  var timer;
+  document.querySelectorAll('textarea[data-section]').forEach(function(ta){
+    ta.addEventListener('input',function(){clearTimeout(timer);timer=setTimeout(updateComments,400)});
+    ta.addEventListener('blur',function(){
+      if(planId&&this.value.trim()){
+        fetch((window.htmlgraphPlanBase||'')+'/api/plans/'+planId+'/feedback',{
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify({section:this.dataset.section,action:'comment',value:this.value.trim(),question_id:''})
+        });
+      }
+    });
+  });
+
+  var finalizeMsg=document.createElement('p');
+  finalizeMsg.style.cssText='font-size:.85rem;margin-top:8px;text-align:center;display:none';
+  var finalizeBtn=document.getElementById('finalizeBtn');
+  if(finalizeBtn){
+    finalizeBtn.parentNode.insertBefore(finalizeMsg,finalizeBtn.nextSibling);
+    finalizeBtn.addEventListener('click',function(){
+      if(!planId){return;}
+      var btn=this;
+      btn.disabled=true;
+      btn.textContent='Finalizing...';
+      finalizeMsg.style.display='none';
+      fetch((window.htmlgraphPlanBase||'')+'/api/plans/'+planId+'/finalize',{
+        method:'POST',
+        headers:{'Content-Type':'application/json'}
+      })
+      .then(function(r){
+        if(r.ok){
+          r.json().then(function(data){
+            var art=document.querySelector('article[id]');if(art)art.dataset.status='finalized';
+            btn.textContent='Plan Finalized';
+            btn.style.background='var(--approved)';
+            btn.style.color='#fff';
+            if(data&&data.next_steps){
+              var pre=document.createElement('pre');
+              pre.style.cssText='margin-top:12px;padding:10px 14px;background:var(--bg-input);border:1px solid var(--border);border-radius:var(--radius);font-family:var(--mono);font-size:.78rem;text-align:left;white-space:pre-wrap;word-break:break-all;color:var(--text)';
+              pre.textContent=data.next_steps;
+              finalizeMsg.innerHTML='';
+              finalizeMsg.appendChild(pre);
+            } else {
+              finalizeMsg.textContent='Plan finalized successfully.';
+            }
+            finalizeMsg.style.color='var(--approved)';
+            finalizeMsg.style.display='block';
+          });
+        } else {
+          return r.json().then(function(data){
+            btn.textContent='Finalize Plan';
+            btn.disabled=false;
+            finalizeMsg.textContent=data.error||'Not all sections approved.';
+            finalizeMsg.style.color='var(--blocked)';
+            finalizeMsg.style.display='block';
+          });
+        }
+      })
+      .catch(function(){
+        btn.textContent='Finalize Plan';
+        btn.disabled=false;
+        finalizeMsg.textContent='Could not reach server. Is htmlgraph serve running?';
+        finalizeMsg.style.color='var(--revision)';
+        finalizeMsg.style.display='block';
+      });
+    });
+  }
+
+  function loadExistingFeedback(){
+    if(!planId){return;}
+    fetch((window.htmlgraphPlanBase||'')+'/api/plans/'+planId+'/feedback')
+      .then(function(r){return r.ok?r.json():null;})
+      .then(function(data){
+        if(!data){return;}
+        if(data.sections){
+          Object.keys(data.sections).forEach(function(sec){
+            var info=data.sections[sec];
+            if(info.approved){
+              var cb=document.querySelector('input[data-section="'+sec+'"][data-action="approve"]');
+              if(cb&&!cb.checked){cb.checked=true;cb.dispatchEvent(new Event('change'));}
+            }
+            if(info.comment){
+              var ta=document.querySelector('textarea[data-section="'+sec+'"]');
+              if(ta) ta.value=info.comment;
+            }
+          });
+        }
+        if(data.questions){
+          Object.keys(data.questions).forEach(function(qid){
+            var val=data.questions[qid];
+            var radio=document.querySelector('input[type="radio"][data-question="'+qid+'"][value="'+val+'"]');
+            if(radio&&!radio.checked){radio.checked=true;radio.dispatchEvent(new Event('change'));}
+          });
+        }
+        updateProgress();
+      })
+      .catch(function(){});
+  }
+
+  loadExistingFeedback();
+
+  document.querySelectorAll('input[data-action="approve"]').forEach(function(cb){
+    cb.addEventListener('change',function(){
+      var sec=this.dataset.section;
+      if(sec.startsWith('slice-')){
+        var n=sec.split('-')[1];
+        var nodeRect=d3.select('#dep-graph-svg .node[id="'+n+'"] rect');
+        if(!nodeRect.empty()){
+          var color=this.checked?'#16a34a':'#6b7280';
+          var cs=getComputedStyle(document.querySelector('.dep-graph')||document.documentElement);
+          nodeRect.style('stroke',color).style('fill',cs.getPropertyValue('--bg-input').trim()||'#222228');
+        }
+      }
+    });
+  });
+})();
+
+// Render dagre-d3 dependency graph
+(function(){
+  'use strict';
+
+  var STATUS_COLORS={pending:'#6b7280',approved:'#16a34a',revision:'#f59e0b',discuss:'#8b5cf6',blocked:'#dc2626'};
+
+  function renderGraph(){
+    var container=document.getElementById('graph-data');
+    if(!container) return;
+
+    var g=new dagreD3.graphlib.Graph().setGraph({rankdir:'TB',marginx:24,marginy:24,ranksep:48,nodesep:32});
+    g.setDefaultEdgeLabel(function(){return{};});
+
+    var nodes=container.querySelectorAll('[data-node]');
+    nodes.forEach(function(el){
+      var id=el.dataset.node;
+      var name=el.dataset.name;
+      var files=el.dataset.files;
+      var status=el.dataset.status||'pending';
+      g.setNode(id,{
+        label: name+'\n'+files+' files',
+        rx: 6,
+        ry: 6,
+        paddingX: 36,
+        paddingY: 16,
+        status: status
+      });
+    });
+
+    nodes.forEach(function(el){
+      var id=el.dataset.node;
+      var deps=el.dataset.deps?el.dataset.deps.split(',').map(function(d){return d.trim();}).filter(Boolean):[];
+      deps.forEach(function(dep){g.setEdge(dep,id);});
+    });
+
+    var svg=d3.select('#dep-graph-svg');
+    var inner=svg.append('g');
+    var render=new dagreD3.render();
+    render(inner,g);
+
+    // Read CSS vars from the plan container so graph respects light/dark theme
+    var cs=getComputedStyle(document.querySelector('.dep-graph')||document.documentElement);
+    var nodeFill=cs.getPropertyValue('--bg-input').trim()||'#222228';
+    var nodeText=cs.getPropertyValue('--text').trim()||'#ededea';
+    var edgeColor=cs.getPropertyValue('--text-muted').trim()||'#707070';
+
+    inner.selectAll('g.node').each(function(id){
+      var nodeData=g.node(id);
+      var status=nodeData?nodeData.status:'pending';
+      var color=STATUS_COLORS[status]||STATUS_COLORS.pending;
+      d3.select(this).select('rect')
+        .style('fill',nodeFill)
+        .style('stroke',color)
+        .style('stroke-width','2px');
+      d3.select(this).select('text').style('fill',nodeText).style('font-size','13px');
+    });
+
+    inner.selectAll('g.edgePath path')
+      .style('stroke',edgeColor)
+      .style('stroke-dasharray','4 3')
+      .style('fill','none');
+    inner.selectAll('g.edgePath marker path')
+      .style('fill','#707070');
+
+    var svgEl=document.getElementById('dep-graph-svg');
+    var graphWidth=g.graph().width;
+    var graphHeight=g.graph().height;
+    var pad=24;
+    inner.attr('transform','translate('+pad+','+pad+')');
+    svgEl.setAttribute('width',graphWidth+pad*2);
+    svgEl.setAttribute('height',graphHeight+pad*2);
+    svgEl.removeAttribute('viewBox');
+  }
+
+  if(document.readyState==='loading'){
+    document.addEventListener('DOMContentLoaded',renderGraph);
+  } else {
+    renderGraph();
+  }
+})();
+
+// Chat panel
+// Global markdown renderer — shared by chat bubbles and data-markdown elements
+function escHtml(s){var d=document.createElement('div');d.textContent=s;return d.innerHTML;}
+function renderMd(text){
+  var s=escHtml(text);
+  s=s.replace(/```(\w*)\n([\s\S]*?)```/g,function(_,lang,code){
+    return '<pre><code'+(lang?' class="language-'+lang+'"':'')+'>'+code.trim()+'</code></pre>';
+  });
+  s=s.replace(/`([^`]+)`/g,'<code>$1</code>');
+  s=s.replace(/\*\*([^*]+)\*\*/g,'<strong>$1</strong>');
+  s=s.replace(/\*([^*]+)\*/g,'<em>$1</em>');
+  s=s.replace(/^### (.+)$/gm,'<h4>$1</h4>');
+  s=s.replace(/^## (.+)$/gm,'<h3>$1</h3>');
+  s=s.replace(/^(\|.+\|)\n(\|[-| :]+\|)\n((?:\|.+\|\n?)+)/gm,function(_,hdr,sep,body){
+    var ths=hdr.split('|').filter(Boolean).map(function(c){return '<th>'+c.trim()+'</th>';}).join('');
+    var rows=body.trim().split('\n').map(function(row){
+      var tds=row.split('|').filter(Boolean).map(function(c){return '<td>'+c.trim()+'</td>';}).join('');
+      return '<tr>'+tds+'</tr>';
+    }).join('');
+    return '<table class="q-table"><thead><tr>'+ths+'</tr></thead><tbody>'+rows+'</tbody></table>';
+  });
+  s=s.replace(/^[*-] (.+)$/gm,'<li>$1</li>');
+  s=s.replace(/(<li>.*<\/li>\n?)+/g,'<ul>$&</ul>');
+  s=s.replace(/^\d+\. (.+)$/gm,'<li data-ol>$1</li>');
+  s=s.replace(/(<li data-ol>.*<\/li>\n?)+/g,'<ol>$&</ol>');
+  s=s.replace(/ data-ol/g,'');
+  // Split on paragraph boundaries and wrap each block.
+  var blocks=s.split(/\n\n/);
+  var html=blocks.map(function(block){
+    var trimmed=block.trim();
+    if(!trimmed) return '';
+    return '<p>'+trimmed.replace(/\n/g,'<br>')+'</p>';
+  }).filter(Boolean).join('');
+  return html||'<p></p>';
+}
+// Render inline markdown for elements with data-markdown attribute.
+// For block elements (div/p) replaces innerHTML; for inline (li/span)
+// renders without wrapping <p> tags.
+(function(){
+  document.querySelectorAll('[data-markdown]').forEach(function(el){
+    var raw=el.textContent;
+    if(!raw.trim()) return;
+    var tag=el.tagName.toLowerCase();
+    if(tag==='li'||tag==='span'||tag==='td'){
+      // Inline context — just apply bold/italic/code, no block transforms
+      var s=escHtml(raw);
+      s=s.replace(/`([^`]+)`/g,'<code>$1</code>');
+      s=s.replace(/\*\*([^*]+)\*\*/g,'<strong>$1</strong>');
+      s=s.replace(/\*([^*]+)\*/g,'<em>$1</em>');
+      el.innerHTML=s;
+    } else {
+      el.innerHTML=renderMd(raw);
+    }
+    el.removeAttribute('data-markdown');
+  });
+})();
+
+(function(){
+  'use strict';
+  var chatMessages=document.getElementById('chat-messages');
+  var chatInput=document.getElementById('chat-input');
+  var chatSend=document.getElementById('chat-send');
+  var chatEmpty=document.getElementById('chat-empty');
+  if(!chatMessages||!chatInput||!chatSend) return;
+
+  function addBubble(role,content){
+    if(!content||!content.trim()) return null; // skip empty messages
+    if(chatEmpty) chatEmpty.style.display='none';
+    var div=document.createElement('div');
+    div.className='chat-bubble';
+    div.dataset.role=role;
+    if(role==='assistant'){
+      div.innerHTML=renderMd(content);
+    } else {
+      div.textContent=content;
+    }
+    chatMessages.appendChild(div);
+    chatMessages.scrollTop=chatMessages.scrollHeight;
+    return div;
+  }
+
+  function setInputEnabled(enabled){
+    chatInput.disabled=!enabled;
+    chatSend.disabled=!enabled;
+    if(enabled) chatInput.focus();
+  }
+
+  // Load previous messages directly into the chat thread.
+  if(planId){
+    fetch((window.htmlgraphPlanBase||'')+'/api/plans/'+planId+'/feedback')
+      .then(function(r){return r.ok?r.json():null;})
+      .then(function(data){
+        if(!data||!data.chat_messages||!data.chat_messages.length) return;
+        if(chatEmpty) chatEmpty.style.display='none';
+        data.chat_messages.forEach(function(m){
+          addBubble(m.role,m.content);
+        });
+      })
+      .catch(function(){});
+  }
+
+  function sendMessage(){
+    var text=chatInput.value.trim();
+    if(!text||!planId) return;
+    chatInput.value='';
+    setInputEnabled(false);
+
+    addBubble('user',text);
+    // Create streaming bubble directly (addBubble skips empty content)
+    if(chatEmpty) chatEmpty.style.display='none';
+    var assistantBubble=document.createElement('div');
+    assistantBubble.className='chat-bubble';
+    assistantBubble.dataset.role='assistant';
+    chatMessages.appendChild(assistantBubble);
+    var rawResponse='';
+
+    fetch((window.htmlgraphPlanBase||'')+'/api/plans/'+planId+'/chat',{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({message:text})
+    }).then(function(response){
+      if(response.status===503){
+        assistantBubble.textContent='Chat unavailable \u2014 Claude CLI not found and no API key configured.';
+        assistantBubble.style.color='var(--text-muted)';
+        assistantBubble.style.fontStyle='italic';
+        setInputEnabled(true);
+        return;
+      }
+      if(!response.ok){
+        assistantBubble.textContent='Error: '+response.statusText;
+        setInputEnabled(true);
+        return;
+      }
+      var reader=response.body.getReader();
+      var decoder=new TextDecoder();
+      var buffer='';
+
+      function processStream(){
+        reader.read().then(function(result){
+          if(result.done){
+            // Stream complete — render accumulated text as markdown
+            if(rawResponse) assistantBubble.innerHTML=renderMd(rawResponse);
+            setInputEnabled(true);
+            return;
+          }
+          buffer+=decoder.decode(result.value,{stream:true});
+          var lines=buffer.split('\n');
+          buffer=lines.pop()||'';
+          lines.forEach(function(line){
+            line=line.trim();
+            if(!line.startsWith('data: ')) return;
+            var jsonStr=line.substring(6);
+            try{
+              var evt=JSON.parse(jsonStr);
+              if(evt.type==='chunk'&&evt.text){
+                rawResponse+=evt.text;
+                assistantBubble.textContent=rawResponse; // show raw while streaming
+                chatMessages.scrollTop=chatMessages.scrollHeight;
+              } else if(evt.type==='error'){
+                assistantBubble.textContent+=' [Error: '+evt.error+']';
+              } else if(evt.type==='done'){
+                if(rawResponse) assistantBubble.innerHTML=renderMd(rawResponse);
+                setInputEnabled(true);
+              }
+            }catch(e){}
+          });
+          processStream();
+        }).catch(function(){
+          setInputEnabled(true);
+        });
+      }
+      processStream();
+    }).catch(function(err){
+      assistantBubble.textContent='Network error: '+err.message;
+      setInputEnabled(true);
+    });
+  }
+
+  chatSend.addEventListener('click',sendMessage);
+  chatInput.addEventListener('keydown',function(e){
+    if(e.key==='Enter'&&!e.shiftKey){
+      e.preventDefault();
+      sendMessage();
+    }
+  });
+})();
+
+// Scroll-spy (uses plan-content scroll, not window)
+(function(){
+  'use strict';
+  var links=document.querySelectorAll('.plan-sidebar a[data-spy]');
+  if(!links.length) return;
+  var ids=Array.prototype.map.call(links,function(a){return a.dataset.spy;});
+  var scrollContainer=document.querySelector('.plan-content')||window;
+  function update(){
+    var current='';
+    ids.forEach(function(id){
+      var el=document.getElementById(id);
+      if(el&&el.getBoundingClientRect().top<=80) current=id;
+    });
+    links.forEach(function(a){
+      a.classList.toggle('active',a.dataset.spy===current);
+    });
+  }
+  scrollContainer.addEventListener('scroll',update,{passive:true});
+  window.addEventListener('scroll',update,{passive:true});
+  update();
+})();
+
+// Chat sidebar drag-resize
+(function(){
+  var handle=document.getElementById('chat-resize-handle');
+  var sidebar=document.getElementById('chat-sidebar');
+  if(!handle||!sidebar) return;
+  var startX,startW;
+  handle.addEventListener('mousedown',function(e){
+    e.preventDefault();
+    startX=e.clientX;
+    startW=sidebar.offsetWidth;
+    handle.classList.add('dragging');
+    document.body.style.cursor='col-resize';
+    document.body.style.userSelect='none';
+    function onMove(e){
+      var delta=startX-e.clientX;
+      var newW=Math.max(280,Math.min(600,startW+delta));
+      sidebar.style.width=newW+'px';
+    }
+    function onUp(){
+      handle.classList.remove('dragging');
+      document.body.style.cursor='';
+      document.body.style.userSelect='';
+      document.removeEventListener('mousemove',onMove);
+      document.removeEventListener('mouseup',onUp);
+    }
+    document.addEventListener('mousemove',onMove);
+    document.addEventListener('mouseup',onUp);
+  });
+})();
+
+
+// Sync highlight.js theme with current dark/light mode
+function syncHljsTheme(){
+  var isLight=document.documentElement.dataset.theme==='light';
+  var dark=document.getElementById('hljs-dark');
+  var light=document.getElementById('hljs-light');
+  if(dark) dark.disabled=isLight;
+  if(light) light.disabled=!isLight;
+}
+syncHljsTheme();
+
+// YAML viewer — lazy-loads plan YAML on first open or re-highlights on reopen
+(function(){
+  var viewer=document.getElementById('yaml-viewer');
+  var codeEl=document.getElementById('yaml-content');
+  if(!viewer||!codeEl)return;
+
+  function loadAndHighlight(){
+    var planEl=document.querySelector('[data-plan-id]');
+    if(!planEl)return;
+    var id=planEl.getAttribute('data-plan-id');
+    fetch((window.htmlgraphPlanBase||'')+'/api/plans/'+id+'/yaml')
+      .then(function(r){if(!r.ok)throw new Error('err');return r.text();})
+      .then(function(t){
+        codeEl.textContent=t;
+        delete codeEl.dataset.highlighted; // allow re-highlighting
+        syncHljsTheme();
+        function tryHighlight(){
+          if(window.hljs&&hljs.getLanguage&&hljs.getLanguage('yaml')){
+            hljs.highlightElement(codeEl);
+          } else {
+            setTimeout(tryHighlight,200);
+          }
+        }
+        tryHighlight();
+      })
+      .catch(function(){codeEl.textContent='YAML not available';});
+  }
+
+  var loaded=false;
+  viewer.addEventListener('toggle',function(){
+    if(!viewer.open||loaded)return;
+    loaded=true;
+    loadAndHighlight();
+  });
+  // If already open (e.g. re-rendered in embedded view), load immediately
+  if(viewer.open){loaded=true;loadAndHighlight();}
+})();
+
+// Amendments panel
+(function(){
+  var panel=document.getElementById('amendments-panel');
+  var list=document.getElementById('amendments-list');
+  var summary=document.getElementById('amendments-summary');
+  if(!panel||!list)return;
+
+  var article=document.querySelector('article[id]');
+  var planId=article?article.id:null;
+  if(!planId)return;
+
+  function escapeHtml(s){var d=document.createElement('div');d.textContent=s;return d.innerHTML;}
+
+  function updateSummary(){
+    var selects=list.querySelectorAll('select');
+    var accepted=0,pending=0;
+    selects.forEach(function(s){
+      if(s.value==='accepted')accepted++;
+      else if(s.value==='pending')pending++;
+    });
+    summary.textContent=selects.length+' amendments — '+accepted+' accepted, '+pending+' pending';
+  }
+
+  fetch((window.htmlgraphPlanBase||'')+'/api/plans/'+planId+'/amendments')
+    .then(function(r){return r.json();})
+    .then(function(amendments){
+      if(!amendments||!amendments.length)return;
+      panel.style.display='';
+      amendments.forEach(function(a,i){
+        var item=document.createElement('div');
+        item.className='amendment-item';
+        var desc=document.createElement('div');
+        desc.className='amendment-desc';
+        desc.innerHTML='<span class="op">'+escapeHtml(a.operation)+'</span> '+
+          '<span class="field">'+escapeHtml(a.field)+'</span> on slice-'+a.slice_num+': '+
+          escapeHtml(a.content);
+        var sel=document.createElement('select');
+        sel.className='amendment-select';
+        ['pending','accepted','rejected'].forEach(function(s){
+          var opt=document.createElement('option');
+          opt.value=s;
+          opt.textContent=s.charAt(0).toUpperCase()+s.slice(1);
+          if(s===a.status)opt.selected=true;
+          sel.appendChild(opt);
+        });
+        sel.addEventListener('change',function(){
+          fetch((window.htmlgraphPlanBase||'')+'/api/plans/'+planId+'/feedback',{
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body:JSON.stringify({
+              section:'amendment',
+              action:'amendment_status',
+              value:sel.value,
+              question_id:'amend-'+i
+            })
+          });
+          updateSummary();
+        });
+        item.appendChild(desc);
+        item.appendChild(sel);
+        list.appendChild(item);
+      });
+      updateSummary();
+    })
+    .catch(function(){});
+})();
+</script>
+</div><!-- .plan-content -->
+</body>
+</html>

--- a/.htmlgraph/plans/plan-251676c5.yaml
+++ b/.htmlgraph/plans/plan-251676c5.yaml
@@ -1,0 +1,643 @@
+meta:
+    id: plan-251676c5
+    title: Distribution de-bundle, version-sync, and container launchers
+    description: 'Four-part architecture change: (A) strip bundled binary from plugin — ship CLI and plugin as two artifacts with shared version; (B) add SessionStart version-check hook + htmlgraph doctor + upgrade messaging to prevent plugin/CLI version skew; (C) curl install script + Homebrew tap for frictionless first install; (D) --container launchers that use a shared devcontainer and skip host-state mutations. Inspired by roborev''s binary-first distribution, refined to keep our marketplace presence for discoverability.'
+    created_at: "2026-04-21"
+    status: draft
+    version: 4
+design:
+    problem: |
+        HtmlGraph currently bundles the CLI binary inside the Claude Code plugin tree (`plugin/hooks/bin/`), bloating the marketplace artifact with per-arch binaries and coupling plugin versioning to CLI versioning. When a user updates the plugin via the marketplace while running an older CLI (or vice versa), hooks resolve to the wrong binary with no runtime detection — silent version skew with no recovery path. There is no first-run install story beyond `claude plugin install`: no curl script, no Homebrew tap, no `htmlgraph doctor` to surface mismatches. The `--dev` launcher mutates host `~/.claude/plugins/` state (remove/reinstall marketplace plugin) that bleeds across machines when users sync dotfiles, and fails outright in a container where the host state is ephemeral or absent. These four pain points — bundle bloat, version skew, install friction, host mutation — are the concrete problems this plan resolves.
+    goals:
+        - '**Binary de-bundled** — plugin artifact ships zero binaries; size reduction >80% for the marketplace tarball'
+        - '**Version skew detected** — SessionStart hook blocks (exit 2) on missing CLI and warns (exit 1) on mismatch, with actionable remediation message surfaced in-session'
+        - '**Frictionless first install** — a single `curl | bash` command installs the CLI binary; `htmlgraph doctor` reports plugin-vs-CLI alignment across all three harnesses'
+        - '**Stable version contract** — `plugin.json` version and `htmlgraph --version` are read by the same hook code; any divergence is caught by the version-check handler and by `htmlgraph doctor`'
+        - '**Container-safe launchers** — `--container` flag (and `HTMLGRAPH_DEVCONTAINER=1` auto-detect) skips all host-state mutations; yolo `--container` implies `--no-worktree`'
+        - '**Two-artifact deploy** — `deploy-all.sh` emits binary release (GitHub Releases + Homebrew tap) and plugin release (marketplace) as separate, version-tagged artifacts from the same commit'
+    constraints:
+        - Must retain Claude Code marketplace presence — discoverability via marketplace is a deliberate divergence from roborev's binary-only model; the plugin cannot become marketplace-free
+        - Must not break existing installs — the SessionStart version-check must degrade to a non-blocking warning (exit 1, not exit 2) for users on older CLIs that pre-date de-bundling, never a hard block that kills their session
+        - Cross-platform coverage limited to macOS (arm64, x86_64) and Linux (arm64, x86_64) — Windows is out of scope for v1; install script must not silently fail on Windows, it must error clearly
+        - Install script must respect corporate shell constraints — `HTMLGRAPH_NO_MODIFY_PATH` skips PATH edits, `HTMLGRAPH_INSTALL_DIR` overrides install location, `HTMLGRAPH_VERSION` pins a specific release; mirrors roborev's escape-hatch pattern
+        - Plugin must remain functional in all three harnesses — Claude Code, Codex CLI, and Gemini CLI all consume generated trees from `plugin/` and `packages/plugin-core/manifest.json`; de-bundling and port generation must be harness-neutral
+        - Workstream D (container launchers) is strictly gated on A — the container image can only `go install` from source or curl the binary; it must not depend on a bundled binary that no longer exists after A lands
+        - Plugin and CLI versions are tagged and published atomically by a single release workflow. Mid-release skew is bounded to job duration; the SessionStart version check must tolerate this window by emitting only a warning (exit 1), never a hard block (exit 2) on minor/patch divergence.
+    approved: false
+    comment: ""
+slices:
+    - id: slice-1
+      num: 1
+      title: Delete plugin/hooks/bin/ and update build script to stop copying there
+      what: |
+        Remove the bundled binary from the Claude Code plugin tree. Specifically: delete `plugin/hooks/bin/htmlgraph`, `plugin/hooks/bin/htmlgraph-dev`, `plugin/hooks/bin/bootstrap.sh`, and `plugin/hooks/bin/install-binary.sh` from source control. Update `plugin/build.sh` (invoked by `htmlgraph build`) to stop installing the binary into `plugin/hooks/bin/`. Update `cmd/htmlgraph/build.go` to remove the walk-up path that resolves the binary from `plugin/hooks/bin/htmlgraph` (the `os.Executable()` two-level walk-up at line 111). Update `cmd/htmlgraph/serve.go` comment at line 159 that refers to `plugin/hooks/bin/htmlgraph`. All hook commands in `plugin/hooks/hooks.json` already use `htmlgraph hook <handler>` via PATH — confirm no hook still references the bin/ path. The `htmlgraph build` output path becomes only the PATH-installed binary (e.g. `~/.local/bin/htmlgraph`).
+      why: |
+        The bundled binary in `plugin/hooks/bin/` is the root cause of plugin artifact bloat and the CLI/plugin version-skew problem. Removing it is the prerequisite for workstreams B (version-check hook), C (install UX), and D (container launchers). Without this slice the marketplace artifact stays oversized and the hook-via-PATH model is not the sole truth.
+      files:
+        - plugin/hooks/bin/htmlgraph
+        - plugin/hooks/bin/htmlgraph-dev
+        - plugin/hooks/bin/bootstrap.sh
+        - plugin/hooks/bin/install-binary.sh
+        - plugin/build.sh
+        - cmd/htmlgraph/build.go
+        - cmd/htmlgraph/serve.go
+      deps: []
+      done_when:
+        - '`plugin/hooks/bin/` directory no longer exists in source control'
+        - '`git ls-files plugin/hooks/bin/` returns empty'
+        - '`htmlgraph build` succeeds without writing anything to `plugin/hooks/bin/`'
+        - '`go build ./...` and `go vet ./...` pass with no errors'
+        - The marketplace plugin directory (sans bin/) is under 10 MB
+        - '`htmlgraph build` resolves its own binary and build.sh location without relying on `plugin/hooks/bin/` parentage — uses `os.Executable()` for the binary path and a known repo-root discovery (walk-up to `.htmlgraph/` directory) for build.sh'
+      effort: S
+      risk: Med
+      tests: |
+        Unit: TestResolveBuildScript in cmd/htmlgraph (update or add) — assert that
+          the walk-up strategy does not reference a hooks/bin path, and that
+          CLAUDE_PLUGIN_ROOT still resolves correctly.
+        Integration: Run `htmlgraph build` in the devcontainer, confirm binary lands
+          in ~/.local/bin/htmlgraph and plugin/hooks/bin/ is absent.
+        Regression: All existing go test ./... must pass. Confirm `htmlgraph hook
+          session-start` resolves from PATH (not bin/) after build.
+      approved: false
+      comment: ""
+    - id: slice-2
+      num: 2
+      title: Add post-build assertion to plugin build-ports verifying binary-free hook commands
+      what: |
+        `htmlgraph plugin build-ports` is already registered in `cmd/htmlgraph/plugin_build_ports.go` (line 47) and current adapter code contains no binary copy logic — the de-bundle for Codex and Gemini trees is already functionally complete. This slice adds a correctness guard: add a post-build assertion in `pluginBuildPortsCmd` (in `plugin_build_ports.go`) that iterates all generated hook command strings across the three output trees (`plugin/hooks/hooks.json`, `packages/codex-marketplace/.agents/plugins/htmlgraph/hooks.json`, `packages/gemini-extension/hooks.json`) and fails with a clear error if any command references a path containing `plugin/hooks/bin/` or any other local filesystem path. The assertion must match the pattern `^htmlgraph hook ` for all hook commands and reject anything else. This prevents future regressions where a manifest edit accidentally reintroduces a local-path hook reference.
+      why: |
+        The current build-ports adapters already emit binary-free trees, but there is no guard preventing a future manifest edit from reintroducing a local binary path. The assertion is a zero-overhead regression gate — it runs at build time, costs nothing at runtime, and makes the binary-free invariant machine-enforceable rather than convention-based.
+      files:
+        - cmd/htmlgraph/plugin_build_ports.go
+      deps:
+        - 1
+      done_when:
+        - '`find packages/ -name ''bin'' -type d` returns empty after `htmlgraph plugin build-ports`'
+        - Every hook command in all three `hooks.json` files matches `^htmlgraph hook `
+        - '`htmlgraph plugin build-ports` exits non-zero and prints a clear error if any generated hook command contains `plugin/hooks/bin/` or a local file path'
+        - '`htmlgraph plugin build-ports` exits 0 and prints no warnings about binary paths on a clean tree'
+        - '`go test ./cmd/htmlgraph/...` passes including any new assertion unit tests'
+      effort: S
+      risk: Low
+      tests: |
+        Unit: Add TestBuildPortsAssertionFails — inject a fake hooks.json with a local-path command into a temp dir, assert pluginBuildPortsCmd returns a non-nil error containing "plugin/hooks/bin/". Add TestBuildPortsAssertionPasses — clean tree exits 0.
+        Integration: Run `htmlgraph plugin build-ports` in the devcontainer, then
+          grep all generated hooks.json files for local paths — expect zero matches.
+        Regression: Existing plugin_build_ports tests (if any) must still pass.
+          `go build ./...` clean.
+      approved: false
+      comment: ""
+    - id: slice-3
+      num: 3
+      title: Split deploy-all.sh into binary-release and plugin-release artifacts with shared version file
+      what: |
+        Refactor `scripts/deploy-all.sh` into two independently runnable phases within the same script (or two separate scripts called from a thin orchestrator): (a) `deploy-binary` — bumps Go version via ldflags, pushes git tag,
+            triggers GoReleaser via `release-go.yml`, updates the Homebrew formula
+            SHA values in `packages/homebrew/update-formula.sh`;
+        (b) `deploy-plugin` — bumps `plugin/.claude-plugin/plugin.json` version,
+            regenerates port trees via `htmlgraph plugin build-ports`, pulls and
+            updates `~/.claude/plugins/marketplaces/htmlgraph` marketplace clone.
+        Introduce a single shared version source — the `version` field in `packages/plugin-core/manifest.json` (already present at version 0.55.5) — that both phases read. This field is the canonical version; the CLI binary receives it via ldflags at build time, and `plugin.json` is updated from it during `deploy-plugin`. Both phases must read the same version string so CLI binary and plugin artifact always share a version. Add `--binary-only` and `--plugin-only` flags so CI can run each phase independently. Both phases are triggered by a single GitHub Actions workflow run on the same tag and commit, bounding the skew window to the job duration (<2 min).
+      why: |
+        Currently `deploy-all.sh` is a monolith that updates both artifacts in one run. The curl install script (slice 7) and Homebrew tap (slice 8) need to reference stable binary release URLs that are published before the marketplace plugin is updated — or the user can be left with a mismatched install. Splitting into two phases with a shared version file is also the prerequisite for automating the plugin-only release in CI.
+      files:
+        - scripts/deploy-all.sh
+        - packages/homebrew/update-formula.sh
+        - packages/homebrew/htmlgraph.rb
+        - packages/plugin-core/manifest.json
+      deps:
+        - 1
+        - 2
+      done_when:
+        - '`./scripts/deploy-all.sh 0.99.0 --binary-only --dry-run` exits 0 and prints only binary-related steps'
+        - '`./scripts/deploy-all.sh 0.99.0 --plugin-only --dry-run` exits 0 and prints only plugin-related steps'
+        - Both phases read version from `packages/plugin-core/manifest.json` (no hard-coded version in two places)
+        - '`./scripts/deploy-all.sh 0.99.0 --no-confirm --dry-run` (full run) exits 0'
+        - Release pipeline publishes binary and plugin within a single GitHub Actions workflow run (same tag, same commit); skew window is bounded to job duration (<2 min)
+      effort: M
+      risk: High
+      tests: |
+        Unit: Bash unit tests (bats or inline assertions) for argument parsing —
+          --binary-only and --plugin-only flags are mutually exclusive, VERSION
+          validation rejects non-semver strings.
+        Integration: Run `./scripts/deploy-all.sh 0.99.0 --dry-run --no-confirm`
+          in CI, assert both phases print correct step lists without executing.
+        Regression: Existing `./scripts/deploy-all.sh --build-only` must still
+          work. GoReleaser workflow (`release-go.yml`) trigger path unchanged.
+      approved: false
+      comment: ""
+    - id: slice-4
+      num: 4
+      title: Refactor version-check into shared decision function and add missing-CLI block path to SessionStart
+      what: |
+        The version-check logic already partially exists: `internal/hooks/version_check.go` has `readPluginVersion()`, `versionMismatchWarning()`, and `CLIVersion`. `internal/hooks/session_start.go` (line 226) already calls `versionMismatchWarning()`. The dispatch layer is `cmd/htmlgraph/hook.go` (cobra `hookSubcmd`), not `internal/hooks/runner.go`. This slice makes two targeted changes: (1) Add a new exported function `CheckVersionAlignment(pluginVersion, cliVersion string) (status string, message string)` in `internal/hooks/version_check.go` that returns one of ("ok", "warn", "block") and an accompanying message. "block" is returned when cliVersion is empty (CLI missing). "warn" is returned on minor/patch divergence. "ok" is returned on match or dev builds. This function is the single comparison logic reused by both the session_start handler (slice 4) and `htmlgraph doctor` (slice 5). (2) Extend the existing session_start handler in `internal/hooks/session_start.go` to call `CheckVersionAlignment` and, when the result is "block" (CLI missing), return a `BlockExit2Error` (the pattern already used in hook.go lines 195-198) with JSON `{"decision":"block","reason":"htmlgraph CLI not found. Install: curl -fsSL https://raw.githubusercontent.com/shakestzd/htmlgraph/main/install.sh | sh"}`. Do NOT add a second SessionStart hook entry. One handler, one path. Remove `internal/hooks/runner.go` from scope — the dispatch layer is hook.go.
+      why: |
+        Without a SessionStart gate for the missing-CLI case, a user can install the plugin from the marketplace and run Claude Code with no CLI installed — all hooks silently fail. The shared `CheckVersionAlignment` function eliminates duplication between the hook handler and `htmlgraph doctor`, ensuring consistent comparison semantics across both surfaces.
+      files:
+        - internal/hooks/version_check.go
+        - internal/hooks/session_start.go
+      deps:
+        - 1
+      done_when:
+        - '`CheckVersionAlignment("", "dev")` returns ("block", ...) — missing CLI case'
+        - '`CheckVersionAlignment("0.55.5", "0.55.5")` returns ("ok", "") — match case'
+        - '`CheckVersionAlignment("0.55.4", "0.55.5")` returns ("warn", ...) — mismatch case'
+        - Session_start handler calls CheckVersionAlignment and returns BlockExit2Error when status is "block"
+        - No second SessionStart entry added to hooks.json or manifest.json
+        - '`go test ./internal/hooks/...` passes including new TestCheckVersionAlignment tests'
+      effort: M
+      risk: Med
+      tests: |
+        Unit: TestCheckVersionAlignment_Missing, TestCheckVersionAlignment_Match,
+          TestCheckVersionAlignment_Mismatch in internal/hooks/version_check_test.go —
+          test all three return paths with table-driven cases.
+        Integration: Install the rebuilt plugin in a devcontainer with a deliberate
+          version mismatch, start a Claude Code session, verify the additionalContext
+          message appears in the conversation.
+        Regression: Existing TestVersionMismatchWarning and TestStripGitDescribeSuffix
+          in version_check_test.go must still pass. session_start_test.go must still pass.
+      approved: false
+      comment: ""
+    - id: slice-5
+      num: 5
+      title: Add htmlgraph doctor subcommand with cross-harness version matrix
+      what: |
+        Add `cmd/htmlgraph/doctor.go` implementing `htmlgraph doctor` as a new Cobra subcommand registered in `cmd/htmlgraph/main.go`. The command queries: (a) CLI binary version — accessed directly via the `version` package-level var in `cmd/htmlgraph/main.go` (set via ldflags; doctor.go is in the same package so it can read it directly without an internal/version package); (b) Claude Code plugin version — read `~/.claude/plugins/marketplaces/htmlgraph`
+            or `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`;
+        (c) Codex plugin version — read
+            `~/.codex/plugins/htmlgraph/` (equivalent path, probe for a `plugin.json` or
+            `htmlgraph.json` manifest);
+        (d) Gemini extension version — read
+            `~/.gemini/extensions/htmlgraph/gemini-extension.json`.
+        For each, output a row: harness name, installed path, installed version, match/mismatch vs CLI version. Reuse `readPluginVersion()` from `internal/hooks/version_check.go` (refactor to accept an arbitrary path) and reuse `CheckVersionAlignment()` from slice 4 for consistent comparison logic. Print the matrix as a plain-text table (no external dependency). Exit 1 if any harness has a mismatch; exit 0 if all match or are not installed. Note: `internal/version/version.go` does NOT exist; the version string lives as `var version string` in `cmd/htmlgraph/main.go` — access it directly from the same package.
+      why: |
+        Slice 4 handles the automated SessionStart gate; `htmlgraph doctor` gives humans an explicit diagnostic surface for debugging installs across all three harnesses — especially useful after `htmlgraph upgrade` or a marketplace update. Pattern mirrors roborev's `roborev skills` matrix. Reusing `CheckVersionAlignment` from slice 4 ensures consistent comparison semantics.
+      files:
+        - cmd/htmlgraph/doctor.go
+        - cmd/htmlgraph/main.go
+        - internal/hooks/version_check.go
+      deps:
+        - 4
+      done_when:
+        - '`htmlgraph doctor` prints a table with at least three rows (claude, codex, gemini)'
+        - '`htmlgraph doctor` exits 1 when any harness version does not match the CLI version'
+        - '`htmlgraph doctor` exits 0 when all detected harness versions match or none are installed'
+        - '`go test ./cmd/htmlgraph/...` passes including TestDoctorCmd'
+        - doctor.go uses the `version` var from main.go directly (no internal/version package)
+        - doctor.go calls CheckVersionAlignment from slice 4 for all comparison logic
+      effort: M
+      risk: Low
+      tests: |
+        Unit: TestDoctorCmd in cmd/htmlgraph/doctor_test.go — stub plugin manifest
+          files under a temp home dir, assert table rows and exit code.
+        Integration: Run `htmlgraph doctor` in the devcontainer after a fresh build,
+          confirm at least the claude row populates with a version.
+        Regression: `go build ./...` clean. Existing plugin_ensure_test.go must pass
+          (doctor and plugin_ensure share version-reading helpers).
+      approved: false
+      comment: ""
+    - id: slice-6
+      num: 6
+      title: Extend htmlgraph upgrade to print post-upgrade plugin-update instructions
+      what: |
+        Edit `cmd/htmlgraph/upgrade_cmd.go` function `runUpgrade`. After the self-test at line 120 confirms the new binary runs, append to stdout: "CLI upgraded to vX.Y.Z. To sync the plugin, run:
+          /plugin marketplace htmlgraph   (inside Claude Code)
+        Then run: htmlgraph doctor   to verify all harnesses are in sync." Also add a `--check` output line that prints plugin versions detected by the same logic used in slice 5 (`htmlgraph doctor` can be called internally). No new flags — this is purely additive output.
+      why: |
+        After `htmlgraph upgrade` the CLI binary is at the new version but the marketplace plugin is at the old version until the user manually updates it. Without the reminder, users are left in the skewed state that slice 4 detects. Closing the loop here makes the version-sync story end-to-end.
+      files:
+        - cmd/htmlgraph/upgrade_cmd.go
+        - cmd/htmlgraph/upgrade_cmd_test.go
+      deps:
+        - 5
+      done_when:
+        - '`htmlgraph upgrade --check` output includes a line mentioning `/plugin marketplace htmlgraph`'
+        - After `htmlgraph upgrade` (mocked), stdout includes `htmlgraph doctor`
+        - '`go test ./cmd/htmlgraph/... -run TestUpgrade` passes'
+      effort: S
+      risk: Low
+      tests: |
+        Unit: TestUpgradePostMessage in upgrade_cmd_test.go — mock the HTTP version
+          fetch and binary replace, assert stdout contains the post-upgrade message.
+        Integration: Run `htmlgraph upgrade --check` in devcontainer, confirm new
+          message lines appear.
+        Regression: Existing TestUpgradeCmd* tests must still pass.
+      approved: false
+      comment: ""
+    - id: slice-7
+      num: 7
+      title: Add env-var escape hatches to install.sh (HTMLGRAPH_INSTALL_DIR, HTMLGRAPH_NO_MODIFY_PATH, HTMLGRAPH_VERSION)
+      what: |
+        Edit `install.sh` to honour three environment variables that override CLI flags when set: - `HTMLGRAPH_INSTALL_DIR` — overrides `--install-dir` (current default
+          `~/.local/bin`); used by corporate-managed shells and CI.
+        - `HTMLGRAPH_NO_MODIFY_PATH` — when set to `1`, skip the shell-rc PATH
+          modification block unconditionally.
+        - `HTMLGRAPH_VERSION` — when set, install that version instead of
+          fetching the latest GitHub release; overrides `--version` flag if both
+          are set (env takes precedence for scriptability).
+        The existing `--install-dir` and `--version` flags must still work as before. Add a `--help` section documenting all three env vars. No other changes to install.sh logic.
+      why: |
+        Corporate environments and CI pipelines need deterministic, non-interactive installs without shell-rc mutation. These are the exact escape hatches roborev ships (`ROBOREV_INSTALL_DIR`, `ROBOREV_NO_MODIFY_PATH`). Without them, `curl | sh` is not safe to run in CI. Slice 8 (Homebrew tap) is independent; slices 7 and 8 together complete the install UX story.
+      files:
+        - install.sh
+      deps:
+        - 3
+      done_when:
+        - '`HTMLGRAPH_INSTALL_DIR=/tmp/testbin sh install.sh` installs binary to `/tmp/testbin/htmlgraph`'
+        - '`HTMLGRAPH_NO_MODIFY_PATH=1 sh install.sh` does not modify ~/.bashrc or ~/.zshrc'
+        - '`HTMLGRAPH_VERSION=0.35.0 sh install.sh` downloads version 0.35.0 regardless of latest'
+        - All three env vars are documented in `install.sh --help` output
+      effort: S
+      risk: Low
+      tests: |
+        Unit: Bash test (bats or inline) — set each env var in isolation,
+          mock the download step, assert correct install path / version / rc mutation.
+        Integration: Run `HTMLGRAPH_INSTALL_DIR=/tmp/hg-test sh install.sh` in
+          the devcontainer, verify binary appears at /tmp/hg-test/htmlgraph.
+        Regression: Existing `--install-dir` and `--version` flag tests (if any)
+          must still pass. Default install to ~/.local/bin must still work.
+      approved: false
+      comment: ""
+    - id: slice-8
+      num: 8
+      title: Publish Homebrew tap formula and wire version bump into deploy pipeline
+      what: |
+        Create or update the external tap repo `shakestzd/homebrew-htmlgraph` so that `brew install shakestzd/htmlgraph/htmlgraph` works. The formula template already exists at `packages/homebrew/htmlgraph.rb`. Steps: (a) Confirm the tap repo exists at github.com/shakestzd/homebrew-htmlgraph
+            (create if not); its only required file is `Formula/htmlgraph.rb`.
+        (b) Update `packages/homebrew/update-formula.sh` to accept the new version
+            and SHA256 values as arguments (already partially implemented), compute
+            SHA256 from the GoReleaser-published `.tar.gz` assets on GitHub Releases,
+            patch `Formula/htmlgraph.rb` in the tap repo, and push a commit.
+        (c) Wire `update-formula.sh` into `scripts/deploy-all.sh`'s `deploy-binary`
+            phase (slice 3) so formula is bumped automatically on every binary release.
+        Document the one-time tap repo setup in `packages/homebrew/README.md`.
+      why: |
+        `brew install` is the default install path for macOS developers. Without a tap the Homebrew formula placeholder in `packages/homebrew/htmlgraph.rb` has SHA256 stubs and is not installable. Closing this gap completes the install UX workstream for macOS users and is required for public release.
+      files:
+        - packages/homebrew/htmlgraph.rb
+        - packages/homebrew/update-formula.sh
+        - scripts/deploy-all.sh
+      deps:
+        - 3
+      done_when:
+        - Tap repo `shakestzd/homebrew-htmlgraph` exists with an initial `Formula/htmlgraph.rb` and PAT-based push credentials are configured in this repo's GitHub Actions secrets (prereq — must be satisfied before this slice can complete)
+        - '`brew install shakestzd/htmlgraph/htmlgraph` succeeds on macOS (arm64 and amd64)'
+        - '`packages/homebrew/update-formula.sh 0.99.0` patches version and SHA256 placeholders'
+        - '`scripts/deploy-all.sh --binary-only` invokes update-formula.sh as a step'
+        - Formula file contains no SHA256 placeholder strings after a dry-run update
+      effort: M
+      risk: Low
+      tests: |
+        Unit: Bash test for update-formula.sh — mock curl SHA256 fetch, assert
+          Formula/htmlgraph.rb is patched with correct version and SHA256.
+        Integration: Run update-formula.sh against a real GitHub release asset,
+          confirm SHA256 matches `shasum -a 256` output.
+        Regression: deploy-all.sh --build-only must still pass (formula update skipped).
+      approved: false
+      comment: Requires one-time creation of github.com/shakestzd/homebrew-htmlgraph — boundary invented here; research only says 'new repo'. Flagged for orchestrator review.
+    - id: slice-9
+      num: 9
+      title: 'Add internal/launcher/container/ package: preflight, wrap, paths'
+      what: |
+        Create package `internal/launcher/container/` with three files: - `preflight.go` — exports `IsDevcontainer() bool` that returns true when
+          `HTMLGRAPH_DEVCONTAINER=1` is set OR `/workspaces` exists on the
+          filesystem (VS Code devcontainer convention). Also exports
+          `MustHaveBinaryInContainer() error` that checks the binary is on PATH
+          inside the container and returns a human-readable error if not.
+        - `paths.go` — exports `PluginRoots() []string` returning the container-local
+          paths for Claude, Codex, and Gemini config dirs (e.g.
+          `/home/vscode/.claude`, `/home/vscode/.codex`, `/home/vscode/.gemini`).
+        - `wrap.go` — exports `WrapArgs(args []string) []string` that prepends
+          any container-specific environment setup (e.g. ensuring PATH includes
+          `/home/vscode/.local/bin`) before the underlying command args. Initially
+          this may be a no-op pass-through; the structure is what matters for the
+          subsequent slice.
+        Write unit tests in `internal/launcher/container/container_test.go`.
+      why: |
+        Workstream D (slices 9-11) depends on a clean abstraction layer that the launcher commands (claude.go, codex.go, gemini.go, yolo.go) can import without duplicating devcontainer detection logic. This slice creates that layer; slice 10 wires it into the launcher commands.
+      files:
+        - internal/launcher/container/preflight.go
+        - internal/launcher/container/paths.go
+        - internal/launcher/container/wrap.go
+        - internal/launcher/container/container_test.go
+      deps:
+        - 1
+      done_when:
+        - '`IsDevcontainer()` returns true when HTMLGRAPH_DEVCONTAINER=1 is set'
+        - '`IsDevcontainer()` returns true in a devcontainer where `/workspaces` exists'
+        - '`IsDevcontainer()` returns false in a normal host environment'
+        - '`go test ./internal/launcher/container/...` passes'
+        - '`go vet ./internal/launcher/container/...` clean'
+      effort: S
+      risk: Low
+      tests: |
+        Unit: TestIsDevcontainer_EnvSet, TestIsDevcontainer_WorkspacesPath,
+          TestIsDevcontainer_HostEnv, TestPluginRoots, TestWrapArgs in container_test.go.
+        Integration: Run `go test` inside the devcontainer — TestIsDevcontainer_WorkspacesPath
+          should pass automatically.
+        Regression: `go build ./...` clean. No other internal packages affected.
+      approved: false
+      comment: ""
+    - id: slice-10
+      num: 10
+      title: Add --container flag to claude/codex/gemini/yolo and wire HTMLGRAPH_DEVCONTAINER=1
+      what: |
+        Edit `cmd/htmlgraph/claude.go`, `cmd/htmlgraph/codex.go`, `cmd/htmlgraph/gemini.go`, `cmd/htmlgraph/yolo.go`, and `cmd/htmlgraph/dev.go` to add a `--container` boolean flag. When `--container` is true (or `HTMLGRAPH_DEVCONTAINER=1` is set), the launcher must apply the following, scoped to only those launchers where the mutation actually exists: (1) In `claude.go` and `yolo.go` (the only launchers that call `removeMarketplaceHtmlgraph()`): skip the `removeMarketplaceHtmlgraph()` call. Also skip `setPluginEnabled()` calls that modify `~/.claude/settings.json`, the `os.RemoveAll` calls that wipe `~/.claude/plugins/marketplaces/htmlgraph` and `~/.claude/plugins/cache/`, and any `installOrUpdatePlugin()` call. List of actual mutations to skip in claude.go: removeMarketplaceHtmlgraph() (line 161), setPluginEnabled() (line 249), os.RemoveAll on plugin cache dirs (lines 123-130). (2) In `codex.go` and `gemini.go`: `--container` is a no-op stub flag (accepted, ignored, clearly documented in code comments) — these launchers have no host-mutation calls equivalent to removeMarketplaceHtmlgraph, so there is nothing to skip. Do not claim to skip mutations that do not exist. (3) Call `container.IsDevcontainer()` from slice 9 to auto-detect the flag when the env var is set in all launchers. (4) In `yolo.go`, when `--container` is active, force `noWorktree=true` and log a single message "container mode: worktree creation skipped". (5) In `dev.go`, default `container` to `container.IsDevcontainer()` so the devcontainer auto-applies container mode.
+      why: |
+        In a devcontainer the host filesystem is bind-mounted; `removeMarketplaceHtmlgraph` and the associated cache-wipe calls in claude.go mutate host paths that may be volume-mounted or non-writable. Skipping those specific mutations when `--container` prevents errors and unexpected side effects. `--container` also makes yolo safe to run inside the devcontainer without worktree isolation (which requires host git). Codex and gemini launchers have no equivalent host mutations, so stub-only is the honest scope.
+      files:
+        - cmd/htmlgraph/claude.go
+        - cmd/htmlgraph/codex.go
+        - cmd/htmlgraph/gemini.go
+        - cmd/htmlgraph/yolo.go
+        - cmd/htmlgraph/dev.go
+      deps:
+        - 9
+      done_when:
+        - '`htmlgraph claude --container` starts without calling removeMarketplaceHtmlgraph, setPluginEnabled, or os.RemoveAll on plugin cache dirs'
+        - '`htmlgraph yolo --container` logs ''container mode: worktree creation skipped'' and sets noWorktree'
+        - '`HTMLGRAPH_DEVCONTAINER=1 htmlgraph yolo` behaves identically to `htmlgraph yolo --container`'
+        - codex.go and gemini.go accept `--container` without error but document it as a no-op in code comments
+        - '`go test ./cmd/htmlgraph/...` passes'
+      effort: M
+      risk: Med
+      tests: |
+        Unit: TestContainerFlagSkipsMarketplace in claude_test.go (or new file) —
+          mock removeMarketplaceHtmlgraph, assert it is not called when --container.
+          TestYoloContainerNoWorktree — assert noWorktree=true when --container.
+          TestCodexContainerFlagNoOp — assert codex.go accepts --container without error.
+        Integration: Run `htmlgraph claude --container --dry-run` (if dry-run exists)
+          in devcontainer, confirm no marketplace operations are attempted.
+        Regression: Existing codex_test.go, gemini_test.go, yolo_test.go must pass.
+          Default (non-container) behavior unchanged.
+      approved: false
+      comment: ""
+    - id: slice-11
+      num: 11
+      title: Add .devcontainer/Dockerfile and wire postCreateCommand to install htmlgraph CLI
+      what: |
+        Edit `.devcontainer/Dockerfile` (already exists) to add a layer that runs `go install ./cmd/htmlgraph/` so the CLI binary is available at container creation time without requiring a manual `htmlgraph build`. If the project is bind-mounted (not baked into the image), the `postCreateCommand` in `.devcontainer/devcontainer.json` (currently `bash .devcontainer/post-create.sh`) handles the install instead — add `go install ./cmd/htmlgraph/` as a step in `post-create.sh` before the existing htmlgraph references at line 28. Ensure `GOBIN` is set to `/home/vscode/.local/bin` in the Dockerfile ENV so the installed binary lands on PATH. Update `post-create.sh` to verify `htmlgraph version` runs after install and bail with a clear error if it does not.
+      why: |
+        Currently the devcontainer relies on `htmlgraph build` being run manually after `post-create.sh`. If the binary is missing, every htmlgraph CLI call in `post-create.sh` (line 75+) silently fails. Auto-provisioning via `go install` makes the container self-contained and is the recommended devcontainer pattern for Go projects.
+      files:
+        - .devcontainer/Dockerfile
+        - .devcontainer/post-create.sh
+        - .devcontainer/devcontainer.json
+      deps:
+        - 9
+        - 10
+      done_when:
+        - Rebuilding the devcontainer from scratch results in `htmlgraph version` succeeding without manual steps
+        - '`which htmlgraph` inside the container returns `/home/vscode/.local/bin/htmlgraph`'
+        - '`post-create.sh` exits non-zero with a clear error if `htmlgraph version` fails after install'
+      effort: S
+      risk: Low
+      tests: |
+        Unit: No Go unit tests — bash assertion in post-create.sh itself is the gate.
+        Integration: Rebuild the devcontainer in CI (GitHub Actions devcontainer-verify
+          workflow if it exists, or add one), assert `htmlgraph version` exits 0.
+        Regression: Existing `scripts/devcontainer-verify.sh` must still pass.
+          post-create.sh must not break for existing volume-mount setups.
+      approved: false
+      comment: ""
+questions:
+    - id: q-install-url
+      text: Should the curl install script use a dedicated domain or GitHub's raw content URL?
+      description: |
+        The install script needs a stable, memorable URL. Dedicated domains (htmlgraph.dev/io/sh) provide better branding and match roborev's precedent but require domain purchase and GitHub Pages hosting setup. GitHub raw URLs (raw.githubusercontent.com/shakestzd/htmlgraph/main/install.sh) cost nothing and are migratable to a domain later. For v1, GitHub-raw minimizes scope and external dependencies while remaining professional.
+      recommended: github-raw
+      options:
+        - key: dedicated-domain
+          label: 'A: Dedicated Domain — Buy htmlgraph.{dev,io,sh}, point to GitHub Pages, matches roborev.io precedent'
+        - key: github-raw
+          label: 'B: GitHub Raw URL — Zero cost, clunkier but functional, migratable to domain later'
+      answer: null
+    - id: q-version-skew-severity
+      text: How strictly should SessionStart block or warn when plugin and CLI versions don't match?
+      description: |
+        The version-check hook runs on every SessionStart. Strict blocking (exit 2 on any mismatch) prevents silent breakage but creates upgrade friction. Warn-only (exit 1) surfaces the problem without blocking work. Block-if-major-mismatch splits the difference — allows patch/minor updates but enforces major version alignment. Roborev forces full sync by design; HtmlGraph's marketplace distribution means skew is inevitable and users need some grace period.
+      recommended: block-if-major-mismatch
+      options:
+        - key: warn-only
+          label: 'A: Warn Only — Exit 1, render additionalContext, session proceeds with known mismatch'
+        - key: block-if-major-mismatch
+          label: 'B: Block on Major Mismatch — Exit 2 if major versions differ, warn on minor/patch'
+        - key: block-any-mismatch
+          label: 'C: Block Any Mismatch — Exit 2 on any version difference, roborev''s strict model'
+      answer: null
+    - id: q-binary-distribution-channels
+      text: 'Which install channels should ship in v1: curl only, or curl + homebrew?'
+      description: |
+        Curl script gives universal coverage and works offline. Homebrew adds convenience for macOS users (brew install shakestzd/htmlgraph/htmlgraph) but requires tap setup and maintenance. Go install (go install github.com/shakestzd/htmlgraph/cmd/htmlgraph@latest) requires public GitHub and appeals to developers. Curl-plus-brew matches roborev's v1 approach and covers 90% of users without overscoping.
+      recommended: curl-plus-brew
+      options:
+        - key: curl-only
+          label: 'A: Curl Only — Ship install.sh, defer brew/go-install to later'
+        - key: curl-plus-brew
+          label: 'B: Curl + Brew — curl script + homebrew tap, matches roborev''s coverage'
+        - key: curl-brew-go-install
+          label: 'C: All Three — curl, homebrew, and go install, maximum coverage'
+      answer: null
+    - id: q-container-image-base
+      text: 'Which base image for .devcontainer/Dockerfile: official Go, DevContainers base, or Claude Code prebuilt?'
+      description: |
+        Official Go image (golang:1.24-bookworm) starts minimal and requires installing Claude/Codex/Gemini CLIs. DevContainers base (mcr.microsoft.com/devcontainers/base:bookworm) is what the existing devcontainer uses, includes dev tools, and is maintained for stability. Claude Code prebuilt would be ideal but doesn't exist yet. Using the existing devcontainers-base maintains consistency with the current setup and is battle-tested.
+      recommended: devcontainers-base
+      options:
+        - key: official-go
+          label: 'A: Official Go Image — golang:1.24-bookworm, then install CLIs'
+        - key: devcontainers-base
+          label: 'B: DevContainers Base — mcr.microsoft.com/devcontainers/base:bookworm, current approach'
+        - key: claude-code-prebuilt
+          label: 'C: Claude Code Prebuilt — anthropic/claude-code:latest (not yet published)'
+      answer: null
+    - id: q-hook-event-ingestion-scope
+      text: Should this plan include ingesting new Claude Code hook events (WorktreeCreate, FileChanged, etc.)?
+      description: |
+        Claude Code shipped new hook events in Jan 2026: FileChanged, CwdChanged, ConfigChange, WorktreeCreate/Remove, Elicitation, etc. WorktreeCreate and WorktreeRemove are particularly relevant to yolo's worktree flow. Including them adds depth but expands this plan's scope. Deferring to a separate design pass keeps v1 focused on distribution while leaving room for a dedicated observability pass.
+      recommended: out-of-scope
+      options:
+        - key: out-of-scope
+          label: 'A: Out of Scope — Defer to separate plan, keep this plan focused on distribution'
+        - key: include-worktree-events
+          label: 'B: Include Worktree Events — Add WorktreeCreate/Remove since yolo depends on worktrees'
+        - key: include-all-new-events
+          label: 'C: Include All New Events — Opportunistic ingestion of all new hook events'
+      answer: null
+    - id: q-plugin-json-version-source
+      text: Where should the CLI read the expected plugin version for the version-check hook?
+      description: |
+        Build-time embedding (write plugin.json version into a Go string via -ldflags) is fast but requires rebuilding on every plugin version bump, creating unnecessary coupling. Reading from ${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json at runtime always reflects what Claude Code loaded and needs no build-time wiring. Fetching from GitHub is network-dependent and slow. Reading from plugin root is simplest and most reliable.
+      recommended: read-from-plugin-root
+      options:
+        - key: embedded-at-build-time
+          label: 'A: Embedded at Build Time — Write version into Go string via build flag, fast but couples builds'
+        - key: read-from-plugin-root
+          label: 'B: Read from Plugin Root — Read ${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json at runtime'
+        - key: fetch-from-github-release
+          label: 'C: Fetch from GitHub — Network call to check latest, slow and offline-hostile'
+      answer: null
+    - id: q-shared-version-source
+      text: What should be the canonical shared version source for both CLI binary and plugin artifact?
+      description: |
+        Slice 3 asserts a "shared version file" but the exact path/format matters. Three viable options: (A) New VERSION file at repo root — a plain text file read by ldflags for CLI build and by build-ports for plugin.json rewrite; explicit and grep-friendly but a new artifact to maintain. (B) plugin.json as canonical — plugin/.claude-plugin/plugin.json remains source of truth; CLI reads it at build via ldflags; but plugin.json is generated (never hand-edit), so the actual source is manifest.json. (C) packages/plugin-core/manifest.json as canonical — manifest.json already has a `version` field (currently 0.55.5) and is the source that generates plugin.json; making it authoritative means everything derives from one place with no extra file. Option C is recommended: manifest.json already declares the version, is hand-editable (unlike the generated plugin.json), and is already parsed by build-ports — adding a version-read step is minimal.
+      recommended: manifest-canonical
+      options:
+        - key: version-file
+          label: 'A: New VERSION file — plain text at repo root, read by ldflags and build-ports'
+        - key: plugin-json-canonical
+          label: 'B: plugin.json canonical — plugin.json as version source, but it is generated from manifest'
+        - key: manifest-canonical
+          label: 'C: manifest.json canonical — packages/plugin-core/manifest.json version field is authoritative; everything derives from it'
+      answer: null
+critique:
+    reviewed_at: "2026-04-21"
+    reviewers:
+        - Haiku (design review)
+        - Sonnet (feasibility)
+    assumptions:
+        - id: A1
+          status: verified
+          text: plugin/hooks/bin/ contains bundled binaries that bloat the marketplace artifact
+          evidence: Directory exists in source control with htmlgraph, htmlgraph-dev, bootstrap.sh, install-binary.sh — confirmed by git ls-files
+        - id: A2
+          status: verified
+          text: All hook commands currently use `htmlgraph hook <handler>` via PATH
+          evidence: Inspection of plugin/hooks/hooks.json shows hook commands reference bare `htmlgraph` binary, not the bin/ path
+        - id: A3
+          status: falsified
+          text: htmlgraph plugin build-ports is not yet registered or contains binary copy logic
+          evidence: cmd/htmlgraph/plugin_build_ports.go line 47 shows command is already registered; grepping adapters shows NO binary copy logic — current trees are already binary-free
+        - id: A4
+          status: falsified
+          text: Version-check handler requires a new internal/hooks/runner.go dispatch layer
+          evidence: Dispatch layer is cmd/htmlgraph/hook.go (cobra hookSubcmd); internal/hooks/session_start.go:226 already calls versionMismatchWarning(); runner.go is not the dispatch layer
+        - id: A5
+          status: falsified
+          text: Version string lives in internal/version/version.go
+          evidence: internal/version/version.go does not exist; var version string is in cmd/htmlgraph/main.go, set via ldflags — doctor.go can access it directly as same package
+        - id: A6
+          status: falsified
+          text: codex.go and gemini.go have equivalent removeMarketplaceHtmlgraph() blocks to claude.go
+          evidence: grep of codex.go and gemini.go shows no removeMarketplaceHtmlgraph call; only claude.go:161 and yolo.go:295 call it — codex/gemini have different plugin registration patterns
+        - id: A7
+          status: verified
+          text: deploy-all.sh is a monolith that must be split into binary and plugin phases
+          evidence: scripts/deploy-all.sh reviewed — single script with no --binary-only/--plugin-only flags; refactor required
+    critics:
+        - title: DESIGN CRITIC
+          sections:
+            - heading: Slice Assessment
+              items:
+                - badge: S1
+                  kind: success
+                  text: Slice 1 correctly identifies the root cause and the files to delete. Risk rating Med is appropriate — removing walk-up path logic requires care.
+                - badge: S2
+                  kind: warn
+                  text: 'Slice 2 framing was wrong: build-ports is already registered and adapters already produce binary-free trees. Slice must pivot to a post-build assertion guard, not a removal operation.'
+                - badge: S4
+                  kind: warn
+                  text: Slice 4 listed internal/hooks/runner.go as dispatch layer — incorrect. Dispatch is cmd/htmlgraph/hook.go. Also proposed a second SessionStart entry which contradicts one-handler-one-path principle.
+                - badge: S5
+                  kind: danger
+                  text: Slice 5 referenced internal/version/version.go which does not exist. Doctor must read the version var from cmd/htmlgraph/main.go directly (same package). Filing this as falsified assumption A5.
+                - badge: S10
+                  kind: danger
+                  text: Slice 10 claimed codex.go and gemini.go have equivalent removeMarketplaceHtmlgraph blocks — they do not. Only claude.go and yolo.go have this call. Scope must be corrected to enumerate actual mutations per launcher.
+                - badge: S3
+                  kind: info
+                  text: Slice 3 correctly identifies the deploy monolith problem but must name manifest.json as the shared version source (not a generic 'shared version file').
+            - heading: Gaps & Missing Considerations
+              items:
+                - badge: GAP
+                  kind: warn
+                  text: No question defined the canonical shared version source path. Three options exist (VERSION file, plugin.json, manifest.json) — plan must pick one. Added as q-shared-version-source.
+                - badge: GAP
+                  kind: warn
+                  text: Slice 1 done_when did not address how htmlgraph build locates build.sh without the hooks/bin/ walk-up anchor. Added explicit criterion about os.Executable() + repo-root discovery.
+                - badge: GAP
+                  kind: info
+                  text: Slice 8 Homebrew tap prerequisite (tap repo existence + PAT credentials) was not the first done_when item, making it easy to miss as a blocker.
+                - badge: GAP
+                  kind: info
+                  text: 'Slice 6 had no deps despite requiring doctor logic from slice 5 for its --check enrichment. Added deps: [5].'
+            - heading: Alternative Approaches
+              items:
+                - badge: ALT
+                  kind: info
+                  text: 'Version source: a VERSION file at repo root is simpler to grep and requires no YAML parsing at build time. Tradeoff vs manifest-canonical is one extra file vs coupling to YAML format.'
+                - badge: ALT
+                  kind: info
+                  text: CheckVersionAlignment could be in a separate internal/hooks/version_alignment.go to keep version_check.go focused on reading plugin.json. Consolidating in version_check.go is simpler for this scope.
+                - badge: ALT
+                  kind: info
+                  text: Slice 4 could use a separate cobra subcommand (htmlgraph hook version-check) rather than extending the existing session_start handler. Extending the existing handler is lower surface area and avoids manifest changes.
+                - badge: ALT
+                  kind: info
+                  text: Container detection could use REMOTE_CONTAINERS env var (set by VS Code) in addition to HTMLGRAPH_DEVCONTAINER=1 and /workspaces path check — more robust but more magic.
+        - title: FEASIBILITY CRITIC
+          sections:
+            - heading: What Exists to Leverage
+              items:
+                - badge: EXIST
+                  kind: success
+                  text: 'internal/hooks/version_check.go: readPluginVersion(), versionMismatchWarning(), CLIVersion — refactor path for CheckVersionAlignment is already ~60% done.'
+                - badge: EXIST
+                  kind: success
+                  text: internal/hooks/session_start.go:226 already calls versionMismatchWarning() — adding the block path for missing CLI is an extension, not a new handler.
+                - badge: EXIST
+                  kind: success
+                  text: cmd/htmlgraph/plugin_build_ports.go is already registered (line 47) and adapters produce binary-free output — slice 2 is purely additive (assertion only).
+                - badge: EXIST
+                  kind: success
+                  text: packages/plugin-core/manifest.json has a version field at 0.55.5 — making it canonical for slice 3 requires no new file, just convention.
+            - heading: What the Plan Gets Wrong
+              items:
+                - badge: WRONG
+                  kind: danger
+                  text: Slice 4 files list included internal/hooks/runner.go — this file is not the dispatch layer and should not be modified for hook dispatch.
+                - badge: WRONG
+                  kind: danger
+                  text: Slice 5 files list included internal/version/version.go — file does not exist; version var is in cmd/htmlgraph/main.go.
+                - badge: WRONG
+                  kind: danger
+                  text: Slice 10 claimed equivalent host mutations in codex.go and gemini.go — neither file contains removeMarketplaceHtmlgraph or equivalent. Scope was overstated.
+                - badge: WRONG
+                  kind: warn
+                  text: Slice 2 framed the work as removing binary copy logic that does not exist in adapters. The real work is adding an assertion guard.
+            - heading: Prior Art & Examples
+              items:
+                - badge: ART
+                  kind: info
+                  text: 'roborev distribution model: binary-first, no marketplace — HtmlGraph deliberately diverges by keeping marketplace for discoverability. The version-check hook is HtmlGraph-specific compensation.'
+                - badge: ART
+                  kind: info
+                  text: BlockExit2Error pattern in cmd/htmlgraph/hook.go lines 195-198 — already established for blocking hooks; slice 4's missing-CLI block should reuse this pattern.
+                - badge: ART
+                  kind: info
+                  text: roborev escape hatches (ROBOREV_INSTALL_DIR, ROBOREV_NO_MODIFY_PATH) — slice 7 mirrors these directly, reducing design risk.
+                - badge: ART
+                  kind: info
+                  text: packages/homebrew/update-formula.sh is 'already partially implemented' per plan — slice 8 is an extension not a greenfield build.
+    risks:
+        - risk: R1 / Release skew window — binary and plugin released in separate CI steps; user who installs between steps gets a mismatched state
+          severity: High
+          mitigation: Both phases run in a single GitHub Actions workflow on the same tag/commit; skew window bounded to job duration (<2 min). SessionStart version check uses warn (exit 1) not block (exit 2) on minor/patch divergence. Added as design constraint.
+        - risk: R2 / Plugin artifact size regression — future manifest edit reintroduces binary paths
+          severity: Medium
+          mitigation: Post-build assertion in slice 2 fails the build if any generated hook command contains a local path. Machine-enforceable guard, not convention.
+        - risk: R3 / Walk-up binary resolution breaks after removing hooks/bin/
+          severity: Medium
+          mitigation: Slice 1 done_when now explicitly requires os.Executable() + repo-root discovery (walk up to .htmlgraph/) to replace the hooks/bin/ walk-up. TestResolveBuildScript covers this.
+        - risk: R4 / CheckVersionAlignment semantics diverge between hook and doctor
+          severity: Medium
+          mitigation: Single exported function in version_check.go used by both paths — same code path, cannot diverge. Covered by TestCheckVersionAlignment unit tests.
+        - risk: R5 / Homebrew tap prerequisite missing — tap repo or PAT not yet set up
+          severity: High
+          mitigation: Tap repo existence and PAT credentials are now the FIRST done_when criterion for slice 8 — it is a hard prereq, not an afterthought. Flagged for human review.
+        - risk: R6 / Container mode skips mutations that do not exist in codex/gemini — false sense of coverage
+          severity: Medium
+          mitigation: Slice 10 rewritten to enumerate only ACTUAL mutations in claude.go and yolo.go. codex.go and gemini.go get a no-op stub flag with explicit code comments documenting the intentional no-op.
+    synthesis: |
+        The dual critique (Haiku design + Sonnet feasibility) falsified four assumptions and identified two high-severity risks that required plan rewrites. Slice 2 was reframed from removing non-existent binary copy logic to adding a post-build assertion guard; slice 4 was rewritten to extend the existing session_start handler (not add a new dispatch path) and to introduce CheckVersionAlignment as a shared exported function; slice 5 was corrected to read the version var from cmd/htmlgraph/main.go directly rather than a non-existent internal/version package; slice 10 was scoped to only the launchers with actual host mutations (claude.go and yolo.go) and codex/gemini get honest no-op stubs. Beyond the four rewrites, slice 1 gained an explicit build.sh relocation criterion, slice 3 gained a release atomicity done_when and now names manifest.json as the canonical version source, slice 6 gained a dep on slice 5, and slice 8 gained the Homebrew tap prereq as its first done_when. A new question (q-shared-version-source) was added — the human must decide between VERSION file, plugin.json, and manifest.json as canonical; the recommendation is manifest.json since it already exists and is already authoritative. A new design constraint on release atomicity and version-check warn-not-block semantics was added to protect against the skew window risk. Slices 7, 9, and 11 were unchanged.

--- a/.htmlgraph/plans/plan-c248b73f.yaml
+++ b/.htmlgraph/plans/plan-c248b73f.yaml
@@ -175,7 +175,7 @@ slices:
       deps:
         - 1
       done_when:
-        - 'PRECONDITION: at least one real Copilot session captured locally and committed under internal/ingest/testdata/copilot/ (redacted). The fixture in /home/vscode/.copilot/session-state/869d1f67.../ from the user''s working session is the seed candidate'
+        - 'PRECONDITION: at least one real Copilot session captured locally and committed under internal/ingest/testdata/copilot/ (redacted). The fixture in <user-home>/.copilot/session-state/<session-id>/ from the user''s working session is the seed candidate'
         - 'PRECONDITION: Copilot session-state format documented — files present, JSON shape, message ordering. The plan asserts ''likely JSON files including plan.md, messages, tool calls'' but this is unverified'
         - DiscoverCopilotSessions() returns sessions from ~/.copilot/session-state/
         - Parser handles real Copilot session-state with format-version sniff and warning on unknown formats
@@ -486,7 +486,7 @@ critique:
           evidence: File exists, scans ~/.gemini/tmp/<slug>/chats/, structurally similar pattern is reusable for codex/copilot
         - id: A6
           status: verified
-          text: .codex/config.toml exists at /workspaces/htmlgraph/.codex/config.toml
+          text: .codex/config.toml exists at <repo-root>/.codex/config.toml
           evidence: Confirmed by feasibility critic; current contents are sandbox_mode=danger-full-access, approval_policy=on-request. Slice 6 must add [features] codex_hooks=true without disturbing existing keys
         - id: A7
           status: plausible

--- a/cmd/htmlgraph/agent_worktree.go
+++ b/cmd/htmlgraph/agent_worktree.go
@@ -1,0 +1,66 @@
+// Package main — agent_worktree provides git worktree helpers for parallel
+// agent workflows. Each agent task gets its own worktree branched from the
+// named track branch, keeping agent work isolated until it is ready to merge.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// agentBranchName returns the flat branch name for an agent task.
+// Format: agent-<trackBranch>-<taskID>
+func agentBranchName(trackBranch, taskID string) string {
+	return "agent-" + trackBranch + "-" + taskID
+}
+
+// agentWorktreePath returns the worktree path for an agent task.
+// Format: <projectDir>/.claude/worktrees/<trackBranch>/agent-<taskID>
+func agentWorktreePath(trackBranch, taskID, projectDir string) string {
+	return filepath.Join(projectDir, ".claude", "worktrees", trackBranch, "agent-"+taskID)
+}
+
+// createAgentWorktree creates (or reuses) a git worktree for the given agent
+// task, branching from trackBranch. Returns the worktree path, a cleanup
+// function that removes the worktree, and any error.
+func createAgentWorktree(trackBranch, taskID, projectDir string) (string, func(), error) {
+	worktreePath := agentWorktreePath(trackBranch, taskID, projectDir)
+	branchName := agentBranchName(trackBranch, taskID)
+
+	noop := func() {}
+
+	// Verify the track branch exists before creating the worktree.
+	checkCmd := exec.Command("git", "-C", projectDir, "rev-parse", "--verify", trackBranch)
+	if out, err := checkCmd.CombinedOutput(); err != nil {
+		return "", noop, fmt.Errorf("track branch %q not found: %s", trackBranch, out)
+	}
+
+	// If worktree path already exists, reuse it.
+	if _, err := os.Stat(worktreePath); err == nil {
+		cleanup := func() {
+			exec.Command("git", "-C", projectDir, "worktree", "remove", "--force", worktreePath).Run() //nolint:errcheck
+		}
+		return worktreePath, cleanup, nil
+	}
+
+	// Ensure parent directory exists.
+	if err := os.MkdirAll(filepath.Dir(worktreePath), 0755); err != nil {
+		return "", noop, fmt.Errorf("mkdir %s: %w", filepath.Dir(worktreePath), err)
+	}
+
+	// Create the worktree with a new branch from trackBranch.
+	addCmd := exec.Command("git", "-C", projectDir, "worktree", "add", "-b", branchName, worktreePath, trackBranch)
+	if out, err := addCmd.CombinedOutput(); err != nil {
+		return "", noop, fmt.Errorf("git worktree add: %s: %w", out, err)
+	}
+
+	cleanup := func() {
+		exec.Command("git", "-C", projectDir, "worktree", "remove", "--force", worktreePath).Run() //nolint:errcheck
+		exec.Command("git", "-C", projectDir, "branch", "-D", branchName).Run()                   //nolint:errcheck
+	}
+
+	return worktreePath, cleanup, nil
+}
+

--- a/cmd/htmlgraph/agent_worktree_test.go
+++ b/cmd/htmlgraph/agent_worktree_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,18 +37,17 @@ func setupAgentGitRepo(t *testing.T) string {
 	return dir
 }
 
-func TestCreateAgentWorktree_BranchesFromTrackBranch(t *testing.T) {
+func TestEnsureForAgent_BranchesFromTrackBranch(t *testing.T) {
 	dir := setupAgentGitRepo(t)
 
 	// Create a track branch first (not via worktree, just as a branch)
 	exec.Command("git", "-C", dir, "branch", "track-abc").Run()
 
 	// Now create agent worktree branching from track-abc
-	path, agentCleanup, err := createAgentWorktree("track-abc", "task1", dir)
+	path, err := EnsureForAgent("track-abc", "task1", dir, io.Discard)
 	if err != nil {
-		t.Fatalf("createAgentWorktree: %v", err)
+		t.Fatalf("EnsureForAgent: %v", err)
 	}
-	defer agentCleanup()
 
 	// Verify path
 	expected := filepath.Join(dir, ".claude", "worktrees", "track-abc", "agent-task1")
@@ -63,17 +63,16 @@ func TestCreateAgentWorktree_BranchesFromTrackBranch(t *testing.T) {
 	}
 }
 
-func TestCreateAgentWorktree_PathNamingConvention(t *testing.T) {
+func TestEnsureForAgent_PathNamingConvention(t *testing.T) {
 	dir := setupAgentGitRepo(t)
 
 	// Create a track branch
 	exec.Command("git", "-C", dir, "branch", "mytrack").Run()
 
-	path, cleanup, err := createAgentWorktree("mytrack", "my-task", dir)
+	path, err := EnsureForAgent("mytrack", "my-task", dir, io.Discard)
 	if err != nil {
-		t.Fatalf("createAgentWorktree: %v", err)
+		t.Fatalf("EnsureForAgent: %v", err)
 	}
-	defer cleanup()
 
 	// Check the worktree path follows naming convention
 	if !strings.Contains(path, "mytrack") || !strings.Contains(path, "agent-my-task") {
@@ -81,35 +80,33 @@ func TestCreateAgentWorktree_PathNamingConvention(t *testing.T) {
 	}
 }
 
-func TestCreateAgentWorktree_FailsWithoutTrackBranch(t *testing.T) {
+func TestEnsureForAgent_FailsWithoutTrackBranch(t *testing.T) {
 	dir := setupAgentGitRepo(t)
 
 	// Don't create track branch — agent should fail
-	_, _, err := createAgentWorktree("nonexistent-track", "task1", dir)
+	_, err := EnsureForAgent("nonexistent-track", "task1", dir, io.Discard)
 	if err == nil {
 		t.Error("expected error when track branch doesn't exist")
 	}
 }
 
-func TestCreateAgentWorktree_ReusesExistingPath(t *testing.T) {
+func TestEnsureForAgent_ReusesExistingPath(t *testing.T) {
 	dir := setupAgentGitRepo(t)
 
 	// Create a track branch
 	exec.Command("git", "-C", dir, "branch", "track-reuse").Run()
 
 	// Create agent worktree
-	path1, cleanup1, err := createAgentWorktree("track-reuse", "task1", dir)
+	path1, err := EnsureForAgent("track-reuse", "task1", dir, io.Discard)
 	if err != nil {
-		t.Fatalf("first createAgentWorktree: %v", err)
+		t.Fatalf("first EnsureForAgent: %v", err)
 	}
-	defer cleanup1()
 
 	// Try to create the same agent worktree again
-	path2, cleanup2, err := createAgentWorktree("track-reuse", "task1", dir)
+	path2, err := EnsureForAgent("track-reuse", "task1", dir, io.Discard)
 	if err != nil {
-		t.Fatalf("second createAgentWorktree: %v", err)
+		t.Fatalf("second EnsureForAgent: %v", err)
 	}
-	defer cleanup2()
 
 	if path1 != path2 {
 		t.Errorf("reused worktree paths don't match: %s vs %s", path1, path2)
@@ -123,11 +120,10 @@ func TestMergeAgentToTrack(t *testing.T) {
 	exec.Command("git", "-C", dir, "branch", "merge-track").Run()
 
 	// Create agent worktree
-	agentPath, agentCleanup, err := createAgentWorktree("merge-track", "task1", dir)
+	agentPath, err := EnsureForAgent("merge-track", "task1", dir, io.Discard)
 	if err != nil {
-		t.Fatalf("createAgentWorktree: %v", err)
+		t.Fatalf("EnsureForAgent: %v", err)
 	}
-	defer agentCleanup()
 
 	// Make a change in the agent worktree
 	testFile := filepath.Join(agentPath, "test.txt")

--- a/cmd/htmlgraph/check.go
+++ b/cmd/htmlgraph/check.go
@@ -64,6 +64,7 @@ Returns exit code 0 if all gates pass, 1 if any fail.`,
 	cmd.AddCommand(checkOrphansCmd())
 	cmd.AddCommand(checkIncompleteCmd())
 	cmd.AddCommand(checkCrossProjectCmd())
+	cmd.AddCommand(checkHostPathsCmd())
 	return cmd
 }
 

--- a/cmd/htmlgraph/check_host_paths.go
+++ b/cmd/htmlgraph/check_host_paths.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// hostPathPattern matches absolute paths that are specific to a developer's machine:
+//   - /Users/<name>/        — macOS home directories
+//   - /home/<name>/         — Linux home directories
+//   - /workspaces/<name>/   — GitHub Codespaces per-user workspace paths
+//   - /private/var/folders/ — macOS temp directory (always machine-specific)
+//
+// /home/runner/ (GitHub Actions CI user) is filtered out after matching via ciAllowPattern.
+var hostPathPattern = regexp.MustCompile(
+	`/Users/[^/\s]+/` +
+		`|/home/[^/\s]+/` +
+		`|/workspaces/[^/\s]+/` +
+		`|/private/var/folders/`,
+)
+
+// ciAllowPattern matches paths that should be excluded from violations even though
+// they match hostPathPattern — specifically /home/runner/ used by GitHub Actions CI.
+var ciAllowPattern = regexp.MustCompile(`^/home/runner/`)
+
+// hostPathViolation records a single match found during scanning.
+type hostPathViolation struct {
+	file    string
+	line    int
+	matched string
+}
+
+func (v hostPathViolation) String() string {
+	return fmt.Sprintf("%s:%d: %s", v.file, v.line, v.matched)
+}
+
+// checkHostPathsCmd returns the cobra sub-command wired into `htmlgraph check`.
+func checkHostPathsCmd() *cobra.Command {
+	var stagedOnly bool
+
+	cmd := &cobra.Command{
+		Use:   "host-paths",
+		Short: "Scan committed artifacts for host-local absolute paths",
+		Long: `Scan .htmlgraph/ and .claude/ for host-local absolute paths that must
+not be committed (e.g. /Users/alice/, /home/bob/, /workspaces/charlie/).
+
+Files listed in scripts/host-paths-allowlist.txt are skipped.
+The binary .htmlgraph/htmlgraph.db and .claude/settings.local.json are always skipped.
+
+Exit code 0 — no violations; exit code 1 — violations found.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repoRoot, err := projectRoot()
+			if err != nil {
+				return fmt.Errorf("resolve git root: %w", err)
+			}
+
+			allowlist, err := loadHostPathAllowlist(filepath.Join(repoRoot, "scripts", "host-paths-allowlist.txt"))
+			if err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("load allowlist: %w", err)
+			}
+
+			var files []string
+			if stagedOnly {
+				files, err = stagedScopeFiles(repoRoot)
+			} else {
+				files, err = fullScopeFiles(repoRoot)
+			}
+			if err != nil {
+				return fmt.Errorf("collect files: %w", err)
+			}
+
+			violations, scanned, err := scanHostPathFiles(repoRoot, files, allowlist)
+			if err != nil {
+				return err
+			}
+
+			if len(violations) > 0 {
+				for _, v := range violations {
+					fmt.Println(v)
+				}
+				fmt.Printf("\nFAIL: %d host-local path violation(s) in %d file(s) scanned.\n", len(violations), scanned)
+				fmt.Println("      Commit only project-relative or portable paths.")
+				fmt.Println("      To allowlist a file, add its repo-relative path to scripts/host-paths-allowlist.txt")
+				return fmt.Errorf("host-local path violations found")
+			}
+
+			fmt.Printf("OK — %d file(s) scanned, no host-local path violations found.\n", scanned)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&stagedOnly, "staged", false, "Scan only git-staged files (for pre-commit use)")
+	return cmd
+}
+
+// loadHostPathAllowlist reads an allowlist file and returns a set of repo-relative paths.
+// Lines starting with # and blank lines are ignored.
+func loadHostPathAllowlist(path string) (map[string]bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	allowlist := make(map[string]bool)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		allowlist[line] = true
+	}
+	return allowlist, scanner.Err()
+}
+
+// fullScopeFiles collects all scannable files under .htmlgraph/ and .claude/.
+// Skips .htmlgraph/htmlgraph.db (binary) and .claude/settings.local.json (ephemeral).
+func fullScopeFiles(repoRoot string) ([]string, error) {
+	var files []string
+	for _, dir := range []string{".htmlgraph", ".claude"} {
+		dirPath := filepath.Join(repoRoot, dir)
+		if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+			continue
+		}
+		err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return nil // skip unreadable entries
+			}
+			if info.IsDir() {
+				return nil
+			}
+			base := filepath.Base(path)
+			if base == "htmlgraph.db" || base == "settings.local.json" {
+				return nil
+			}
+			files = append(files, path)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return files, nil
+}
+
+// stagedScopeFiles returns the subset of git-staged files that fall within scan scope.
+func stagedScopeFiles(repoRoot string) ([]string, error) {
+	out, err := exec.Command("git", "-C", repoRoot, "diff", "--cached", "--name-only", "--diff-filter=ACMR").Output()
+	if err != nil {
+		return nil, fmt.Errorf("git diff --cached: %w", err)
+	}
+
+	var files []string
+	for _, rel := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if rel == "" {
+			continue
+		}
+		if !strings.HasPrefix(rel, ".htmlgraph/") && !strings.HasPrefix(rel, ".claude/") {
+			continue
+		}
+		base := filepath.Base(rel)
+		if base == "htmlgraph.db" || base == "settings.local.json" {
+			continue
+		}
+		abs := filepath.Join(repoRoot, rel)
+		if _, err := os.Stat(abs); err == nil {
+			files = append(files, abs)
+		}
+	}
+	return files, nil
+}
+
+// scanHostPathFiles scans each file for host-local path violations, skipping allowlisted entries.
+// Returns the list of violations and the number of files actually scanned.
+func scanHostPathFiles(repoRoot string, files []string, allowlist map[string]bool) ([]hostPathViolation, int, error) {
+	var violations []hostPathViolation
+	scanned := 0
+
+	for _, absPath := range files {
+		relPath, err := filepath.Rel(repoRoot, absPath)
+		if err != nil {
+			relPath = absPath
+		}
+
+		if allowlist[relPath] {
+			continue
+		}
+
+		scanned++
+		vs, err := scanFileForHostPaths(absPath, relPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping %s: %v\n", relPath, err)
+			continue
+		}
+		violations = append(violations, vs...)
+	}
+
+	return violations, scanned, nil
+}
+
+// scanFileForHostPaths scans a single file for host-local path patterns.
+func scanFileForHostPaths(absPath, displayPath string) ([]hostPathViolation, error) {
+	f, err := os.Open(absPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var violations []hostPathViolation
+	scanner := bufio.NewScanner(f)
+	// Increase buffer for long HTML lines
+	scanner.Buffer(make([]byte, 256*1024), 256*1024)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		matches := hostPathPattern.FindAllString(line, -1)
+		for _, m := range matches {
+			// /home/runner/ is the GitHub Actions CI user — not a developer path.
+			if ciAllowPattern.MatchString(m) {
+				continue
+			}
+			violations = append(violations, hostPathViolation{
+				file:    displayPath,
+				line:    lineNum,
+				matched: m,
+			})
+		}
+	}
+	return violations, scanner.Err()
+}

--- a/cmd/htmlgraph/check_host_paths.go
+++ b/cmd/htmlgraph/check_host_paths.go
@@ -122,7 +122,12 @@ func loadHostPathAllowlist(path string) (map[string]bool, error) {
 }
 
 // fullScopeFiles collects all scannable files under .htmlgraph/ and .claude/.
-// Skips .htmlgraph/htmlgraph.db (binary) and .claude/settings.local.json (ephemeral).
+// Skips:
+//   - .htmlgraph/htmlgraph.db (binary)
+//   - .claude/settings.local.json (ephemeral)
+//   - .claude/worktrees/ entirely — linked-worktree .git files legitimately
+//     carry absolute gitdir: paths by design (git requires them). Scanning
+//     them produces noisy false positives on every developer's machine.
 func fullScopeFiles(repoRoot string) ([]string, error) {
 	var files []string
 	for _, dir := range []string{".htmlgraph", ".claude"} {
@@ -133,6 +138,13 @@ func fullScopeFiles(repoRoot string) ([]string, error) {
 		err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return nil // skip unreadable entries
+			}
+			rel, relErr := filepath.Rel(repoRoot, path)
+			if relErr == nil && strings.HasPrefix(rel, filepath.Join(".claude", "worktrees")+string(filepath.Separator)) {
+				if info.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
 			}
 			if info.IsDir() {
 				return nil

--- a/cmd/htmlgraph/check_host_paths_test.go
+++ b/cmd/htmlgraph/check_host_paths_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestScanFileForHostPaths_BadSample verifies that the bad-path fixture is flagged.
+func TestScanFileForHostPaths_BadSample(t *testing.T) {
+	fixture := filepath.Join("testdata", "bad-path-sample.html")
+	violations, err := scanFileForHostPaths(fixture, fixture)
+	if err != nil {
+		t.Fatalf("scanFileForHostPaths error: %v", err)
+	}
+	if len(violations) == 0 {
+		t.Error("expected violations for bad-path-sample.html, got none")
+	}
+
+	// Verify at least the /Users/fakeuser/ path is flagged.
+	found := false
+	for _, v := range violations {
+		if v.matched == "/Users/fakeuser/" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected /Users/fakeuser/ to be flagged; got violations: %v", violations)
+	}
+}
+
+// TestScanFileForHostPaths_CleanSample verifies that the clean fixture passes.
+func TestScanFileForHostPaths_CleanSample(t *testing.T) {
+	fixture := filepath.Join("testdata", "clean-sample.html")
+	violations, err := scanFileForHostPaths(fixture, fixture)
+	if err != nil {
+		t.Fatalf("scanFileForHostPaths error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Errorf("expected no violations for clean-sample.html, got: %v", violations)
+	}
+}
+
+// TestScanFileForHostPaths_CIRunnerAllowed verifies /home/runner/ is not flagged.
+func TestScanFileForHostPaths_CIRunnerAllowed(t *testing.T) {
+	tmp := t.TempDir()
+	f := filepath.Join(tmp, "ci.html")
+	if err := os.WriteFile(f, []byte("<p>/home/runner/work/htmlgraph/htmlgraph</p>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	violations, err := scanFileForHostPaths(f, "ci.html")
+	if err != nil {
+		t.Fatalf("scanFileForHostPaths error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Errorf("expected /home/runner/ to be allowed; got violations: %v", violations)
+	}
+}
+
+// TestScanFileForHostPaths_AllPatterns checks each host-local pattern is detected.
+func TestScanFileForHostPaths_AllPatterns(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		wantHit bool
+	}{
+		{"macOS Users", "path=/Users/alice/project", true},
+		{"Linux home", "path=/home/bob/project", true},
+		{"Codespaces", "path=/workspaces/charlie/repo", true},
+		{"macOS tmp", "path=/private/var/folders/abc/xyz", true},
+		{"CI runner allowed", "path=/home/runner/work/repo", false},
+		{"generic usr", "path=/usr/local/bin/tool", false},
+		{"relative path", "path=./cmd/main.go", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			f := filepath.Join(tmp, "sample.txt")
+			if err := os.WriteFile(f, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			violations, err := scanFileForHostPaths(f, "sample.txt")
+			if err != nil {
+				t.Fatalf("scanFileForHostPaths error: %v", err)
+			}
+			if tc.wantHit && len(violations) == 0 {
+				t.Errorf("expected violation for %q, got none", tc.content)
+			}
+			if !tc.wantHit && len(violations) != 0 {
+				t.Errorf("expected no violation for %q, got: %v", tc.content, violations)
+			}
+		})
+	}
+}
+
+// TestLoadHostPathAllowlist verifies the allowlist loader skips comments and blanks.
+func TestLoadHostPathAllowlist(t *testing.T) {
+	tmp := t.TempDir()
+	f := filepath.Join(tmp, "allowlist.txt")
+	content := "# comment\n\n.htmlgraph/bugs/bug-4b6d8369.html\n.claude/settings.local.json\n"
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	allowlist, err := loadHostPathAllowlist(f)
+	if err != nil {
+		t.Fatalf("loadHostPathAllowlist error: %v", err)
+	}
+	if len(allowlist) != 2 {
+		t.Errorf("expected 2 entries, got %d: %v", len(allowlist), allowlist)
+	}
+	if !allowlist[".htmlgraph/bugs/bug-4b6d8369.html"] {
+		t.Error("expected .htmlgraph/bugs/bug-4b6d8369.html in allowlist")
+	}
+	if !allowlist[".claude/settings.local.json"] {
+		t.Error("expected .claude/settings.local.json in allowlist")
+	}
+}
+
+// TestLoadHostPathAllowlist_Missing verifies that a missing allowlist is not fatal.
+func TestLoadHostPathAllowlist_Missing(t *testing.T) {
+	_, err := loadHostPathAllowlist("/does/not/exist/allowlist.txt")
+	if err == nil {
+		t.Error("expected error for missing allowlist file")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("expected os.IsNotExist error, got: %v", err)
+	}
+}
+
+// TestScanHostPathFiles_AllowlistSkipsFile verifies allowlisted files are not scanned.
+func TestScanHostPathFiles_AllowlistSkipsFile(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Write a file with violations.
+	bad := filepath.Join(tmp, "bad.html")
+	if err := os.WriteFile(bad, []byte("<p>/Users/fakeuser/project</p>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	allowlist := map[string]bool{"bad.html": true}
+	violations, scanned, err := scanHostPathFiles(tmp, []string{bad}, allowlist)
+	if err != nil {
+		t.Fatalf("scanHostPathFiles error: %v", err)
+	}
+	if scanned != 0 {
+		t.Errorf("expected 0 files scanned (allowlisted), got %d", scanned)
+	}
+	if len(violations) != 0 {
+		t.Errorf("expected 0 violations for allowlisted file, got %d", len(violations))
+	}
+}
+
+// TestFullScopeFiles_SkipsBinaryAndLocal verifies that the scope collector excludes
+// htmlgraph.db and settings.local.json.
+func TestFullScopeFiles_SkipsBinaryAndLocal(t *testing.T) {
+	tmp := t.TempDir()
+
+	hgDir := filepath.Join(tmp, ".htmlgraph")
+	claudeDir := filepath.Join(tmp, ".claude")
+	for _, d := range []string{hgDir, claudeDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create files that should be excluded.
+	for _, name := range []string{
+		filepath.Join(hgDir, "htmlgraph.db"),
+		filepath.Join(claudeDir, "settings.local.json"),
+	} {
+		if err := os.WriteFile(name, []byte("data"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create files that should be included.
+	included := filepath.Join(hgDir, "bugs", "bug-abc.html")
+	if err := os.MkdirAll(filepath.Dir(included), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(included, []byte("<html></html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := fullScopeFiles(tmp)
+	if err != nil {
+		t.Fatalf("fullScopeFiles error: %v", err)
+	}
+
+	for _, f := range files {
+		base := filepath.Base(f)
+		if base == "htmlgraph.db" || base == "settings.local.json" {
+			t.Errorf("fullScopeFiles returned excluded file: %s", f)
+		}
+	}
+
+	found := false
+	for _, f := range files {
+		if f == included {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("fullScopeFiles did not include bug HTML file")
+	}
+}

--- a/cmd/htmlgraph/execute_preview.go
+++ b/cmd/htmlgraph/execute_preview.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/shakestzd/htmlgraph/internal/htmlparse"
+	"github.com/shakestzd/htmlgraph/internal/models"
+	"github.com/shakestzd/htmlgraph/internal/workitem"
+	"github.com/spf13/cobra"
+)
+
+// executePreview is the JSON envelope returned by `htmlgraph execute-preview`.
+// It aggregates everything an orchestrator needs to start dispatching work on a
+// track: track metadata, linked work items grouped by kind, and current git state.
+type executePreview struct {
+	Track    *models.Node    `json:"track"`
+	Features []*models.Node  `json:"features,omitempty"`
+	Bugs     []*models.Node  `json:"bugs,omitempty"`
+	Plans    []*models.Node  `json:"plans,omitempty"`
+	Spikes   []*models.Node  `json:"spikes,omitempty"`
+	Git      executeGitState `json:"git"`
+}
+
+type executeGitState struct {
+	Branch            string `json:"branch"`
+	HeadSHA           string `json:"head_sha"`
+	CommitsAheadMain  int    `json:"commits_ahead_main"`
+	CommitsBehindMain int    `json:"commits_behind_main"`
+	WorktreePath      string `json:"worktree_path"`
+}
+
+func executePreviewCmd() *cobra.Command {
+	var format string
+	cmd := &cobra.Command{
+		Use:   "execute-preview <trk-id>",
+		Short: "Return everything /htmlgraph:execute needs to start dispatching — one call",
+		Long: "Aggregates track metadata, linked features/bugs/plans, and current git state " +
+			"into a single structured payload. Collapses the ~10-call discovery sequence " +
+			"that orchestrators previously needed before first dispatch.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runExecutePreview(args[0], format)
+		},
+	}
+	cmd.Flags().StringVar(&format, "format", "text", "Output format: json or text")
+	return cmd
+}
+
+func runExecutePreview(id, format string) error {
+	dir, err := findHtmlgraphDir()
+	if err != nil {
+		return err
+	}
+	resolved, err := resolveID(dir, id)
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(resolved, "trk-") {
+		return fmt.Errorf("execute-preview: expected a track id, got %q", resolved)
+	}
+
+	preview, err := buildExecutePreview(dir, resolved)
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case "json":
+		data, err := json.MarshalIndent(preview, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal json: %w", err)
+		}
+		fmt.Println(string(data))
+	default:
+		printExecutePreviewText(preview)
+	}
+	return nil
+}
+
+func buildExecutePreview(dir, trackID string) (*executePreview, error) {
+	trackPath := resolveNodePath(dir, trackID)
+	if trackPath == "" {
+		return nil, workitem.ErrNotFoundOnDisk("track", trackID)
+	}
+	trackNode, err := htmlparse.ParseFile(trackPath)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", trackPath, err)
+	}
+
+	preview := &executePreview{Track: trackNode}
+
+	// Walk every edge from the track and categorize linked nodes by id prefix.
+	seen := make(map[string]bool)
+	for _, edges := range trackNode.Edges {
+		for _, edge := range edges {
+			if seen[edge.TargetID] {
+				continue
+			}
+			seen[edge.TargetID] = true
+			path := resolveNodePath(dir, edge.TargetID)
+			if path == "" {
+				continue
+			}
+			node, err := htmlparse.ParseFile(path)
+			if err != nil {
+				continue
+			}
+			switch {
+			case strings.HasPrefix(edge.TargetID, "feat-"):
+				preview.Features = append(preview.Features, node)
+			case strings.HasPrefix(edge.TargetID, "bug-"):
+				preview.Bugs = append(preview.Bugs, node)
+			case strings.HasPrefix(edge.TargetID, "plan-"):
+				preview.Plans = append(preview.Plans, node)
+			case strings.HasPrefix(edge.TargetID, "spike-"):
+				preview.Spikes = append(preview.Spikes, node)
+			}
+		}
+	}
+
+	sort.Slice(preview.Features, func(i, j int) bool { return preview.Features[i].ID < preview.Features[j].ID })
+	sort.Slice(preview.Bugs, func(i, j int) bool { return preview.Bugs[i].ID < preview.Bugs[j].ID })
+	sort.Slice(preview.Plans, func(i, j int) bool { return preview.Plans[i].ID < preview.Plans[j].ID })
+	sort.Slice(preview.Spikes, func(i, j int) bool { return preview.Spikes[i].ID < preview.Spikes[j].ID })
+
+	preview.Git = currentGitState(dir)
+	return preview, nil
+}
+
+// currentGitState resolves git state for the caller's current working directory.
+// The orchestrator calling execute-preview wants to know "where am I in git?",
+// so probes run in the caller's cwd (typically a worktree) rather than in the
+// shared htmlgraph project root. On any failure returns a zero-valued struct.
+func currentGitState(htmlgraphDir string) executeGitState {
+	state := executeGitState{}
+	cwd, err := os.Getwd()
+	if err != nil {
+		// Fall back to the htmlgraph project root when cwd is unavailable.
+		cwd = filepath.Dir(htmlgraphDir)
+	}
+	state.WorktreePath = cwd
+
+	if branch, err := gitOutputIn(cwd, "rev-parse", "--abbrev-ref", "HEAD"); err == nil {
+		state.Branch = branch
+	}
+	if sha, err := gitOutputIn(cwd, "rev-parse", "HEAD"); err == nil {
+		state.HeadSHA = sha
+	}
+	// --left-right main...HEAD with --count emits "<behind>\t<ahead>".
+	if counts, err := gitOutputIn(cwd, "rev-list", "--left-right", "--count", "main...HEAD"); err == nil {
+		parts := strings.Fields(counts)
+		if len(parts) == 2 {
+			if behind, err := strconv.Atoi(parts[0]); err == nil {
+				state.CommitsBehindMain = behind
+			}
+			if ahead, err := strconv.Atoi(parts[1]); err == nil {
+				state.CommitsAheadMain = ahead
+			}
+		}
+	}
+	return state
+}
+
+// gitOutputIn runs a git sub-command with cwd set to repoRoot, returning
+// trimmed stdout. Distinct from gitOutput in review.go (which runs in the
+// current working directory) because execute-preview needs to resolve paths
+// relative to the discovered htmlgraph project root, not the caller's cwd.
+func gitOutputIn(repoRoot string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoRoot
+	cmd.Stderr = nil
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func printExecutePreviewText(p *executePreview) {
+	fmt.Printf("Track: %s  %s  [%s]\n", p.Track.ID, p.Track.Title, p.Track.Status)
+	fmt.Printf("Git:   branch=%s  ahead=%d  behind=%d  head=%s\n",
+		p.Git.Branch, p.Git.CommitsAheadMain, p.Git.CommitsBehindMain, firstN(p.Git.HeadSHA, 8))
+	printNodeGroup("Features", p.Features)
+	printNodeGroup("Bugs", p.Bugs)
+	printNodeGroup("Plans", p.Plans)
+	printNodeGroup("Spikes", p.Spikes)
+}
+
+func printNodeGroup(label string, nodes []*models.Node) {
+	if len(nodes) == 0 {
+		return
+	}
+	fmt.Printf("\n%s (%d):\n", label, len(nodes))
+	for _, n := range nodes {
+		fmt.Printf("  %-20s  %-12s  %s\n", n.ID, n.Status, n.Title)
+	}
+}
+
+func firstN(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+

--- a/cmd/htmlgraph/execute_preview.go
+++ b/cmd/htmlgraph/execute_preview.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -85,7 +86,7 @@ func runExecutePreview(id, format string) error {
 }
 
 func buildExecutePreview(dir, trackID string) (*executePreview, error) {
-	trackPath := resolveNodePath(dir, trackID)
+	trackPath := resolveTrackPath(dir, trackID)
 	if trackPath == "" {
 		return nil, workitem.ErrNotFoundOnDisk("track", trackID)
 	}
@@ -95,34 +96,31 @@ func buildExecutePreview(dir, trackID string) (*executePreview, error) {
 	}
 
 	preview := &executePreview{Track: trackNode}
-
-	// Walk every edge from the track and categorize linked nodes by id prefix.
 	seen := make(map[string]bool)
+
+	// 1. Direct edges from the track — features, bugs, spikes, plans.
 	for _, edges := range trackNode.Edges {
 		for _, edge := range edges {
-			if seen[edge.TargetID] {
-				continue
-			}
-			seen[edge.TargetID] = true
-			path := resolveNodePath(dir, edge.TargetID)
-			if path == "" {
-				continue
-			}
-			node, err := htmlparse.ParseFile(path)
-			if err != nil {
-				continue
-			}
-			switch {
-			case strings.HasPrefix(edge.TargetID, "feat-"):
-				preview.Features = append(preview.Features, node)
-			case strings.HasPrefix(edge.TargetID, "bug-"):
-				preview.Bugs = append(preview.Bugs, node)
-			case strings.HasPrefix(edge.TargetID, "plan-"):
-				preview.Plans = append(preview.Plans, node)
-			case strings.HasPrefix(edge.TargetID, "spike-"):
-				preview.Spikes = append(preview.Spikes, node)
+			addLinkedNode(dir, edge.TargetID, preview, seen)
+		}
+	}
+
+	// 2. Indirect plans — plans commonly link back to a feature or track via
+	//    data-feature-id, or a feature's planned_in edges point to a plan.
+	//    Walk linked features' planned_in targets and scan plans/ for any
+	//    plan whose data-feature-id matches the track or a linked feature.
+	for _, feat := range preview.Features {
+		for _, edges := range feat.Edges {
+			for _, edge := range edges {
+				if strings.HasPrefix(edge.TargetID, "plan-") {
+					addLinkedNode(dir, edge.TargetID, preview, seen)
+				}
 			}
 		}
+	}
+	discoverPlansByFeatureID(dir, trackID, preview, seen)
+	for _, feat := range preview.Features {
+		discoverPlansByFeatureID(dir, feat.ID, preview, seen)
 	}
 
 	sort.Slice(preview.Features, func(i, j int) bool { return preview.Features[i].ID < preview.Features[j].ID })
@@ -134,27 +132,103 @@ func buildExecutePreview(dir, trackID string) (*executePreview, error) {
 	return preview, nil
 }
 
-// currentGitState resolves git state for the caller's current working directory.
-// The orchestrator calling execute-preview wants to know "where am I in git?",
-// so probes run in the caller's cwd (typically a worktree) rather than in the
-// shared htmlgraph project root. On any failure returns a zero-valued struct.
-func currentGitState(htmlgraphDir string) executeGitState {
-	state := executeGitState{}
-	cwd, err := os.Getwd()
-	if err != nil {
-		// Fall back to the htmlgraph project root when cwd is unavailable.
-		cwd = filepath.Dir(htmlgraphDir)
+// resolveTrackPath mirrors runTrackShowWithFormat's track-path lookup: flat
+// tracks/<id>.html first, then the directory-backed tracks/<id>/index.html
+// fallback. resolveNodePath only handles the flat form, so execute-preview
+// needs its own resolver to avoid regressing directory-backed tracks.
+func resolveTrackPath(htmlgraphDir, id string) string {
+	flat := filepath.Join(htmlgraphDir, "tracks", id+".html")
+	if _, err := os.Stat(flat); err == nil {
+		return flat
 	}
-	state.WorktreePath = cwd
+	indexed := filepath.Join(htmlgraphDir, "tracks", id, "index.html")
+	if _, err := os.Stat(indexed); err == nil {
+		return indexed
+	}
+	return ""
+}
 
-	if branch, err := gitOutputIn(cwd, "rev-parse", "--abbrev-ref", "HEAD"); err == nil {
+// addLinkedNode resolves a node path, parses the HTML, and appends it to the
+// correct preview bucket based on the canonical id prefix. Spikes use spk-
+// (matching internal/models/enums.go and history.go). Idempotent via seen.
+func addLinkedNode(htmlgraphDir, id string, p *executePreview, seen map[string]bool) {
+	if id == "" || seen[id] {
+		return
+	}
+	seen[id] = true
+	path := resolveNodePath(htmlgraphDir, id)
+	if path == "" {
+		if strings.HasPrefix(id, "trk-") {
+			path = resolveTrackPath(htmlgraphDir, id)
+		}
+		if path == "" {
+			return
+		}
+	}
+	node, err := htmlparse.ParseFile(path)
+	if err != nil {
+		return
+	}
+	switch {
+	case strings.HasPrefix(id, "feat-"):
+		p.Features = append(p.Features, node)
+	case strings.HasPrefix(id, "bug-"):
+		p.Bugs = append(p.Bugs, node)
+	case strings.HasPrefix(id, "plan-"):
+		p.Plans = append(p.Plans, node)
+	case strings.HasPrefix(id, "spk-"):
+		p.Spikes = append(p.Spikes, node)
+	}
+}
+
+// discoverPlansByFeatureID scans .htmlgraph/plans/*.html for any plan whose
+// data-feature-id attribute matches sourceID, and adds matching plans to the
+// preview. Mirrors findExistingPlanForSource in plan_cmds.go but collects
+// all hits rather than returning the first.
+func discoverPlansByFeatureID(htmlgraphDir, sourceID string, p *executePreview, seen map[string]bool) {
+	plansDir := filepath.Join(htmlgraphDir, "plans")
+	entries, err := os.ReadDir(plansDir)
+	if err != nil {
+		return
+	}
+	needle := []byte(fmt.Sprintf(`data-feature-id="%s"`, sourceID))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".html") {
+			continue
+		}
+		planID := strings.TrimSuffix(e.Name(), ".html")
+		if seen[planID] {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(plansDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		if !bytes.Contains(data, needle) {
+			continue
+		}
+		addLinkedNode(htmlgraphDir, planID, p, seen)
+	}
+}
+
+// currentGitState resolves git state for the caller's current working directory
+// when it belongs to the same repository as the HtmlGraph project. If the
+// caller is inside a nested/submodule repo (different git-common-dir), probes
+// run against the HtmlGraph project root instead so the preview never reports
+// branch/ahead/behind for an unrelated repository. Mirrors the same guard as
+// `htmlgraph history` (see resolveHistoryRoot in history.go).
+func currentGitState(htmlgraphDir string) executeGitState {
+	repoRoot := resolveGitProbeRoot(htmlgraphDir)
+	state := executeGitState{WorktreePath: repoRoot}
+
+	if branch, err := gitOutputIn(repoRoot, "rev-parse", "--abbrev-ref", "HEAD"); err == nil {
 		state.Branch = branch
 	}
-	if sha, err := gitOutputIn(cwd, "rev-parse", "HEAD"); err == nil {
+	if sha, err := gitOutputIn(repoRoot, "rev-parse", "HEAD"); err == nil {
 		state.HeadSHA = sha
 	}
 	// --left-right main...HEAD with --count emits "<behind>\t<ahead>".
-	if counts, err := gitOutputIn(cwd, "rev-list", "--left-right", "--count", "main...HEAD"); err == nil {
+	if counts, err := gitOutputIn(repoRoot, "rev-list", "--left-right", "--count", "main...HEAD"); err == nil {
 		parts := strings.Fields(counts)
 		if len(parts) == 2 {
 			if behind, err := strconv.Atoi(parts[0]); err == nil {
@@ -166,6 +240,20 @@ func currentGitState(htmlgraphDir string) executeGitState {
 		}
 	}
 	return state
+}
+
+// resolveGitProbeRoot picks the repo root for git probes. Prefers the caller's
+// cwd when it shares a git-common-dir with the HtmlGraph project (linked
+// worktree — branch-local state is correct). Otherwise falls back to the
+// project owner so nested/submodule CWDs don't leak unrelated repo state.
+// Reuses resolveHistoryRoot which already implements this check.
+func resolveGitProbeRoot(htmlgraphDir string) string {
+	owner := filepath.Dir(htmlgraphDir)
+	root, err := resolveHistoryRoot(owner)
+	if err != nil {
+		return owner
+	}
+	return root
 }
 
 // gitOutputIn runs a git sub-command with cwd set to repoRoot, returning

--- a/cmd/htmlgraph/execute_preview.go
+++ b/cmd/htmlgraph/execute_preview.go
@@ -247,10 +247,16 @@ func currentGitState(htmlgraphDir string) executeGitState {
 // worktree — branch-local state is correct). Otherwise falls back to the
 // project owner so nested/submodule CWDs don't leak unrelated repo state.
 // Reuses resolveHistoryRoot which already implements this check.
+//
+// On error from resolveHistoryRoot (permission error, missing git, etc.) we
+// silently fall back to the project owner rather than aborting — execute-
+// preview must stay non-fatal — but emit a stderr diagnostic so confused
+// ahead/behind counts have a visible trail for debugging.
 func resolveGitProbeRoot(htmlgraphDir string) string {
 	owner := filepath.Dir(htmlgraphDir)
 	root, err := resolveHistoryRoot(owner)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "execute-preview: resolveHistoryRoot(%s) failed, falling back to project owner: %v\n", owner, err)
 		return owner
 	}
 	return root

--- a/cmd/htmlgraph/execute_preview_test.go
+++ b/cmd/htmlgraph/execute_preview_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestExecutePreview_BuildsEnvelope is a unit test for buildExecutePreview that
+// sets up a minimal .htmlgraph/ tree and verifies the JSON envelope contains the
+// track, linked bugs, and git state fields.
+func TestExecutePreview_BuildsEnvelope(t *testing.T) {
+	dir := t.TempDir()
+	hgDir := filepath.Join(dir, ".htmlgraph")
+
+	// Create directory skeleton.
+	for _, sub := range []string{"tracks", "features", "bugs", "plans", "spikes"} {
+		if err := os.MkdirAll(filepath.Join(hgDir, sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+
+	// Track with two edges — one to a bug, one to a feature.
+	trackHTML := `<!DOCTYPE html><html><body>
+<article id="trk-test001" data-type="track" data-status="in-progress" data-priority="medium">
+<header><h1>Sample Track</h1></header>
+<nav data-graph-edges>
+  <section data-edge-type="contains">
+    <ul>
+      <li><a href="bug-test001.html" data-relationship="contains">Sample Bug</a></li>
+      <li><a href="feat-test001.html" data-relationship="contains">Sample Feature</a></li>
+    </ul>
+  </section>
+</nav>
+</article>
+</body></html>`
+	writeFile(t, filepath.Join(hgDir, "tracks", "trk-test001.html"), trackHTML)
+
+	bugHTML := `<!DOCTYPE html><html><body>
+<article id="bug-test001" data-type="bug" data-status="todo" data-priority="medium">
+<header><h1>Sample Bug</h1></header>
+</article>
+</body></html>`
+	writeFile(t, filepath.Join(hgDir, "bugs", "bug-test001.html"), bugHTML)
+
+	featHTML := `<!DOCTYPE html><html><body>
+<article id="feat-test001" data-type="feature" data-status="done" data-priority="medium">
+<header><h1>Sample Feature</h1></header>
+</article>
+</body></html>`
+	writeFile(t, filepath.Join(hgDir, "features", "feat-test001.html"), featHTML)
+
+	preview, err := buildExecutePreview(hgDir, "trk-test001")
+	if err != nil {
+		t.Fatalf("buildExecutePreview: %v", err)
+	}
+
+	if preview.Track == nil {
+		t.Fatal("Track is nil")
+	}
+	if preview.Track.ID != "trk-test001" {
+		t.Errorf("Track.ID = %q, want trk-test001", preview.Track.ID)
+	}
+	if got := len(preview.Bugs); got != 1 {
+		t.Errorf("len(Bugs) = %d, want 1", got)
+	}
+	if got := len(preview.Features); got != 1 {
+		t.Errorf("len(Features) = %d, want 1", got)
+	}
+
+	// Marshal to JSON to prove the envelope serializes cleanly — mirrors what
+	// the --format json path does.
+	b, err := json.Marshal(preview)
+	if err != nil {
+		t.Fatalf("marshal preview: %v", err)
+	}
+	s := string(b)
+	for _, key := range []string{`"track"`, `"bugs"`, `"features"`, `"git"`} {
+		if !strings.Contains(s, key) {
+			t.Errorf("json envelope missing %s", key)
+		}
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile %s: %v", path, err)
+	}
+}

--- a/cmd/htmlgraph/execute_preview_test.go
+++ b/cmd/htmlgraph/execute_preview_test.go
@@ -16,13 +16,15 @@ func TestExecutePreview_BuildsEnvelope(t *testing.T) {
 	hgDir := filepath.Join(dir, ".htmlgraph")
 
 	// Create directory skeleton.
-	for _, sub := range []string{"tracks", "features", "bugs", "plans", "spikes"} {
+	for _, sub := range []string{"tracks", "features", "bugs", "plans", "spikes", "specs"} {
 		if err := os.MkdirAll(filepath.Join(hgDir, sub), 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", sub, err)
 		}
 	}
 
-	// Track with two edges — one to a bug, one to a feature.
+	// Track with three direct edges: bug, feature, spike. Spike uses the
+	// canonical "spk-" prefix to guard against regression of the original
+	// "spike-" prefix bug in the first execute-preview implementation.
 	trackHTML := `<!DOCTYPE html><html><body>
 <article id="trk-test001" data-type="track" data-status="in-progress" data-priority="medium">
 <header><h1>Sample Track</h1></header>
@@ -31,6 +33,7 @@ func TestExecutePreview_BuildsEnvelope(t *testing.T) {
     <ul>
       <li><a href="bug-test001.html" data-relationship="contains">Sample Bug</a></li>
       <li><a href="feat-test001.html" data-relationship="contains">Sample Feature</a></li>
+      <li><a href="spk-test001.html" data-relationship="contains">Sample Spike</a></li>
     </ul>
   </section>
 </nav>
@@ -52,6 +55,13 @@ func TestExecutePreview_BuildsEnvelope(t *testing.T) {
 </body></html>`
 	writeFile(t, filepath.Join(hgDir, "features", "feat-test001.html"), featHTML)
 
+	spikeHTML := `<!DOCTYPE html><html><body>
+<article id="spk-test001" data-type="spike" data-status="todo" data-priority="medium">
+<header><h1>Sample Spike</h1></header>
+</article>
+</body></html>`
+	writeFile(t, filepath.Join(hgDir, "spikes", "spk-test001.html"), spikeHTML)
+
 	preview, err := buildExecutePreview(hgDir, "trk-test001")
 	if err != nil {
 		t.Fatalf("buildExecutePreview: %v", err)
@@ -68,6 +78,9 @@ func TestExecutePreview_BuildsEnvelope(t *testing.T) {
 	}
 	if got := len(preview.Features); got != 1 {
 		t.Errorf("len(Features) = %d, want 1", got)
+	}
+	if got := len(preview.Spikes); got != 1 {
+		t.Errorf("len(Spikes) = %d, want 1 (spk- prefix regression)", got)
 	}
 
 	// Marshal to JSON to prove the envelope serializes cleanly — mirrors what
@@ -88,5 +101,82 @@ func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("WriteFile %s: %v", path, err)
+	}
+}
+
+// TestExecutePreview_DirectoryBackedTrack verifies tracks stored at
+// tracks/<id>/index.html resolve correctly (regression guard for roborev
+// finding that resolveNodePath-only lookup regressed the directory form).
+func TestExecutePreview_DirectoryBackedTrack(t *testing.T) {
+	dir := t.TempDir()
+	hgDir := filepath.Join(dir, ".htmlgraph")
+	if err := os.MkdirAll(filepath.Join(hgDir, "tracks", "trk-dirform"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	trackHTML := `<!DOCTYPE html><html><body>
+<article id="trk-dirform" data-type="track" data-status="todo" data-priority="medium">
+<header><h1>Directory-Backed Track</h1></header>
+</article>
+</body></html>`
+	writeFile(t, filepath.Join(hgDir, "tracks", "trk-dirform", "index.html"), trackHTML)
+
+	preview, err := buildExecutePreview(hgDir, "trk-dirform")
+	if err != nil {
+		t.Fatalf("buildExecutePreview: %v", err)
+	}
+	if preview.Track == nil || preview.Track.ID != "trk-dirform" {
+		t.Errorf("directory-backed track not resolved: got %+v", preview.Track)
+	}
+}
+
+// TestExecutePreview_PlanByFeatureID verifies plans that reference a linked
+// feature via data-feature-id surface in the envelope even when they are
+// not directly linked from the track (regression guard for the HIGH finding
+// that plans were under-discovered).
+func TestExecutePreview_PlanByFeatureID(t *testing.T) {
+	dir := t.TempDir()
+	hgDir := filepath.Join(dir, ".htmlgraph")
+	for _, sub := range []string{"tracks", "features", "plans"} {
+		if err := os.MkdirAll(filepath.Join(hgDir, sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+
+	trackHTML := `<!DOCTYPE html><html><body>
+<article id="trk-planned" data-type="track" data-status="in-progress" data-priority="medium">
+<header><h1>Planned Track</h1></header>
+<nav data-graph-edges>
+  <section data-edge-type="contains">
+    <ul>
+      <li><a href="feat-planned.html" data-relationship="contains">Planned Feature</a></li>
+    </ul>
+  </section>
+</nav>
+</article>
+</body></html>`
+	writeFile(t, filepath.Join(hgDir, "tracks", "trk-planned.html"), trackHTML)
+
+	featHTML := `<!DOCTYPE html><html><body>
+<article id="feat-planned" data-type="feature" data-status="todo" data-priority="medium">
+<header><h1>Planned Feature</h1></header>
+</article>
+</body></html>`
+	writeFile(t, filepath.Join(hgDir, "features", "feat-planned.html"), featHTML)
+
+	// Plan is NOT linked from the track — it references feat-planned via
+	// data-feature-id only. Execute-preview must still surface it.
+	planHTML := `<!DOCTYPE html><html><body>
+<article id="plan-indirect" data-type="plan" data-status="draft" data-priority="medium" data-feature-id="feat-planned">
+<header><h1>Indirect Plan</h1></header>
+</article>
+</body></html>`
+	writeFile(t, filepath.Join(hgDir, "plans", "plan-indirect.html"), planHTML)
+
+	preview, err := buildExecutePreview(hgDir, "trk-planned")
+	if err != nil {
+		t.Fatalf("buildExecutePreview: %v", err)
+	}
+	if got := len(preview.Plans); got != 1 {
+		t.Errorf("len(Plans) = %d, want 1 (plan should surface via data-feature-id)", got)
 	}
 }

--- a/cmd/htmlgraph/ingest_events_test.go
+++ b/cmd/htmlgraph/ingest_events_test.go
@@ -37,13 +37,13 @@ func TestStoreParseResult_CreatesAgentEvents(t *testing.T) {
 				MessageOrdinal: 1,
 				ToolName:       "Read",
 				ToolUseID:      "tu-abc123",
-				InputJSON:      `{"file_path":"/tmp/test.go"}`,
+				InputJSON:      `{"file_path":"/mock/test.go"}`,
 			},
 			{
 				MessageOrdinal: 1,
 				ToolName:       "Edit",
 				ToolUseID:      "tu-def456",
-				InputJSON:      `{"file_path":"/tmp/test.go","old_string":"foo","new_string":"bar"}`,
+				InputJSON:      `{"file_path":"/mock/test.go","old_string":"foo","new_string":"bar"}`,
 			},
 		},
 	}
@@ -141,7 +141,7 @@ func TestStoreParseResult_IdempotentReingestion(t *testing.T) {
 				MessageOrdinal: 0,
 				ToolName:       "Read",
 				ToolUseID:      "tu-idem-001",
-				InputJSON:      `{"file_path":"/tmp/test.go"}`,
+				InputJSON:      `{"file_path":"/mock/test.go"}`,
 			},
 		},
 	}

--- a/cmd/htmlgraph/main.go
+++ b/cmd/htmlgraph/main.go
@@ -140,6 +140,10 @@ func buildRoot() *cobra.Command {
 	lineage.GroupID = "query"
 	root.AddCommand(lineage)
 
+	executePreview := executePreviewCmd()
+	executePreview.GroupID = "query"
+	root.AddCommand(executePreview)
+
 	// quality group
 	check := checkCmd()
 	check.GroupID = "quality"

--- a/cmd/htmlgraph/migrate_test.go
+++ b/cmd/htmlgraph/migrate_test.go
@@ -57,7 +57,7 @@ func setupMigrateEnv(t *testing.T, orphanIDs ...string) string {
 			SessionID:      id,
 			ToolName:       "Read",
 			ToolUseID:      "tu-" + id,
-			InputJSON:      `{"file_path":"/tmp/a.go"}`,
+			InputJSON:      `{"file_path":"/mock/a.go"}`,
 			Category:       "Read",
 			MessageOrdinal: 0,
 		}

--- a/cmd/htmlgraph/plan_show.go
+++ b/cmd/htmlgraph/plan_show.go
@@ -13,23 +13,34 @@ import (
 )
 
 func planShowCmd() *cobra.Command {
-	return &cobra.Command{
+	var format string
+	cmd := &cobra.Command{
 		Use:   "show <plan-id>",
 		Short: "Show plan details (warns on YAML/HTML drift)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			rawID := args[0]
-			if htmlgraphDir, err := findHtmlgraphDir(); err == nil {
-				resolved, err := resolveID(htmlgraphDir, rawID)
-				if err == nil && strings.HasPrefix(resolved, "plan-") {
-					yamlPath := filepath.Join(htmlgraphDir, "plans", resolved+".yaml")
-					htmlPath := filepath.Join(htmlgraphDir, "plans", resolved+".html")
-					checkPlanDrift(yamlPath, htmlPath, os.Stderr)
-				}
-			}
-			return runWiShow(rawID)
+			return runPlanShowWithFormat(args[0], format)
 		},
 	}
+	cmd.Flags().StringVar(&format, "format", "text", "Output format: json or text")
+	return cmd
+}
+
+// runPlanShowWithFormat shows a plan in the requested format (text or json),
+// checking for YAML/HTML drift in text mode.
+func runPlanShowWithFormat(rawID, format string) error {
+	if format != "json" {
+		// Only check drift for human-readable output (avoids confusing stderr noise in JSON mode).
+		if htmlgraphDir, err := findHtmlgraphDir(); err == nil {
+			resolved, err := resolveID(htmlgraphDir, rawID)
+			if err == nil && strings.HasPrefix(resolved, "plan-") {
+				yamlPath := filepath.Join(htmlgraphDir, "plans", resolved+".yaml")
+				htmlPath := filepath.Join(htmlgraphDir, "plans", resolved+".html")
+				checkPlanDrift(yamlPath, htmlPath, os.Stderr)
+			}
+		}
+	}
+	return runWiShowWithFormat(rawID, format)
 }
 
 var (

--- a/cmd/htmlgraph/session_roundtrip_test.go
+++ b/cmd/htmlgraph/session_roundtrip_test.go
@@ -60,8 +60,8 @@ func TestSessionRoundTrip_IngestThenReindex(t *testing.T) {
 			{Ordinal: 1, Role: "assistant", Timestamp: msgTs.Add(2 * time.Second)},
 		},
 		ToolCalls: []models.ToolCall{
-			{MessageOrdinal: 1, ToolName: "Read", ToolUseID: "tu-a", InputJSON: `{"file_path":"/tmp/a.go"}`},
-			{MessageOrdinal: 1, ToolName: "Edit", ToolUseID: "tu-b", InputJSON: `{"file_path":"/tmp/a.go"}`},
+			{MessageOrdinal: 1, ToolName: "Read", ToolUseID: "tu-a", InputJSON: `{"file_path":"/mock/a.go"}`},
+			{MessageOrdinal: 1, ToolName: "Edit", ToolUseID: "tu-b", InputJSON: `{"file_path":"/mock/a.go"}`},
 			{MessageOrdinal: 1, ToolName: "Bash", ToolUseID: "tu-c", InputJSON: `{"command":"go test"}`},
 		},
 	}
@@ -200,7 +200,7 @@ func TestSessionRoundTrip_MigrationBackfill(t *testing.T) {
 		}
 		tc := &models.ToolCall{
 			MessageID: int(msgID), SessionID: id, ToolName: "Read",
-			ToolUseID: "tu-" + id, InputJSON: `{"file_path":"/tmp/a.go"}`,
+			ToolUseID: "tu-" + id, InputJSON: `{"file_path":"/mock/a.go"}`,
 			Category: "Read", MessageOrdinal: 0,
 		}
 		if err := dbpkg.InsertToolCall(database, tc); err != nil {

--- a/cmd/htmlgraph/show_format_test.go
+++ b/cmd/htmlgraph/show_format_test.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shakestzd/htmlgraph/internal/htmlparse"
+)
+
+// sampleBugHTML is a minimal HtmlGraph bug HTML fixture.
+const sampleBugHTML = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Test Bug</title></head>
+<body>
+<article id="bug-aabbccdd"
+         data-type="bug"
+         data-status="in-progress"
+         data-priority="high"
+         data-created="2026-01-01T00:00:00Z"
+         data-track-id="trk-testtrack">
+  <header><h1>Sample Bug Title</h1></header>
+  <section data-content>
+    <p>This is a bug description.</p>
+  </section>
+</article>
+</body>
+</html>`
+
+// sampleSpikeHTML is a minimal HtmlGraph spike HTML fixture.
+const sampleSpikeHTML = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Test Spike</title></head>
+<body>
+<article id="spk-aabbccdd"
+         data-type="spike"
+         data-status="todo"
+         data-priority="medium">
+  <header><h1>Sample Spike Title</h1></header>
+  <section data-content>
+    <p>This is a spike description.</p>
+  </section>
+</article>
+</body>
+</html>`
+
+// sampleTrackHTML is a minimal HtmlGraph track HTML fixture.
+const sampleTrackHTML = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Test Track</title></head>
+<body>
+<article id="trk-aabbccdd"
+         data-type="track"
+         data-status="in-progress"
+         data-priority="high"
+         data-created="2026-01-01T00:00:00Z">
+  <header><h1>Sample Track Title</h1></header>
+  <section data-content>
+    <p>This is a track description.</p>
+  </section>
+</article>
+</body>
+</html>`
+
+// samplePlanHTML is a minimal HtmlGraph plan HTML fixture.
+const samplePlanHTML = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Plan: Test Plan</title></head>
+<body>
+<article id="plan-aabbccdd"
+         data-type="plan"
+         data-status="draft"
+         data-priority="medium"
+         data-created="2026-01-01T00:00:00Z">
+  <header><h1>Sample Plan Title</h1></header>
+  <section data-content>
+    <p>This is a plan description.</p>
+  </section>
+</article>
+</body>
+</html>`
+
+// makeShowFixture creates a temp .htmlgraph directory with a single HTML file
+// in the given subdir with the given filename and content. Returns the tmpDir.
+func makeShowFixture(t *testing.T, subdir, filename, content string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	hgDir := filepath.Join(tmpDir, ".htmlgraph")
+	for _, sub := range []string{"features", "bugs", "spikes", "tracks", "plans", "specs"} {
+		if err := os.MkdirAll(filepath.Join(hgDir, sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+	path := filepath.Join(hgDir, subdir, filename)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return tmpDir
+}
+
+// --- Bug show tests ---
+
+func TestBugShow_FormatJSON(t *testing.T) {
+	tmpDir := makeShowFixture(t, "bugs", "bug-aabbccdd.html", sampleBugHTML)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+
+	out := captureStdout(t, func() {
+		if err := runWiShowWithFormat("bug-aabbccdd", "json"); err != nil {
+			t.Fatalf("runWiShowWithFormat: %v", err)
+		}
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	for _, key := range []string{"id", "title", "status"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("JSON missing field %q; got: %s", key, out)
+		}
+	}
+	if m["id"] != "bug-aabbccdd" {
+		t.Errorf("id = %q, want bug-aabbccdd", m["id"])
+	}
+}
+
+func TestBugShow_FormatText(t *testing.T) {
+	tmpDir := makeShowFixture(t, "bugs", "bug-aabbccdd.html", sampleBugHTML)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+
+	out := captureStdout(t, func() {
+		if err := runWiShowWithFormat("bug-aabbccdd", "text"); err != nil {
+			t.Fatalf("runWiShowWithFormat: %v", err)
+		}
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err == nil {
+		t.Error("text format output unexpectedly parsed as JSON")
+	}
+	if !strings.Contains(out, "bug-aabbccdd") {
+		t.Errorf("text output missing ID; got: %s", out)
+	}
+	if !strings.Contains(out, "Sample Bug Title") {
+		t.Errorf("text output missing title; got: %s", out)
+	}
+}
+
+func TestBugShow_DefaultIsText(t *testing.T) {
+	tmpDir := makeShowFixture(t, "bugs", "bug-aabbccdd.html", sampleBugHTML)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+
+	// Default (no format flag) should produce text, not JSON.
+	out := captureStdout(t, func() {
+		if err := runWiShow("bug-aabbccdd"); err != nil {
+			t.Fatalf("runWiShow: %v", err)
+		}
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err == nil {
+		t.Error("default output unexpectedly parsed as JSON; default should be text")
+	}
+}
+
+// --- Feature show tests ---
+
+func TestFeatureShow_FormatJSON(t *testing.T) {
+	tmpDir := makeShowFixture(t, "features", "feat-aabbccdd.html", sampleFeatureHTML)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+
+	out := captureStdout(t, func() {
+		if err := runWiShowWithFormat("feat-aabbccdd", "json"); err != nil {
+			t.Fatalf("runWiShowWithFormat: %v", err)
+		}
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	for _, key := range []string{"id", "title", "status"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("JSON missing field %q; got: %s", key, out)
+		}
+	}
+	if m["id"] != "feat-aabbccdd" {
+		t.Errorf("id = %q, want feat-aabbccdd", m["id"])
+	}
+}
+
+func TestFeatureShow_FormatText(t *testing.T) {
+	tmpDir := makeShowFixture(t, "features", "feat-aabbccdd.html", sampleFeatureHTML)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+
+	out := captureStdout(t, func() {
+		if err := runWiShowWithFormat("feat-aabbccdd", "text"); err != nil {
+			t.Fatalf("runWiShowWithFormat: %v", err)
+		}
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err == nil {
+		t.Error("text format output unexpectedly parsed as JSON")
+	}
+	if !strings.Contains(out, "feat-aabbccdd") {
+		t.Errorf("text output missing ID; got: %s", out)
+	}
+}
+
+// --- Spike show tests ---
+
+func TestSpikeShow_FormatJSON(t *testing.T) {
+	tmpDir := makeShowFixture(t, "spikes", "spk-aabbccdd.html", sampleSpikeHTML)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+
+	out := captureStdout(t, func() {
+		if err := runWiShowWithFormat("spk-aabbccdd", "json"); err != nil {
+			t.Fatalf("runWiShowWithFormat: %v", err)
+		}
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	for _, key := range []string{"id", "title", "status"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("JSON missing field %q; got: %s", key, out)
+		}
+	}
+}
+
+// --- Track show tests ---
+
+func TestTrackShow_FormatJSON(t *testing.T) {
+	tmpDir := makeShowFixture(t, "tracks", "trk-aabbccdd.html", sampleTrackHTML)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+
+	out := captureStdout(t, func() {
+		if err := runTrackShowWithFormat("trk-aabbccdd", false, "json"); err != nil {
+			t.Fatalf("runTrackShowWithFormat: %v", err)
+		}
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	for _, key := range []string{"id", "title", "status"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("JSON missing field %q; got: %s", key, out)
+		}
+	}
+	if m["id"] != "trk-aabbccdd" {
+		t.Errorf("id = %q, want trk-aabbccdd", m["id"])
+	}
+}
+
+func TestTrackShow_FormatText(t *testing.T) {
+	tmpDir := makeShowFixture(t, "tracks", "trk-aabbccdd.html", sampleTrackHTML)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+
+	out := captureStdout(t, func() {
+		if err := runTrackShowWithFormat("trk-aabbccdd", false, "text"); err != nil {
+			t.Fatalf("runTrackShowWithFormat: %v", err)
+		}
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err == nil {
+		t.Error("text format output unexpectedly parsed as JSON")
+	}
+	if !strings.Contains(out, "trk-aabbccdd") {
+		t.Errorf("text output missing ID; got: %s", out)
+	}
+}
+
+func TestTrackShow_DefaultIsText(t *testing.T) {
+	tmpDir := makeShowFixture(t, "tracks", "trk-aabbccdd.html", sampleTrackHTML)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+
+	out := captureStdout(t, func() {
+		if err := runTrackShow("trk-aabbccdd", false); err != nil {
+			t.Fatalf("runTrackShow: %v", err)
+		}
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err == nil {
+		t.Error("default output unexpectedly parsed as JSON; default should be text")
+	}
+}
+
+// --- Plan show tests ---
+
+func TestPlanShow_FormatJSON(t *testing.T) {
+	tmpDir := makeShowFixture(t, "plans", "plan-aabbccdd.html", samplePlanHTML)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+
+	out := captureStdout(t, func() {
+		if err := runPlanShowWithFormat("plan-aabbccdd", "json"); err != nil {
+			t.Fatalf("runPlanShowWithFormat: %v", err)
+		}
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	for _, key := range []string{"id", "title", "status"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("JSON missing field %q; got: %s", key, out)
+		}
+	}
+	if m["id"] != "plan-aabbccdd" {
+		t.Errorf("id = %q, want plan-aabbccdd", m["id"])
+	}
+}
+
+func TestPlanShow_FormatText(t *testing.T) {
+	tmpDir := makeShowFixture(t, "plans", "plan-aabbccdd.html", samplePlanHTML)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+
+	out := captureStdout(t, func() {
+		if err := runPlanShowWithFormat("plan-aabbccdd", "text"); err != nil {
+			t.Fatalf("runPlanShowWithFormat: %v", err)
+		}
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err == nil {
+		t.Error("text format output unexpectedly parsed as JSON")
+	}
+	if !strings.Contains(out, "plan-aabbccdd") {
+		t.Errorf("text output missing ID; got: %s", out)
+	}
+}
+
+func TestPlanShow_DefaultIsText(t *testing.T) {
+	tmpDir := makeShowFixture(t, "plans", "plan-aabbccdd.html", samplePlanHTML)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+
+	// planShowCmd delegates to runWiShow which uses text by default.
+	out := captureStdout(t, func() {
+		if err := runWiShow("plan-aabbccdd"); err != nil {
+			t.Fatalf("runWiShow: %v", err)
+		}
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err == nil {
+		t.Error("default output unexpectedly parsed as JSON; default should be text")
+	}
+}
+
+// --- JSON shape validation ---
+
+func TestShowJSON_ContainsAllKeyFields(t *testing.T) {
+	// Verify JSON output includes all the key fields we care about.
+	node, err := htmlparse.ParseString(sampleBugHTML)
+	if err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := printNodeDetailJSON(node); err != nil {
+			t.Fatalf("printNodeDetailJSON: %v", err)
+		}
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("not valid JSON: %v\noutput: %s", err, out)
+	}
+
+	required := []string{"id", "title", "type", "status", "priority"}
+	for _, key := range required {
+		if _, ok := m[key]; !ok {
+			t.Errorf("JSON missing required field %q; got keys: %v", key, jsonKeys(m))
+		}
+	}
+}
+
+func jsonKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/cmd/htmlgraph/skill_flags_test.go
+++ b/cmd/htmlgraph/skill_flags_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestSkillFlagsIntegration scans the plugin asset tree for `htmlgraph ...`
+// invocations and validates that every prescribed flag is actually registered
+// on the target cobra command. Prevents recurrence of bug-7ca3638b (skill
+// prescribing `--format json` that trackShowCmd did not register).
+//
+// Scope: plugin/skills/**/*.md, plugin/commands/**/*.md, plugin/agents/**/*.md.
+//
+// Allowlist: flags listed in allowedShellFlags are skipped — these belong to
+// piped-to tools (grep, jq, etc.) rather than the htmlgraph CLI.
+func TestSkillFlagsIntegration(t *testing.T) {
+	root := repoRootForTest(t)
+	var pluginRoots []string
+	for _, sub := range []string{"plugin/skills", "plugin/commands", "plugin/agents"} {
+		p := filepath.Join(root, sub)
+		if _, err := os.Stat(p); err == nil {
+			pluginRoots = append(pluginRoots, p)
+		}
+	}
+	if len(pluginRoots) == 0 {
+		t.Skip("no plugin asset tree at repo root — skipping skill-flag validation")
+	}
+
+	cliRoot := buildRoot()
+	var violations []string
+	scanned := 0
+
+	for _, pr := range pluginRoots {
+		err := filepath.WalkDir(pr, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".md") {
+				return nil
+			}
+			scanned++
+			violations = append(violations, scanFileForFlagViolations(t, path, cliRoot)...)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", pr, err)
+		}
+	}
+
+	t.Logf("scanned %d markdown files", scanned)
+	if len(violations) > 0 {
+		for _, v := range violations {
+			t.Error(v)
+		}
+	}
+}
+
+// TestSkillFlagsValidator_CatchesBadFixture exercises the flag-validation
+// engine against a known-bad fixture so failures in the main scanner can be
+// reproduced in isolation.
+func TestSkillFlagsValidator_CatchesBadFixture(t *testing.T) {
+	fixture := filepath.Join("testdata", "skill_flag_bad.md")
+	if _, err := os.Stat(fixture); err != nil {
+		t.Skipf("fixture missing: %v", err)
+	}
+	violations := scanFileForFlagViolations(t, fixture, buildRoot())
+	if len(violations) == 0 {
+		t.Fatal("scanner failed to flag known-bad fixture")
+	}
+}
+
+// TestSkillFlagsValidator_PassesGoodFixture exercises the engine against a
+// known-good fixture.
+func TestSkillFlagsValidator_PassesGoodFixture(t *testing.T) {
+	fixture := filepath.Join("testdata", "skill_flag_good.md")
+	if _, err := os.Stat(fixture); err != nil {
+		t.Skipf("fixture missing: %v", err)
+	}
+	violations := scanFileForFlagViolations(t, fixture, buildRoot())
+	if len(violations) > 0 {
+		t.Fatalf("clean fixture reported %d violations: %v", len(violations), violations)
+	}
+}
+
+// allowedShellFlags are flags that belong to non-htmlgraph tools reached via
+// pipes in skill examples (grep, jq, etc.). They should not be validated
+// against the cobra tree.
+var allowedShellFlags = map[string]bool{
+	"--line-buffered": true,
+	"--raw-output":    true,
+	"--compact":       true, // htmlgraph help --compact is real; also jq --compact
+	"--quiet":         true,
+	"--deep":          false, // real htmlgraph flag — leave to the validator
+}
+
+// invocationPattern matches `htmlgraph <cmd> [<subcmd>...]` followed by one or
+// more `--flag` tokens. Terminates on newline, backtick, or pipe/redirect.
+// Intentionally permissive — false-positive matches are filtered by the
+// validator when the command path is unknown.
+var invocationPattern = regexp.MustCompile(`\bhtmlgraph[ \t]+([a-zA-Z][\w-]*(?:[ \t]+[a-zA-Z][\w-]*)*?)[ \t]+((?:--[a-zA-Z][\w-]*(?:[= \t]\S+)?[ \t]*)+)`)
+var flagPattern = regexp.MustCompile(`--[a-zA-Z][\w-]*`)
+
+func scanFileForFlagViolations(t *testing.T, path string, cliRoot *cobra.Command) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	content := string(data)
+	lines := strings.Split(content, "\n")
+
+	var violations []string
+	for _, match := range invocationPattern.FindAllStringSubmatchIndex(content, -1) {
+		cmdStr := content[match[2]:match[3]]
+		flagsStr := content[match[4]:match[5]]
+
+		// Remove piped-to-tool tail: if flagsStr contains " | ", " > ", etc.,
+		// strip everything after to avoid validating grep/jq flags.
+		if idx := strings.IndexAny(flagsStr, "|>"); idx >= 0 {
+			flagsStr = flagsStr[:idx]
+		}
+
+		targetCmd := resolveCobraCommand(cliRoot, strings.Fields(cmdStr))
+		if targetCmd == nil {
+			// Unknown command path — likely an illustrative example or a
+			// command we don't care to validate (e.g. `htmlgraph feature`
+			// standalone where the next word is a placeholder). Skip.
+			continue
+		}
+
+		for _, flag := range flagPattern.FindAllString(flagsStr, -1) {
+			if allowedShellFlags[flag] {
+				continue
+			}
+			if !commandRegistersFlag(targetCmd, flag) {
+				lineNum := lineNumberFor(lines, content, match[0])
+				rel, _ := filepath.Rel(repoRootForTest(t), path)
+				violations = append(violations,
+					fmt.Sprintf("%s:%d: command %q does not register flag %s",
+						rel, lineNum, "htmlgraph "+cmdStr, flag))
+			}
+		}
+	}
+	return violations
+}
+
+// resolveCobraCommand walks the cobra tree matching path tokens greedily. It
+// returns the deepest command that all leading tokens resolve to; the first
+// token that isn't a registered subcommand is treated as a positional
+// argument (e.g. an <id>) and ends the walk. Returns nil if root is nil or
+// the very first token doesn't resolve.
+func resolveCobraCommand(root *cobra.Command, path []string) *cobra.Command {
+	if root == nil {
+		return nil
+	}
+	cur := root
+	matched := false
+	for _, token := range path {
+		var next *cobra.Command
+		for _, c := range cur.Commands() {
+			if c.Name() == token {
+				next = c
+				break
+			}
+		}
+		if next == nil {
+			break
+		}
+		cur = next
+		matched = true
+	}
+	if !matched {
+		return nil
+	}
+	return cur
+}
+
+// commandRegistersFlag returns true if cmd (or any of its parents) registers the
+// given flag via Flags() or PersistentFlags().
+func commandRegistersFlag(cmd *cobra.Command, flag string) bool {
+	name := strings.TrimPrefix(flag, "--")
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Flags().Lookup(name) != nil {
+			return true
+		}
+		if c.PersistentFlags().Lookup(name) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// lineNumberFor returns the 1-based line number for the byte offset within
+// content. Used for nice error messages.
+func lineNumberFor(lines []string, content string, offset int) int {
+	if offset < 0 || offset >= len(content) {
+		return 0
+	}
+	return strings.Count(content[:offset], "\n") + 1
+}
+
+// repoRootForTest walks upward from the test's working directory looking for a
+// go.mod. The plugin asset tree lives at repo-root/plugin/... so tests need
+// to resolve that path regardless of which package they're executed from.
+// Wraps the package-internal findRepoRoot helper with a t.Fatal-on-error
+// signature convenient for test code.
+func repoRootForTest(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	root, err := findRepoRoot(cwd)
+	if err != nil {
+		t.Fatalf("findRepoRoot: %v", err)
+	}
+	return root
+}

--- a/cmd/htmlgraph/statusline.go
+++ b/cmd/htmlgraph/statusline.go
@@ -150,29 +150,6 @@ func resolveTrackContext(database *sql.DB, dir, featureID string) string {
 	return fmt.Sprintf("%s %s [%d/%d]", iconFor("track"), title, done, total)
 }
 
-func statuslineFromHTML(dir string) error {
-	p, err := workitem.Open(dir, "claude-code")
-	if err != nil {
-		return nil
-	}
-	defer p.Close()
-
-	for _, typeName := range []string{"bug", "feature"} {
-		col := collectionFor(p, typeName)
-		nodes, err := col.List()
-		if err != nil {
-			continue
-		}
-		for _, n := range nodes {
-			if n.Status == "in-progress" {
-				fmt.Printf("%s %s\n", iconFor(typeName), truncate(n.Title, 30))
-				return nil
-			}
-		}
-	}
-
-	return nil
-}
 
 func iconFor(typeName string) string {
 	switch typeName {

--- a/cmd/htmlgraph/statusline.go
+++ b/cmd/htmlgraph/statusline.go
@@ -39,8 +39,10 @@ func runStatusline(sessionID string) error {
 		return statuslineFromSession(dir, sessionID)
 	}
 
-	// Fallback: scan HTML files for any in-progress item.
-	return statuslineFromHTML(dir)
+	// No session ID: return nothing. The global HTML scan has no session context and
+	// would leak cross-session state (e.g. show a bug from session B when session A
+	// is calling). An empty statusline is correct when no session is scoped.
+	return nil
 }
 
 func statuslineFromSession(dir, sessionID string) error {

--- a/cmd/htmlgraph/statusline_test.go
+++ b/cmd/htmlgraph/statusline_test.go
@@ -212,6 +212,62 @@ func TestReadStatuslineCache_EmptyOnMissing(t *testing.T) {
 	}
 }
 
+// TestRunStatuslineEmptySession verifies that runStatusline with an empty session ID
+// returns nil and produces no output, even when in-progress work items exist on disk.
+// This prevents cross-session state leakage (bug-33476dbf).
+func TestRunStatuslineEmptySession(t *testing.T) {
+	tmpDir := t.TempDir()
+	htmlgraphDir := filepath.Join(tmpDir, ".htmlgraph")
+	// Create the standard subdirectories so workitem.Open succeeds if it were called.
+	for _, sub := range []string{"features", "bugs", "spikes", "tracks", "plans", "specs"} {
+		if err := os.MkdirAll(filepath.Join(htmlgraphDir, sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+
+	// Write a synthetic in-progress feature HTML so statuslineFromHTML *would* return
+	// output if it were invoked.
+	featureHTML := `<!DOCTYPE html><html><head>
+<meta name="id" content="feat-leak1">
+<meta name="type" content="feature">
+<meta name="status" content="in-progress">
+<meta name="title" content="Leaked Feature">
+</head><body></body></html>`
+	featurePath := filepath.Join(htmlgraphDir, "features", "feat-leak1.html")
+	if err := os.WriteFile(featurePath, []byte(featureHTML), 0o644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+
+	// Point the project directory at tmpDir so findHtmlgraphDir can resolve it.
+	oldProjectDir := projectDirFlag
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = oldProjectDir }()
+
+	// Capture stdout to ensure nothing is printed.
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	gotErr := runStatusline("") // empty session
+
+	w.Close()
+	os.Stdout = origStdout
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	if gotErr != nil {
+		t.Errorf("runStatusline(\"\") returned error: %v", gotErr)
+	}
+	if output != "" {
+		t.Errorf("runStatusline(\"\") should produce no output, got %q", output)
+	}
+}
+
 func TestStatuslineCacheProjectIsolation(t *testing.T) {
 	cacheDir := t.TempDir()
 	t.Setenv("HTMLGRAPH_CACHE_DIR", cacheDir)

--- a/cmd/htmlgraph/statusline_test.go
+++ b/cmd/htmlgraph/statusline_test.go
@@ -175,7 +175,7 @@ func TestWriteStatuslineCache_ClearsOnComplete(t *testing.T) {
 	cacheDir := t.TempDir()
 	t.Setenv("HTMLGRAPH_CACHE_DIR", cacheDir)
 
-	hgDir := "/tmp/test-clear/.htmlgraph"
+	hgDir := filepath.Join(t.TempDir(), ".htmlgraph")
 	cachePath := statuslineCachePath(hgDir)
 	os.WriteFile(cachePath, []byte("old data"), 0o644)
 
@@ -192,7 +192,7 @@ func TestReadStatuslineCache_ReadsFile(t *testing.T) {
 	cacheDir := t.TempDir()
 	t.Setenv("HTMLGRAPH_CACHE_DIR", cacheDir)
 
-	hgDir := "/tmp/test-project/.htmlgraph"
+	hgDir := filepath.Join(t.TempDir(), ".htmlgraph")
 	// Write to the project-scoped path.
 	cachePath := statuslineCachePath(hgDir)
 	os.WriteFile(cachePath, []byte("test content"), 0o644)
@@ -206,7 +206,7 @@ func TestReadStatuslineCache_ReadsFile(t *testing.T) {
 func TestReadStatuslineCache_EmptyOnMissing(t *testing.T) {
 	t.Setenv("HTMLGRAPH_CACHE_DIR", t.TempDir())
 
-	got := ReadStatuslineCache("/tmp/nonexistent/.htmlgraph")
+	got := ReadStatuslineCache(filepath.Join(t.TempDir(), "nonexistent", ".htmlgraph"))
 	if got != "" {
 		t.Errorf("expected empty for missing cache, got %q", got)
 	}
@@ -272,8 +272,8 @@ func TestStatuslineCacheProjectIsolation(t *testing.T) {
 	cacheDir := t.TempDir()
 	t.Setenv("HTMLGRAPH_CACHE_DIR", cacheDir)
 
-	dirA := "/tmp/project-a/.htmlgraph"
-	dirB := "/tmp/project-b/.htmlgraph"
+	dirA := filepath.Join(t.TempDir(), "project-a", ".htmlgraph")
+	dirB := filepath.Join(t.TempDir(), "project-b", ".htmlgraph")
 
 	// Write cache for project A.
 	pathA := statuslineCachePath(dirA)

--- a/cmd/htmlgraph/terminal_handlers.go
+++ b/cmd/htmlgraph/terminal_handlers.go
@@ -8,20 +8,34 @@ import (
 	"github.com/shakestzd/htmlgraph/internal/terminal"
 )
 
+// terminalStarter is the interface used by handleTerminalStart.
+// Defined as an interface to allow mocking in tests.
+type terminalStarter interface {
+	Start(req terminal.StartRequest, defaultDir string) (port, pid int, err error)
+	Stop(pid int) error
+}
+
 // terminalMgr is the package-level manager for ttyd sidecar processes.
 // It is initialised once and shared across all requests.
-var terminalMgr = terminal.NewManager()
+var terminalMgr terminalStarter = terminal.NewManager()
 
 // terminalStartRequest is the JSON body for POST /api/terminal/start.
+// All fields are optional; zero values fall back to MVP defaults.
 type terminalStartRequest struct {
+	Agent    string `json:"agent"`
+	Mode     string `json:"mode"`
+	CWD      string `json:"cwd"`
 	WorkItem string `json:"work_item"`
 }
 
 // terminalStartResponse is the JSON body returned on success.
 type terminalStartResponse struct {
-	Port int    `json:"port"`
-	Pid  int    `json:"pid"`
-	URL  string `json:"url"`
+	Port     int    `json:"port"`
+	Pid      int    `json:"pid"`
+	URL      string `json:"url"`
+	Agent    string `json:"agent,omitempty"`
+	Mode     string `json:"mode,omitempty"`
+	WorkItem string `json:"work_item,omitempty"`
 }
 
 // terminalStopRequest is the JSON body for POST /api/terminal/stop.
@@ -31,7 +45,12 @@ type terminalStopRequest struct {
 
 // handleTerminalStart handles POST /api/terminal/start.
 // It spawns a ttyd sidecar on a free port and returns the access URL.
-func handleTerminalStart(projectDir string) http.HandlerFunc {
+// The starter parameter allows injection of a mock for testing.
+func handleTerminalStart(projectDir string, starter ...terminalStarter) http.HandlerFunc {
+	mgr := terminalMgr
+	if len(starter) > 0 && starter[0] != nil {
+		mgr = starter[0]
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -44,7 +63,13 @@ func handleTerminalStart(projectDir string) http.HandlerFunc {
 			return
 		}
 
-		port, pid, err := terminalMgr.Start(projectDir, req.WorkItem)
+		startReq := terminal.StartRequest{
+			Agent:    req.Agent,
+			Mode:     req.Mode,
+			CWD:      req.CWD,
+			WorkItem: req.WorkItem,
+		}
+		port, pid, err := mgr.Start(startReq, projectDir)
 		if err != nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -52,17 +77,34 @@ func handleTerminalStart(projectDir string) http.HandlerFunc {
 			return
 		}
 
+		// Echo back effective agent/mode so callers can verify what launched.
+		agent := req.Agent
+		if agent == "" {
+			agent = "claude"
+		}
+		mode := req.Mode
+		if mode == "" {
+			mode = "dev"
+		}
+
 		respondJSON(w, terminalStartResponse{
-			Port: port,
-			Pid:  pid,
-			URL:  fmt.Sprintf("http://127.0.0.1:%d", port),
+			Port:     port,
+			Pid:      pid,
+			URL:      fmt.Sprintf("http://127.0.0.1:%d", port),
+			Agent:    agent,
+			Mode:     mode,
+			WorkItem: req.WorkItem,
 		})
 	}
 }
 
 // handleTerminalStop handles POST /api/terminal/stop.
 // It signals the ttyd process identified by pid to terminate.
-func handleTerminalStop() http.HandlerFunc {
+func handleTerminalStop(starter ...terminalStarter) http.HandlerFunc {
+	mgr := terminalMgr
+	if len(starter) > 0 && starter[0] != nil {
+		mgr = starter[0]
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -79,7 +121,7 @@ func handleTerminalStop() http.HandlerFunc {
 			return
 		}
 
-		if err := terminalMgr.Stop(req.Pid); err != nil {
+		if err := mgr.Stop(req.Pid); err != nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
 			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})

--- a/cmd/htmlgraph/terminal_handlers_test.go
+++ b/cmd/htmlgraph/terminal_handlers_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/shakestzd/htmlgraph/internal/terminal"
+)
+
+// mockTerminalStarter is a test double that records Start calls without spawning ttyd.
+type mockTerminalStarter struct {
+	lastReq    terminal.StartRequest
+	lastDir    string
+	returnPort int
+	returnPid  int
+	returnErr  error
+}
+
+func (m *mockTerminalStarter) Start(req terminal.StartRequest, defaultDir string) (int, int, error) {
+	m.lastDir = defaultDir
+	m.lastReq = req
+	return m.returnPort, m.returnPid, m.returnErr
+}
+
+func (m *mockTerminalStarter) Stop(pid int) error {
+	return nil
+}
+
+// TestTerminalStartHandler_EmptyBody verifies that POST {} returns 200 and spawns
+// the default claude --dev session in the server's projectDir (back-compat).
+func TestTerminalStartHandler_EmptyBody(t *testing.T) {
+	mock := &mockTerminalStarter{returnPort: 9999, returnPid: 1234}
+	handler := handleTerminalStart("/srv/project", mock)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/terminal/start", bytes.NewBufferString("{}"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 — body: %s", rec.Code, rec.Body)
+	}
+
+	// Empty body should default to agent=claude, mode=dev.
+	if mock.lastReq.Agent != "" {
+		t.Errorf("expected Agent to be empty (handler passes through; terminal applies default), got %q", mock.lastReq.Agent)
+	}
+	if mock.lastReq.Mode != "" {
+		t.Errorf("expected Mode to be empty (handler passes through; terminal applies default), got %q", mock.lastReq.Mode)
+	}
+	if mock.lastDir != "/srv/project" {
+		t.Errorf("expected projectDir /srv/project, got %q", mock.lastDir)
+	}
+
+	var resp terminalStartResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Port != 9999 {
+		t.Errorf("port: got %d, want 9999", resp.Port)
+	}
+	if resp.Pid != 1234 {
+		t.Errorf("pid: got %d, want 1234", resp.Pid)
+	}
+	// Empty body → handler echoes back defaults.
+	if resp.Agent != "claude" {
+		t.Errorf("agent in response: got %q, want claude", resp.Agent)
+	}
+	if resp.Mode != "dev" {
+		t.Errorf("mode in response: got %q, want dev", resp.Mode)
+	}
+}
+
+// TestTerminalStartHandler_CustomAgent verifies that custom agent/mode/cwd/work_item
+// fields are decoded and passed through to the manager correctly.
+func TestTerminalStartHandler_CustomAgent(t *testing.T) {
+	mock := &mockTerminalStarter{returnPort: 8888, returnPid: 5678}
+	handler := handleTerminalStart("/srv/project", mock)
+
+	body := `{"agent":"codex","mode":"dev","cwd":"/tmp/test","work_item":"feat-abc"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/terminal/start", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 — body: %s", rec.Code, rec.Body)
+	}
+
+	if mock.lastReq.Agent != "codex" {
+		t.Errorf("agent: got %q, want codex", mock.lastReq.Agent)
+	}
+	if mock.lastReq.Mode != "dev" {
+		t.Errorf("mode: got %q, want dev", mock.lastReq.Mode)
+	}
+	if mock.lastReq.CWD != "/tmp/test" {
+		t.Errorf("cwd: got %q, want /tmp/test", mock.lastReq.CWD)
+	}
+	if mock.lastReq.WorkItem != "feat-abc" {
+		t.Errorf("work_item: got %q, want feat-abc", mock.lastReq.WorkItem)
+	}
+
+	var resp terminalStartResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.WorkItem != "feat-abc" {
+		t.Errorf("work_item in response: got %q, want feat-abc", resp.WorkItem)
+	}
+	if resp.Agent != "codex" {
+		t.Errorf("agent in response: got %q, want codex", resp.Agent)
+	}
+}
+
+// TestTerminalStartHandler_MethodNotAllowed verifies that GET returns 405.
+func TestTerminalStartHandler_MethodNotAllowed(t *testing.T) {
+	mock := &mockTerminalStarter{}
+	handler := handleTerminalStart("/srv/project", mock)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/terminal/start", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status: got %d, want 405", rec.Code)
+	}
+}

--- a/cmd/htmlgraph/terminal_handlers_test.go
+++ b/cmd/htmlgraph/terminal_handlers_test.go
@@ -80,7 +80,7 @@ func TestTerminalStartHandler_CustomAgent(t *testing.T) {
 	mock := &mockTerminalStarter{returnPort: 8888, returnPid: 5678}
 	handler := handleTerminalStart("/srv/project", mock)
 
-	body := `{"agent":"codex","mode":"dev","cwd":"/tmp/test","work_item":"feat-abc"}`
+	body := `{"agent":"codex","mode":"dev","cwd":"/mock/test","work_item":"feat-abc"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/terminal/start", strings.NewReader(body))
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
@@ -95,8 +95,8 @@ func TestTerminalStartHandler_CustomAgent(t *testing.T) {
 	if mock.lastReq.Mode != "dev" {
 		t.Errorf("mode: got %q, want dev", mock.lastReq.Mode)
 	}
-	if mock.lastReq.CWD != "/tmp/test" {
-		t.Errorf("cwd: got %q, want /tmp/test", mock.lastReq.CWD)
+	if mock.lastReq.CWD != "/mock/test" {
+		t.Errorf("cwd: got %q, want /mock/test", mock.lastReq.CWD)
 	}
 	if mock.lastReq.WorkItem != "feat-abc" {
 		t.Errorf("work_item: got %q, want feat-abc", mock.lastReq.WorkItem)

--- a/cmd/htmlgraph/testdata/bad-path-sample.html
+++ b/cmd/htmlgraph/testdata/bad-path-sample.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head><title>Test: bad path sample</title></head>
+<body>
+<!-- This file contains a host-local absolute path and should be flagged by check-host-paths -->
+<p>Project root: /Users/fakeuser/project/htmlgraph</p>
+<p>Config file: /home/devuser/config/settings.yaml</p>
+<p>Workspace: /workspaces/fakeuser/htmlgraph</p>
+</body>
+</html>

--- a/cmd/htmlgraph/testdata/clean-sample.html
+++ b/cmd/htmlgraph/testdata/clean-sample.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head><title>Test: clean sample</title></head>
+<body>
+<!-- This file contains no host-local absolute paths and should pass check-host-paths -->
+<p>Project: htmlgraph</p>
+<p>CI user: /home/runner/work/htmlgraph</p>
+<p>Relative path: ./cmd/htmlgraph/main.go</p>
+<p>Generic path: /usr/local/bin/htmlgraph</p>
+</body>
+</html>

--- a/cmd/htmlgraph/testdata/skill_flag_bad.md
+++ b/cmd/htmlgraph/testdata/skill_flag_bad.md
@@ -1,0 +1,8 @@
+# Fixture — bad flag that should be flagged
+
+The skill-flag validator must fail on the invocation below, because
+`htmlgraph feature show` does not register `--this-flag-doesnt-exist`.
+
+```
+htmlgraph feature show feat-abc123 --this-flag-doesnt-exist
+```

--- a/cmd/htmlgraph/testdata/skill_flag_good.md
+++ b/cmd/htmlgraph/testdata/skill_flag_good.md
@@ -1,0 +1,10 @@
+# Fixture — only real flags
+
+Each of the invocations below uses a flag that is registered on its target
+command. The skill-flag validator must not report any violation.
+
+```
+htmlgraph track show trk-abc123 --format json
+htmlgraph track show trk-abc123 --deep
+htmlgraph feature show feat-abc123 --format json
+```

--- a/cmd/htmlgraph/track.go
+++ b/cmd/htmlgraph/track.go
@@ -40,19 +40,26 @@ func trackCmdWithExtras() *cobra.Command {
 // trackShowCmd shows a single track by ID.
 func trackShowCmd() *cobra.Command {
 	var deep bool
+	var format string
 	cmd := &cobra.Command{
 		Use:   "show <id>",
 		Short: "Show track details",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runTrackShow(args[0], deep)
+			return runTrackShowWithFormat(args[0], deep, format)
 		},
 	}
 	cmd.Flags().BoolVar(&deep, "deep", false, "Show all linked items with steps and edges")
+	cmd.Flags().StringVar(&format, "format", "text", "Output format: json or text")
 	return cmd
 }
 
 func runTrackShow(id string, deep bool) error {
+	return runTrackShowWithFormat(id, deep, "text")
+}
+
+// runTrackShowWithFormat shows a track in the requested format (text or json).
+func runTrackShowWithFormat(id string, deep bool, format string) error {
 	dir, err := findHtmlgraphDir()
 	if err != nil {
 		return err
@@ -73,12 +80,17 @@ func runTrackShow(id string, deep bool) error {
 		return fmt.Errorf("parse %s: %w", path, err)
 	}
 
-	if deep {
-		printTrackDeep(node, dir)
-	} else {
-		printTrackDetail(node, dir)
+	switch format {
+	case "json":
+		return printNodeDetailJSON(node)
+	default:
+		if deep {
+			printTrackDeep(node, dir)
+		} else {
+			printTrackDetail(node, dir)
+		}
+		return nil
 	}
-	return nil
 }
 
 // topoSortFeatures returns features sorted by dependency order using blocked_by

--- a/cmd/htmlgraph/workitem.go
+++ b/cmd/htmlgraph/workitem.go
@@ -197,9 +197,6 @@ func wiSetStatusWithAgent(typeName, id, status, sessionID, agentID string) error
 	if status == "in-progress" {
 		if sessionID != "" {
 			if p.DB != nil {
-				// Short-circuit: skip all writes if this (session, agent) already
-				// claims this work item. Eliminates redundant SQLite writes under
-				// parallel dispatch where N subagents call start on their own feature.
 				currentActive := dbpkg.GetActiveWorkItem(p.DB, sessionID, agentID)
 				if currentActive != id {
 					// New per-agent attribution table (primary write path).
@@ -214,16 +211,23 @@ func wiSetStatusWithAgent(typeName, id, status, sessionID, agentID string) error
 					if agentID == dbpkg.AgentRootSentinel {
 						_ = hooks.UpdateActiveFeature(p.DB, sessionID, id)
 					}
-					claim := &models.Claim{
-						ClaimID:          "clm-" + uuid.NewString()[:8],
-						WorkItemID:       id,
-						OwnerSessionID:   sessionID,
-						OwnerAgent:       agentForClaim(),
-						ClaimedByAgentID: agentID,
-						Status:           models.ClaimInProgress,
-					}
-					_ = dbpkg.ClaimItem(p.DB, claim, 30*time.Minute)
 				}
+				// Always write (or renew) the claim row regardless of whether
+				// active_work_items already shows this item for (session, agent).
+				// active_work_items and claims are separate tables that can diverge:
+				// an expired or never-written claim row causes ClaimedItem=="" in
+				// the PreToolUse guard, blocking all Write/Edit. ClaimItemOrRenew
+				// is idempotent — it refreshes an existing live claim's lease or
+				// inserts a new row if none exists (bug-0d55d8e4).
+				claim := &models.Claim{
+					ClaimID:          "clm-" + uuid.NewString()[:8],
+					WorkItemID:       id,
+					OwnerSessionID:   sessionID,
+					OwnerAgent:       agentForClaim(),
+					ClaimedByAgentID: agentID,
+					Status:           models.ClaimInProgress,
+				}
+				_ = dbpkg.ClaimItemOrRenew(p.DB, claim, 30*time.Minute)
 			}
 			autoImplementedInEdge(col, id, sessionID, p.DB)
 		}

--- a/cmd/htmlgraph/workitem.go
+++ b/cmd/htmlgraph/workitem.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -96,17 +97,25 @@ func runWiList(dirName, statusFilter string) error {
 }
 
 func wiShowCmd(typeName string) *cobra.Command {
-	return &cobra.Command{
+	var format string
+	cmd := &cobra.Command{
 		Use:   "show <id>",
 		Short: "Show " + typeName + " details",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runWiShow(args[0])
+			return runWiShowWithFormat(args[0], format)
 		},
 	}
+	cmd.Flags().StringVar(&format, "format", "text", "Output format: json or text")
+	return cmd
 }
 
 func runWiShow(id string) error {
+	return runWiShowWithFormat(id, "text")
+}
+
+// runWiShowWithFormat shows a work item in the requested format (text or json).
+func runWiShowWithFormat(id, format string) error {
 	dir, err := findHtmlgraphDir()
 	if err != nil {
 		return err
@@ -124,7 +133,22 @@ func runWiShow(id string) error {
 	if err != nil {
 		return fmt.Errorf("parse %s: %w", path, err)
 	}
-	printNodeDetail(node)
+	switch format {
+	case "json":
+		return printNodeDetailJSON(node)
+	default:
+		printNodeDetail(node)
+		return nil
+	}
+}
+
+// printNodeDetailJSON outputs a node as indented JSON.
+func printNodeDetailJSON(node *models.Node) error {
+	data, err := json.MarshalIndent(node, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal json: %w", err)
+	}
+	fmt.Println(string(data))
 	return nil
 }
 

--- a/cmd/htmlgraph/workitem_test.go
+++ b/cmd/htmlgraph/workitem_test.go
@@ -846,6 +846,193 @@ func TestFeatureStart_DifferentFeatures(t *testing.T) {
 	}
 }
 
+// TestFeatureStart_ClaimWrittenOnFirstStart verifies that a claim row is written
+// to the claims table on the very first call to feature start (bug-0d55d8e4).
+func TestFeatureStart_ClaimWrittenOnFirstStart(t *testing.T) {
+	const sessionID = "test-session-claim-first-start"
+	const agentID = dbpkg.AgentRootSentinel
+
+	tmpDir, hgDir := testHgDirWithDB(t, sessionID)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+	t.Setenv("HTMLGRAPH_SESSION_ID", sessionID)
+	t.Setenv("HTMLGRAPH_CACHE_DIR", tmpDir)
+
+	trackID := testSetupTrack(t, hgDir)
+
+	if err := testCreate("feature", "Claim First Start", trackID, "medium", false, false); err != nil {
+		t.Fatalf("create feature: %v", err)
+	}
+	featFiles, _ := filepath.Glob(filepath.Join(hgDir, "features", "feat-*.html"))
+	if len(featFiles) != 1 {
+		t.Fatalf("expected 1 feature file, got %d", len(featFiles))
+	}
+	featNode, _ := htmlparse.ParseFile(featFiles[0])
+	featID := featNode.ID
+
+	if err := wiSetStatusWithAgent("feature", featID, "in-progress", sessionID, agentID); err != nil {
+		t.Fatalf("first start: %v", err)
+	}
+
+	database, err := dbpkg.Open(filepath.Join(hgDir, "htmlgraph.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	var count int
+	database.QueryRow(
+		`SELECT COUNT(*) FROM claims WHERE work_item_id = ? AND claimed_by_agent_id = ? AND status IN ('proposed','claimed','in_progress','blocked','handoff_pending')`,
+		featID, agentID,
+	).Scan(&count)
+	if count != 1 {
+		t.Errorf("want 1 live claim row after first start, got %d", count)
+	}
+}
+
+// TestFeatureStart_ClaimRenewedOnRepeatStart verifies that calling feature start
+// twice on the same item with the same (session, agent) does not create a
+// duplicate live claim row — the existing claim's lease is renewed instead
+// (bug-0d55d8e4 fix: ClaimItemOrRenew is idempotent).
+func TestFeatureStart_ClaimRenewedOnRepeatStart(t *testing.T) {
+	const sessionID = "test-session-claim-repeat-start"
+	const agentID = dbpkg.AgentRootSentinel
+
+	tmpDir, hgDir := testHgDirWithDB(t, sessionID)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+	t.Setenv("HTMLGRAPH_SESSION_ID", sessionID)
+	t.Setenv("HTMLGRAPH_CACHE_DIR", tmpDir)
+
+	trackID := testSetupTrack(t, hgDir)
+
+	if err := testCreate("feature", "Claim Repeat Start", trackID, "medium", false, false); err != nil {
+		t.Fatalf("create feature: %v", err)
+	}
+	featFiles, _ := filepath.Glob(filepath.Join(hgDir, "features", "feat-*.html"))
+	if len(featFiles) != 1 {
+		t.Fatalf("expected 1 feature file, got %d", len(featFiles))
+	}
+	featNode, _ := htmlparse.ParseFile(featFiles[0])
+	featID := featNode.ID
+
+	// First start.
+	if err := wiSetStatusWithAgent("feature", featID, "in-progress", sessionID, agentID); err != nil {
+		t.Fatalf("first start: %v", err)
+	}
+
+	// Second start — same item, same agent (short-circuit path in active_work_items,
+	// but ClaimItemOrRenew must still run to refresh/ensure the live claim row).
+	if err := wiSetStatusWithAgent("feature", featID, "in-progress", sessionID, agentID); err != nil {
+		t.Fatalf("second start: %v", err)
+	}
+
+	database, err := dbpkg.Open(filepath.Join(hgDir, "htmlgraph.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	// Must have exactly one live claim row (no duplicates) after two starts.
+	var count int
+	database.QueryRow(
+		`SELECT COUNT(*) FROM claims WHERE work_item_id = ? AND claimed_by_agent_id = ? AND status IN ('proposed','claimed','in_progress','blocked','handoff_pending')`,
+		featID, agentID,
+	).Scan(&count)
+	if count != 1 {
+		t.Errorf("want 1 live claim row after repeat start, got %d (no duplicates)", count)
+	}
+}
+
+// TestFeatureStart_ClaimWrittenAfterExpiry verifies that feature start writes a
+// fresh live claim row when the previous claim has expired, even if
+// active_work_items still shows the item as active for this (session, agent).
+// This is the core scenario of bug-0d55d8e4: the short-circuit on
+// active_work_items was preventing the claim re-write when the claim expired.
+func TestFeatureStart_ClaimWrittenAfterExpiry(t *testing.T) {
+	const sessionID = "test-session-claim-after-expiry"
+	const agentID = dbpkg.AgentRootSentinel
+
+	tmpDir, hgDir := testHgDirWithDB(t, sessionID)
+	projectDirFlag = tmpDir
+	defer func() { projectDirFlag = "" }()
+	t.Setenv("HTMLGRAPH_SESSION_ID", sessionID)
+	t.Setenv("HTMLGRAPH_CACHE_DIR", tmpDir)
+
+	trackID := testSetupTrack(t, hgDir)
+
+	if err := testCreate("feature", "Claim After Expiry", trackID, "medium", false, false); err != nil {
+		t.Fatalf("create feature: %v", err)
+	}
+	featFiles, _ := filepath.Glob(filepath.Join(hgDir, "features", "feat-*.html"))
+	if len(featFiles) != 1 {
+		t.Fatalf("expected 1 feature file, got %d", len(featFiles))
+	}
+	featNode, _ := htmlparse.ParseFile(featFiles[0])
+	featID := featNode.ID
+
+	// First start — writes claim and active_work_items.
+	if err := wiSetStatusWithAgent("feature", featID, "in-progress", sessionID, agentID); err != nil {
+		t.Fatalf("first start: %v", err)
+	}
+
+	database, err := dbpkg.Open(filepath.Join(hgDir, "htmlgraph.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	// Manually expire the claim by back-dating its lease.
+	pastTime := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	_, err = database.Exec(
+		`UPDATE claims SET lease_expires_at = ?, last_heartbeat_at = ? WHERE work_item_id = ? AND claimed_by_agent_id = ?`,
+		pastTime, pastTime, featID, agentID,
+	)
+	if err != nil {
+		t.Fatalf("expire claim: %v", err)
+	}
+
+	// Verify claim is now expired (sanity check).
+	var liveCount int
+	database.QueryRow(
+		`SELECT COUNT(*) FROM claims WHERE work_item_id = ? AND claimed_by_agent_id = ? AND status IN ('proposed','claimed','in_progress','blocked','handoff_pending')`,
+		featID, agentID,
+	).Scan(&liveCount)
+	// NOTE: The claim is expired by timestamp but not yet reaped by status.
+	// ReapExpiredClaims runs at the start of ClaimItemOrRenew.
+
+	// active_work_items still shows the item as active (tables are diverged).
+	gotActive := dbpkg.GetActiveWorkItem(database, sessionID, agentID)
+	if gotActive != featID {
+		t.Fatalf("precondition: active_work_items should still show %q, got %q", featID, gotActive)
+	}
+
+	// Close DB — wiSetStatusWithAgent opens its own connection.
+	database.Close()
+
+	// Second start — active_work_items shows short-circuit condition, but the
+	// prior claim is expired. ClaimItemOrRenew must write a fresh claim.
+	if err := wiSetStatusWithAgent("feature", featID, "in-progress", sessionID, agentID); err != nil {
+		t.Fatalf("second start after expiry: %v", err)
+	}
+
+	database2, err := dbpkg.Open(filepath.Join(hgDir, "htmlgraph.db"))
+	if err != nil {
+		t.Fatalf("open db2: %v", err)
+	}
+	defer database2.Close()
+
+	// Must have exactly one live claim row after re-start.
+	var liveClaims int
+	database2.QueryRow(
+		`SELECT COUNT(*) FROM claims WHERE work_item_id = ? AND claimed_by_agent_id = ? AND status IN ('proposed','claimed','in_progress','blocked','handoff_pending')`,
+		featID, agentID,
+	).Scan(&liveClaims)
+	if liveClaims != 1 {
+		t.Errorf("want 1 live claim row after re-start post-expiry, got %d", liveClaims)
+	}
+}
+
 // TestRunWiSetStatus_ConcurrentAgents proves that N goroutines with distinct
 // agentIDs can each claim different features on the same session without
 // contention, error, or loss.

--- a/cmd/htmlgraph/worktree_helpers.go
+++ b/cmd/htmlgraph/worktree_helpers.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"io"
+
+	"github.com/shakestzd/htmlgraph/internal/worktree"
+)
+
+// EnsureForFeature ensures a git worktree exists for the given feature and returns its path.
+// When the feature belongs to a parent track, the track worktree is created/reused instead.
+// Progress is written to w; pass io.Discard to suppress output.
+func EnsureForFeature(featureID, repoRoot string, w io.Writer) (string, error) {
+	return worktree.EnsureForFeature(featureID, repoRoot, w)
+}
+
+// EnsureForTrack ensures a git worktree exists for the given track and returns its path.
+// Progress is written to w; pass io.Discard to suppress output.
+func EnsureForTrack(trackID, repoRoot string, w io.Writer) (string, error) {
+	return worktree.EnsureForTrack(trackID, repoRoot, w)
+}
+
+// EnsureForAgent ensures a git worktree exists for the given agent task and returns its path.
+// The worktree branches from the track branch and is placed at
+// .claude/worktrees/<trackID>/agent-<taskName>.
+// Progress is written to w; pass io.Discard to suppress output.
+func EnsureForAgent(trackID, taskName, repoRoot string, w io.Writer) (string, error) {
+	return worktree.EnsureForAgent(trackID, taskName, repoRoot, w)
+}

--- a/cmd/htmlgraph/worktree_helpers_test.go
+++ b/cmd/htmlgraph/worktree_helpers_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupWorktreeGitRepo creates a temp git repo with an initial commit and returns its path.
+func setupWorktreeGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	cmds := [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+	}
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v failed: %s", args, out)
+		}
+	}
+
+	f, err := os.Create(filepath.Join(dir, "README.md"))
+	if err != nil {
+		t.Fatalf("create README: %v", err)
+	}
+	f.WriteString("# Test")
+	f.Close()
+
+	exec.Command("git", "-C", dir, "add", ".").Run()     //nolint:errcheck
+	exec.Command("git", "-C", dir, "commit",             //nolint:errcheck
+		"-c", "user.name=test", "-c", "user.email=test@test.com",
+		"-m", "initial",
+	).Run()
+
+	return dir
+}
+
+// writeFeatureHTML writes a minimal feature HTML file. If trackID is empty, data-track-id is omitted.
+func writeFeatureHTML(t *testing.T, dir, featureID, trackID string) {
+	t.Helper()
+	featureDir := filepath.Join(dir, ".htmlgraph", "features")
+	if err := os.MkdirAll(featureDir, 0755); err != nil {
+		t.Fatalf("mkdir features: %v", err)
+	}
+	trackAttr := ""
+	if trackID != "" {
+		trackAttr = ` data-track-id="` + trackID + `"`
+	}
+	html := `<article id="` + featureID + `"` + trackAttr + ` data-status="todo">` +
+		`<header><h1>Test Feature</h1></header>` +
+		`<section data-content><p>Description</p></section>` +
+		`</article>`
+	path := filepath.Join(featureDir, featureID+".html")
+	if err := os.WriteFile(path, []byte(html), 0644); err != nil {
+		t.Fatalf("write feature HTML: %v", err)
+	}
+}
+
+// TestEnsureForFeature_CreatesOnFirstCall verifies that the first call creates the worktree.
+func TestEnsureForFeature_CreatesOnFirstCall(t *testing.T) {
+	dir := setupWorktreeGitRepo(t)
+	writeFeatureHTML(t, dir, "feat-aaa", "")
+
+	path, err := EnsureForFeature("feat-aaa", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("EnsureForFeature: %v", err)
+	}
+
+	expected := filepath.Join(dir, ".claude", "worktrees", "feat-aaa")
+	if path != expected {
+		t.Errorf("path: got %q, want %q", path, expected)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("worktree dir does not exist: %v", err)
+	}
+}
+
+// TestEnsureForFeature_IdempotentSecondCall verifies that a second call returns the same path without error.
+func TestEnsureForFeature_IdempotentSecondCall(t *testing.T) {
+	dir := setupWorktreeGitRepo(t)
+	writeFeatureHTML(t, dir, "feat-bbb", "")
+
+	path1, err := EnsureForFeature("feat-bbb", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("first EnsureForFeature: %v", err)
+	}
+
+	path2, err := EnsureForFeature("feat-bbb", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("second EnsureForFeature: %v", err)
+	}
+
+	if path1 != path2 {
+		t.Errorf("paths differ: %q vs %q", path1, path2)
+	}
+}
+
+// TestEnsureForFeature_WithParentTrack verifies that when a feature has a parent track,
+// the track worktree path is returned (not the feature path).
+func TestEnsureForFeature_WithParentTrack(t *testing.T) {
+	dir := setupWorktreeGitRepo(t)
+	writeFeatureHTML(t, dir, "feat-ccc", "trk-parent111")
+
+	path, err := EnsureForFeature("feat-ccc", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("EnsureForFeature: %v", err)
+	}
+
+	expectedTrackPath := filepath.Join(dir, ".claude", "worktrees", "trk-parent111")
+	if path != expectedTrackPath {
+		t.Errorf("path: got %q, want track path %q", path, expectedTrackPath)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("track worktree dir does not exist: %v", err)
+	}
+	// Feature worktree should NOT exist
+	featurePath := filepath.Join(dir, ".claude", "worktrees", "feat-ccc")
+	if _, err := os.Stat(featurePath); err == nil {
+		t.Error("feature worktree should NOT exist when feature has a parent track")
+	}
+}
+
+// TestEnsureForTrack_Idempotent verifies that repeated calls to EnsureForTrack return the same path.
+func TestEnsureForTrack_Idempotent(t *testing.T) {
+	dir := setupWorktreeGitRepo(t)
+
+	path1, err := EnsureForTrack("trk-ttt111", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("first EnsureForTrack: %v", err)
+	}
+
+	path2, err := EnsureForTrack("trk-ttt111", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("second EnsureForTrack: %v", err)
+	}
+
+	if path1 != path2 {
+		t.Errorf("paths differ: %q vs %q", path1, path2)
+	}
+
+	expected := filepath.Join(dir, ".claude", "worktrees", "trk-ttt111")
+	if path1 != expected {
+		t.Errorf("path: got %q, want %q", path1, expected)
+	}
+}
+
+// TestEnsureForAgent_ThreeArgSignature verifies the three-arg signature and naming convention.
+func TestEnsureForAgent_ThreeArgSignature(t *testing.T) {
+	// Use setupAgentGitRepo which correctly creates an initial commit.
+	dir := setupAgentGitRepo(t)
+
+	// First create the track branch that the agent will branch from
+	exec.Command("git", "-C", dir, "branch", "trk-agent111").Run() //nolint:errcheck
+
+	path, err := EnsureForAgent("trk-agent111", "slice-3", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("EnsureForAgent: %v", err)
+	}
+
+	expected := filepath.Join(dir, ".claude", "worktrees", "trk-agent111", "agent-slice-3")
+	if path != expected {
+		t.Errorf("path: got %q, want %q", path, expected)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("agent worktree dir does not exist: %v", err)
+	}
+}
+
+// TestEnsureForFeature_WriterReceivesProgress verifies that progress lines are written to the io.Writer.
+func TestEnsureForFeature_WriterReceivesProgress(t *testing.T) {
+	dir := setupWorktreeGitRepo(t)
+	writeFeatureHTML(t, dir, "feat-ddd", "")
+
+	var buf bytes.Buffer
+	_, err := EnsureForFeature("feat-ddd", dir, &buf)
+	if err != nil {
+		t.Fatalf("EnsureForFeature: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "feat-ddd") {
+		t.Errorf("expected writer to receive progress containing feat-ddd; got: %q", output)
+	}
+}
+
+// TestEnsureForFeature_DiscardWriter verifies that passing io.Discard does not panic.
+func TestEnsureForFeature_DiscardWriter(t *testing.T) {
+	dir := setupWorktreeGitRepo(t)
+	writeFeatureHTML(t, dir, "feat-eee", "")
+
+	// Should not panic — just discard all output
+	_, err := EnsureForFeature("feat-eee", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("EnsureForFeature with Discard: %v", err)
+	}
+}

--- a/cmd/htmlgraph/yolo.go
+++ b/cmd/htmlgraph/yolo.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -94,186 +93,6 @@ func validateWorkItem(trackID, featureID, projectRoot string) (id, kind string, 
 	default:
 		return "", "", nil
 	}
-}
-
-// excludeHtmlgraphFromWorktree adds .htmlgraph/ to the worktree's local git exclude file.
-// In git worktrees, .git is a file (not a directory) containing "gitdir: <path>".
-// The actual git metadata is at the gitdir path, so the exclude file is at gitdir/info/exclude.
-// Best-effort: errors are printed but do not abort.
-func excludeHtmlgraphFromWorktree(worktreePath string) {
-	gitFile := filepath.Join(worktreePath, ".git")
-	content, err := os.ReadFile(gitFile)
-	if err != nil {
-		fmt.Printf("  Warning: could not read .git file for exclude setup: %v\n", err)
-		return
-	}
-
-	// Parse the gitdir from the .git file
-	gitdirLine := strings.TrimSpace(string(content))
-	gitdir := strings.TrimPrefix(gitdirLine, "gitdir: ")
-	if gitdir == gitdirLine {
-		// No gitdir prefix found — not a worktree
-		return
-	}
-
-	excludePath := filepath.Join(gitdir, "info", "exclude")
-
-	// Ensure info/ directory exists
-	if err := os.MkdirAll(filepath.Dir(excludePath), 0755); err != nil {
-		fmt.Printf("  Warning: could not create exclude directory: %v\n", err)
-		return
-	}
-
-	// Append .htmlgraph/ to the exclude file
-	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		fmt.Printf("  Warning: could not open exclude file: %v\n", err)
-		return
-	}
-	defer f.Close()
-
-	if _, err := f.WriteString("\n.htmlgraph/\n"); err != nil {
-		fmt.Printf("  Warning: could not write to exclude file: %v\n", err)
-	}
-}
-
-// createFeatureWorktree creates a git worktree at .claude/worktrees/<featureID> on branch
-// yolo-<featureID>. If the worktree path already exists it is reused. Returns the worktree
-// path and a cleanup function that removes the worktree on error.
-func createFeatureWorktree(featureID, projectRoot string) (string, func(), error) {
-	worktreePath := filepath.Join(projectRoot, ".claude", "worktrees", featureID)
-	branchName := "yolo-" + featureID
-	noop := func() {}
-
-	// If path already exists, reuse it — the worktree was created in a prior run.
-	if _, err := os.Stat(worktreePath); err == nil {
-		fmt.Printf("  Worktree: %s (reusing existing)\n", worktreePath)
-		return worktreePath, noop, nil
-	}
-
-	// Ensure the parent directory exists.
-	if err := os.MkdirAll(filepath.Dir(worktreePath), 0755); err != nil {
-		return "", noop, fmt.Errorf("could not create worktrees directory: %w", err)
-	}
-
-	cmd := exec.Command("git", "-C", projectRoot, "worktree", "add", worktreePath, "-b", branchName)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", noop, fmt.Errorf("git worktree add failed: %w\n%s", err, out)
-	}
-
-	fmt.Printf("  Worktree: %s (branch: %s)\n", worktreePath, branchName)
-
-	// Exclude .htmlgraph/ from git status — all CLI ops route to main via HTMLGRAPH_PROJECT_DIR.
-	excludeHtmlgraphFromWorktree(worktreePath)
-
-	// Reindex the worktree SQLite so it reflects current HTML state.
-	reindexWorktree(worktreePath)
-
-	cleanup := func() {
-		removeCmd := exec.Command("git", "-C", projectRoot, "worktree", "remove", "--force", worktreePath)
-		removeCmd.Run() //nolint:errcheck
-	}
-	return worktreePath, cleanup, nil
-}
-
-// createTrackWorktree creates a git worktree at .claude/worktrees/<trackID> on branch
-// trk-<trackID>. If the worktree path already exists it is reused. Returns the worktree
-// path and a cleanup function that removes the worktree on error.
-func createTrackWorktree(trackID, projectRoot string) (string, func(), error) {
-	worktreePath := filepath.Join(projectRoot, ".claude", "worktrees", trackID)
-	branchName := trackID // Track worktrees use branch name trk-abc123, not yolo-trk-abc123
-	noop := func() {}
-
-	// If path already exists, reuse it — the worktree was created in a prior run.
-	if _, err := os.Stat(worktreePath); err == nil {
-		fmt.Printf("  Worktree: %s (reusing existing)\n", worktreePath)
-		return worktreePath, noop, nil
-	}
-
-	// Ensure the parent directory exists.
-	if err := os.MkdirAll(filepath.Dir(worktreePath), 0755); err != nil {
-		return "", noop, fmt.Errorf("could not create worktrees directory: %w", err)
-	}
-
-	cmd := exec.Command("git", "-C", projectRoot, "worktree", "add", worktreePath, "-b", branchName)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", noop, fmt.Errorf("git worktree add failed: %w\n%s", err, out)
-	}
-
-	fmt.Printf("  Worktree: %s (branch: %s)\n", worktreePath, branchName)
-
-	// Exclude .htmlgraph/ from git status — all CLI ops route to main via HTMLGRAPH_PROJECT_DIR.
-	excludeHtmlgraphFromWorktree(worktreePath)
-
-	// Reindex the worktree SQLite so it reflects current HTML state.
-	reindexWorktree(worktreePath)
-
-	cleanup := func() {
-		removeCmd := exec.Command("git", "-C", projectRoot, "worktree", "remove", "--force", worktreePath)
-		removeCmd.Run() //nolint:errcheck
-	}
-	return worktreePath, cleanup, nil
-}
-
-// reindexWorktree runs `htmlgraph reindex` in the given worktree directory so
-// the worktree's SQLite cache is current before Claude launches. Best-effort:
-// failures are printed but do not abort worktree setup.
-func reindexWorktree(worktreeDir string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	exe, err := os.Executable()
-	if err != nil {
-		fmt.Printf("  Warning: could not determine executable path for reindex: %v\n", err)
-		return
-	}
-	reindexCmd := exec.CommandContext(ctx, exe, "reindex")
-	reindexCmd.Dir = worktreeDir
-	if err := reindexCmd.Run(); err != nil {
-		fmt.Printf("  Warning: reindex in worktree failed: %v\n", err)
-	}
-}
-
-// createAgentWorktree creates a git worktree branching from the track branch
-// (not main). The branch is named agent-{trackID}-{taskName} (flat name due to Git's
-// ref hierarchy constraints) and the worktree is placed at .claude/worktrees/{trackID}/agent-{taskName}.
-//
-// The track branch must exist. If the worktree path already exists, it is reused.
-// Returns the worktree path and a cleanup function.
-func createAgentWorktree(trackID, taskName, projectRoot string) (string, func(), error) {
-	agentBranch := "agent-" + trackID + "-" + taskName
-	worktreePath := filepath.Join(projectRoot, ".claude", "worktrees", trackID, "agent-"+taskName)
-	noop := func() {}
-
-	// If path already exists, reuse.
-	if _, err := os.Stat(worktreePath); err == nil {
-		fmt.Printf("  Agent worktree: %s (reusing existing)\n", worktreePath)
-		return worktreePath, noop, nil
-	}
-
-	// Verify track branch exists.
-	if err := exec.Command("git", "-C", projectRoot, "rev-parse", "--verify", trackID).Run(); err != nil {
-		return "", noop, fmt.Errorf("track branch %s not found: create track worktree first with htmlgraph yolo --track %s", trackID, trackID)
-	}
-
-	// Ensure parent directory exists.
-	if err := os.MkdirAll(filepath.Dir(worktreePath), 0755); err != nil {
-		return "", noop, fmt.Errorf("could not create agent worktrees directory: %w", err)
-	}
-
-	// Create worktree branching from track branch.
-	cmd := exec.Command("git", "-C", projectRoot, "worktree", "add", worktreePath, "-b", agentBranch, trackID)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", noop, fmt.Errorf("git worktree add failed: %w\n%s", err, out)
-	}
-
-	fmt.Printf("  Agent worktree: %s (branch: %s, from: %s)\n", worktreePath, agentBranch, trackID)
-
-	cleanup := func() {
-		removeCmd := exec.Command("git", "-C", projectRoot, "worktree", "remove", "--force", worktreePath)
-		removeCmd.Run() //nolint:errcheck
-	}
-	return worktreePath, cleanup, nil
 }
 
 // mergeAgentToTrack merges an agent branch back into its parent track branch
@@ -378,34 +197,18 @@ func launchYoloDefault(permMode, trackID, featureID string, noWorktree bool, res
 	// Create a worktree for isolation (skip for --no-worktree).
 	workDir := projectRoot
 	if !noWorktree && projectRoot != "" {
-		// If --track is provided, create a track worktree
 		if trackID != "" {
-			worktreePath, cleanup, wtErr := createTrackWorktree(trackID, projectRoot)
+			worktreePath, wtErr := EnsureForTrack(trackID, projectRoot, os.Stdout)
 			if wtErr != nil {
 				return wtErr
 			}
-			_ = cleanup // only used on error; worktree persists for the session
 			workDir = worktreePath
 		} else if featureID != "" {
-			// If --feature is provided, check if it has a parent track
-			resolvedTrackID := resolveTrackForFeature(featureID, projectRoot)
-			if resolvedTrackID != "" {
-				// Feature has a parent track — use the track worktree
-				worktreePath, cleanup, wtErr := createTrackWorktree(resolvedTrackID, projectRoot)
-				if wtErr != nil {
-					return wtErr
-				}
-				_ = cleanup // only used on error; worktree persists for the session
-				workDir = worktreePath
-			} else {
-				// Feature has no parent track — use the feature worktree
-				worktreePath, cleanup, wtErr := createFeatureWorktree(featureID, projectRoot)
-				if wtErr != nil {
-					return wtErr
-				}
-				_ = cleanup // only used on error; worktree persists for the session
-				workDir = worktreePath
+			worktreePath, wtErr := EnsureForFeature(featureID, projectRoot, os.Stdout)
+			if wtErr != nil {
+				return wtErr
 			}
+			workDir = worktreePath
 		}
 	}
 
@@ -473,34 +276,18 @@ func launchYoloDev(trackID, featureID string, noWorktree bool, resumeID string, 
 	// Create a worktree for isolation (skip for --no-worktree).
 	workDir := projectRoot
 	if !noWorktree && projectRoot != "" {
-		// If --track is provided, create a track worktree
 		if trackID != "" {
-			worktreePath, cleanup, wtErr := createTrackWorktree(trackID, projectRoot)
+			worktreePath, wtErr := EnsureForTrack(trackID, projectRoot, os.Stdout)
 			if wtErr != nil {
 				return wtErr
 			}
-			_ = cleanup // only used on error; worktree persists for the session
 			workDir = worktreePath
 		} else if featureID != "" {
-			// If --feature is provided, check if it has a parent track
-			resolvedTrackID := resolveTrackForFeature(featureID, projectRoot)
-			if resolvedTrackID != "" {
-				// Feature has a parent track — use the track worktree
-				worktreePath, cleanup, wtErr := createTrackWorktree(resolvedTrackID, projectRoot)
-				if wtErr != nil {
-					return wtErr
-				}
-				_ = cleanup // only used on error; worktree persists for the session
-				workDir = worktreePath
-			} else {
-				// Feature has no parent track — use the feature worktree
-				worktreePath, cleanup, wtErr := createFeatureWorktree(featureID, projectRoot)
-				if wtErr != nil {
-					return wtErr
-				}
-				_ = cleanup // only used on error; worktree persists for the session
-				workDir = worktreePath
+			worktreePath, wtErr := EnsureForFeature(featureID, projectRoot, os.Stdout)
+			if wtErr != nil {
+				return wtErr
 			}
+			workDir = worktreePath
 		}
 	}
 

--- a/cmd/htmlgraph/yolo_test.go
+++ b/cmd/htmlgraph/yolo_test.go
@@ -1,14 +1,15 @@
 package main
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 )
 
-// TestCreateTrackWorktree_CreatesNewBranch tests that createTrackWorktree creates a new branch with the correct name.
-func TestCreateTrackWorktree_CreatesNewBranch(t *testing.T) {
+// TestEnsureForTrack_CreatesNewBranch tests that EnsureForTrack creates a new branch with the correct name.
+func TestEnsureForTrack_CreatesNewBranch(t *testing.T) {
 	// Set up a temp git repo
 	tmpDir := t.TempDir()
 	initCmd := exec.Command("git", "init")
@@ -22,13 +23,12 @@ func TestCreateTrackWorktree_CreatesNewBranch(t *testing.T) {
 		t.Fatalf("failed to create initial commit: %v", err)
 	}
 
-	// Call createTrackWorktree
+	// Call EnsureForTrack
 	trackID := "trk-abc123"
-	worktreePath, cleanup, err := createTrackWorktree(trackID, tmpDir)
+	worktreePath, err := EnsureForTrack(trackID, tmpDir, io.Discard)
 	if err != nil {
-		t.Fatalf("createTrackWorktree failed: %v", err)
+		t.Fatalf("EnsureForTrack failed: %v", err)
 	}
-	defer cleanup()
 
 	// Assert: worktree path is .claude/worktrees/trk-abc123
 	expectedPath := filepath.Join(tmpDir, ".claude", "worktrees", trackID)
@@ -53,8 +53,8 @@ func TestCreateTrackWorktree_CreatesNewBranch(t *testing.T) {
 	}
 }
 
-// TestCreateTrackWorktree_ReusesExisting tests that createTrackWorktree reuses an existing worktree.
-func TestCreateTrackWorktree_ReusesExisting(t *testing.T) {
+// TestEnsureForTrack_ReusesExisting tests that EnsureForTrack reuses an existing worktree.
+func TestEnsureForTrack_ReusesExisting(t *testing.T) {
 	tmpDir := t.TempDir()
 	initCmd := exec.Command("git", "init")
 	initCmd.Dir = tmpDir
@@ -70,18 +70,16 @@ func TestCreateTrackWorktree_ReusesExisting(t *testing.T) {
 	trackID := "trk-xyz789"
 
 	// Create worktree first time
-	worktreePath1, cleanup1, err := createTrackWorktree(trackID, tmpDir)
+	worktreePath1, err := EnsureForTrack(trackID, tmpDir, io.Discard)
 	if err != nil {
-		t.Fatalf("first createTrackWorktree failed: %v", err)
+		t.Fatalf("first EnsureForTrack failed: %v", err)
 	}
-	defer cleanup1()
 
 	// Create worktree second time (should reuse)
-	worktreePath2, cleanup2, err := createTrackWorktree(trackID, tmpDir)
+	worktreePath2, err := EnsureForTrack(trackID, tmpDir, io.Discard)
 	if err != nil {
-		t.Fatalf("second createTrackWorktree failed: %v", err)
+		t.Fatalf("second EnsureForTrack failed: %v", err)
 	}
-	defer cleanup2()
 
 	// Assert: both calls return the same path
 	if worktreePath1 != worktreePath2 {

--- a/docs/cross-env-path-drift-audit.md
+++ b/docs/cross-env-path-drift-audit.md
@@ -1,0 +1,148 @@
+# Cross-Environment Absolute-Path Drift Audit
+
+## Context
+
+HtmlGraph runs in multiple environments for the same repo clone: macOS host, Linux
+devcontainer, Codespaces, and CI. Artifacts that bake in a host-specific absolute path
+(`/Users/<name>/…`, `/home/<name>/…`, `/workspaces/<name>/…`, `/private/var/folders/…`)
+work on one host and break on another. Three P1/P2 bugs in track `trk-787f57d3` were all
+expressions of this class. This audit enumerates every artifact that can carry such a
+path, classifies it, and records remediation state.
+
+## Classification Key
+
+- **ephemeral** — regenerated on every session start; drift self-heals.
+- **relative-rewriteable** — can store a placeholder or repo-relative path; fix forward.
+- **must-stay-absolute** — value is absolute by nature; must be detected and repaired on
+  session entry.
+
+## Audit Matrix
+
+| # | Artifact | Classification | Remediation | Status |
+|---|----------|---------------|-------------|--------|
+| 1 | `.htmlgraph/plans/*.yaml` body text | relative-rewriteable | Use placeholders; pre-commit guardrail | Done (bug-f4760452, bug-4b6d8369) |
+| 2 | `.htmlgraph/bugs/*.html` body text | relative-rewriteable | Use placeholders; pre-commit guardrail | Done (bug-f4760452, bug-4b6d8369) |
+| 3 | `.htmlgraph/sessions/*.html` `cwd` / `project_dir` meta | ephemeral | Emitted fresh each session; no on-disk persistence across hosts | Accepted |
+| 4 | SQLite `sessions.project_dir` | ephemeral | Per-session row; read-only across session starts on other hosts | Accepted |
+| 5 | SQLite `sessions.transcript_path` | ephemeral | Mirrors Claude Code's local transcript; consumed only when present | Accepted |
+| 6 | `.claude/worktrees/<trk>/.git` gitdir line | must-stay-absolute | Detect + rewrite on SessionStart | Done (bug-e1c968fe) |
+| 7 | `.claude/settings.local.json` | must-stay-absolute | Documented cross-machine drift in `memory/settings_local_cross_machine_drift.md`; should be `.gitignore`d | Open (follow-up 1) |
+| 8 | `~/.claude/projects/<slug>/memory/*.md` body prose | relative-rewriteable | Placeholders in examples; user-authored content | Accepted |
+| 9 | `plugin/hooks/bin/htmlgraph` (compiled binary) | ephemeral | Rebuilt on `htmlgraph build`; no runtime path references persisted | Accepted |
+| 10 | `plugin/skills/**/*.md` reference examples | relative-rewriteable | Skill text uses `<repo-root>` placeholder or `$HTMLGRAPH_PROJECT_DIR`; audit skill corpus quarterly | Open (follow-up 2) |
+| 11 | `.env`, `.env.local` | relative-rewriteable | None present today; recommend adding `.env*` to `.gitignore` | Accepted (no artifact) |
+
+**Summary:** 5 ephemeral · 4 relative-rewriteable · 2 must-stay-absolute.
+**Remediated:** 4 (bugs f4760452, 4b6d8369, e1c968fe, plus in-memory acknowledgement for 3–5).
+**Open:** 2 follow-ups listed below.
+
+## Deep-Dive Per Artifact
+
+### `.htmlgraph/plans/*.yaml` body text (relative-rewriteable)
+
+Plan YAMLs store free-form text in `done_when`, `evidence`, and `rationale` fields.
+Human-authored text occasionally embeds absolute paths (e.g. Copilot session-state file
+locations, codex config paths).
+
+- **Who writes**: agents during `htmlgraph plan` interactive flows and manual edits.
+- **Remediation**: two known hits in `plan-c248b73f.yaml` scrubbed in bug-f4760452;
+  the `htmlgraph check host-paths` guardrail from bug-4b6d8369 flags future drift at
+  commit time.
+
+### `.htmlgraph/bugs/*.html` body text (relative-rewriteable)
+
+Bug HTMLs carry descriptions written by agents and humans. Same failure mode as plans:
+free-text embeds paths to files that only exist on one host.
+
+- **Who writes**: `htmlgraph bug create/update`, direct file edits during investigations.
+- **Remediation**: hit in `bug-71fc095f.html` scrubbed in bug-f4760452; guardrail covers
+  forward.
+
+### `.htmlgraph/sessions/*.html` and SQLite `sessions` rows (ephemeral)
+
+Each session HTML and its SQLite row embeds `cwd` / `project_dir` / `transcript_path`
+captured at SessionStart. When a session row generated on host A is read on host B, the
+values are historical telemetry — they are not re-used to locate files. The dashboard
+renders them as text.
+
+- **Who writes**: `internal/hooks/session_start.go`, `internal/hooks/session_html.go`.
+- **Accepted** because these are immutable per-session records, not live pointers.
+
+### `.claude/worktrees/<trk>/.git` gitdir line (must-stay-absolute)
+
+`git worktree add` writes a single-line `.git` file: `gitdir: /absolute/path/to/.git/worktrees/<name>`.
+When the worktree is created on host A and opened on host B, the absolute path does not
+resolve and every git command fails.
+
+- **Who writes**: `git worktree add`, invoked by `htmlgraph worktree` helpers.
+- **Remediation**: `internal/worktree/repair.go::RepairGitdirFromRepoRoot` detects a
+  stale gitdir and rewrites it using the current repo root. Wired into `SessionStart` so
+  every Claude Code session self-repairs before the first git command runs.
+- **Landed in**: bug-e1c968fe.
+
+### `.claude/settings.local.json` (must-stay-absolute, **open**)
+
+User-specific Claude Code settings file. Records absolute paths (`statusLine.command`,
+permissions allow/deny globs). The repo's shared `.claude/settings.json` points at
+`/home/vscode/.claude/omp-claude-wrapper.sh` — a Linux-only path that breaks on macOS.
+
+- **Who writes**: `claude` itself, plus manual edits.
+- **Follow-up 1**: ensure the file is `.gitignore`d (it may already be — verify). If it
+  must be committed, rewrite absolute paths to `${HOME}`-relative or platform-detected
+  lookups. Alternatively, emit a session-start reconciliation that overwrites stale
+  machine-local keys.
+
+### `~/.claude/projects/<slug>/memory/*.md` (relative-rewriteable)
+
+Auto-memory files under the user's home. Examples and references may embed
+host-specific paths. These are user-authored; drift doesn't break anything, but
+cross-machine users can get confused by paths that reference a directory layout they
+don't have.
+
+- **Accepted** with the convention that memory prose uses `<repo-root>` / `<user-home>`
+  placeholders and `$HTMLGRAPH_PROJECT_DIR` where applicable.
+
+### `plugin/hooks/bin/htmlgraph` (ephemeral)
+
+Compiled Go binary. No runtime paths baked in; rebuilt on `htmlgraph build`. Cross-host
+drift is zero because the binary is never committed.
+
+### `plugin/skills/**/*.md` reference examples (relative-rewriteable, **open**)
+
+Skills teach agents CLI commands. Some historically embedded absolute paths as examples.
+The execute skill's `--format json` bug (bug-7ca3638b) and the same skill's redundant
+git calls (bug-f07a612e) are cousins of this class — skills as code that needs review.
+
+- **Follow-up 2**: quarterly skill-corpus grep for host-local paths. The skill-flag
+  validator from bug-61dc9267 is the natural hook point — extend it to also flag
+  literal `/Users/`, `/home/`, `/workspaces/<name>/` occurrences inside fenced code
+  blocks.
+
+### `.env`, `.env.local` (accepted, no artifact)
+
+No `.env*` files present in the repo today. Recommend adding `.env*` to the top-level
+`.gitignore` as a defensive measure even though nothing currently exists.
+
+## Open Follow-Ups
+
+1. **`.claude/settings.local.json` gitignore audit.** Verify the file is
+   `.gitignore`d at the repo level (existing memory entry suggests users have been
+   burned by stale commits). If committed state is required, document the exact
+   subset of keys that must stay relative and add a session-start reconciler.
+   *Priority: Medium.*
+
+2. **Skill-corpus path lint.** Extend the `TestSkillFlagsIntegration` scanner from
+   bug-61dc9267 to also match `/Users/[a-z]+/`, `/home/[a-z]+/`, and
+   `/workspaces/[a-z]+/` inside fenced code blocks in `plugin/skills/**/*.md`,
+   `plugin/commands/**/*.md`, and `plugin/agents/**/*.md`. Fail the build on any hit
+   that is not in an explicit allowlist.
+   *Priority: Low.*
+
+## Related Bugs
+
+- **bug-f4760452** — scrubbed two committed artifacts
+- **bug-4b6d8369** — pre-commit guardrail (`htmlgraph check host-paths`)
+- **bug-e1c968fe** — worktree `.git` auto-repair on SessionStart
+- **bug-5150e42a** — this audit
+
+All four together retire the immediate class and leave two documented follow-ups.

--- a/internal/agent/detect.go
+++ b/internal/agent/detect.go
@@ -75,7 +75,7 @@ func ResolveSessionID(projectDir string) string {
 // NormaliseSessionID extracts a UUID from a path-style session_id that Claude
 // Code sometimes provides for subagent sessions, e.g.:
 //
-//	/private/tmp/claude-501/-Users-shakes-.../550e8400-e29b-41d4-a716-446655440000
+//	/mock/claude-501/-Users-testuser-/550e8400-e29b-41d4-a716-446655440000
 //
 // If no UUID is found, or the input has no slash, the original string is
 // returned unchanged.

--- a/internal/agent/detect_test.go
+++ b/internal/agent/detect_test.go
@@ -78,7 +78,7 @@ func TestResolveSessionID_ExplicitEnv(t *testing.T) {
 func TestResolveSessionID_ClaudeSessionID(t *testing.T) {
 	testUUID := "550e8400-e29b-41d4-a716-446655440000"
 	t.Setenv("HTMLGRAPH_SESSION_ID", "")
-	t.Setenv("CLAUDE_SESSION_ID", "/private/tmp/claude-501/-Users-shakes-/"+testUUID)
+	t.Setenv("CLAUDE_SESSION_ID", "/mock/claude-501/-Users-testuser-/"+testUUID)
 	result := agent.ResolveSessionID(t.TempDir())
 	if result != testUUID {
 		t.Errorf("got %q, want %q", result, testUUID)
@@ -142,7 +142,7 @@ func TestNormaliseSessionID_PlainUUID(t *testing.T) {
 
 func TestNormaliseSessionID_PathStyle(t *testing.T) {
 	uuid := "550e8400-e29b-41d4-a716-446655440000"
-	path := "/private/tmp/claude-501/-Users-shakes-DevProjects/" + uuid
+	path := "/mock/claude-501/-Users-testuser-DevProjects/" + uuid
 	result := agent.NormaliseSessionID(path)
 	if result != uuid {
 		t.Errorf("should extract UUID from path: got %q, want %q", result, uuid)

--- a/internal/db/claim_repo.go
+++ b/internal/db/claim_repo.go
@@ -101,6 +101,84 @@ func ClaimItem(db *sql.DB, claim *models.Claim, leaseDuration time.Duration) err
 	return nil
 }
 
+// ClaimItemOrRenew creates a new claim or renews the lease on an existing one.
+// If an active claim already exists for the same (work_item_id, claimed_by_agent_id),
+// the lease is refreshed in-place (no duplicate row). Otherwise a new claim is inserted.
+// This is idempotent: calling it N times on the same item/agent is safe and always
+// results in exactly one live claim row with a fresh lease.
+func ClaimItemOrRenew(db *sql.DB, claim *models.Claim, leaseDuration time.Duration) error {
+	if _, err := ReapExpiredClaims(db); err != nil {
+		return fmt.Errorf("reap before claim: %w", err)
+	}
+
+	now := time.Now().UTC()
+	newExpiry := now.Add(leaseDuration)
+	activeList := activeStatusList()
+
+	// Try to renew an existing active claim first.
+	renewQuery := fmt.Sprintf(`
+		UPDATE claims
+		SET last_heartbeat_at = ?, lease_expires_at = ?, updated_at = ?
+		WHERE work_item_id = ?
+		  AND claimed_by_agent_id = ?
+		  AND status IN (%s)`, activeList)
+
+	result, err := db.Exec(renewQuery,
+		now.Format(time.RFC3339), newExpiry.Format(time.RFC3339),
+		now.Format(time.RFC3339),
+		claim.WorkItemID, claim.ClaimedByAgentID,
+	)
+	if err != nil {
+		return fmt.Errorf("renew claim for %s/%s: %w", claim.WorkItemID, claim.ClaimedByAgentID, err)
+	}
+	if rows, _ := result.RowsAffected(); rows > 0 {
+		// Existing live claim refreshed — done.
+		return nil
+	}
+
+	// No live claim exists — insert a fresh one.
+	claim.LeasedAt = now
+	claim.LeaseExpiresAt = newExpiry
+	claim.LastHeartbeatAt = now
+	claim.CreatedAt = now
+	claim.UpdatedAt = now
+
+	if claim.Status == "" {
+		claim.Status = models.ClaimProposed
+	}
+	if claim.OwnerAgent == "" {
+		claim.OwnerAgent = "claude-code"
+	}
+
+	ensureFeatureRow(db, claim.WorkItemID)
+	ensureSessionRow(db, claim.OwnerSessionID, claim.OwnerAgent)
+
+	_, err = db.Exec(`
+		INSERT INTO claims (
+			claim_id, work_item_id, track_id, owner_session_id, owner_agent,
+			claimed_by_agent_id,
+			status, intended_output, write_scope,
+			leased_at, lease_expires_at, last_heartbeat_at,
+			dependencies, progress_notes, blocker_reason,
+			created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		claim.ClaimID, claim.WorkItemID, nullStr(claim.TrackID),
+		claim.OwnerSessionID, claim.OwnerAgent,
+		claim.ClaimedByAgentID,
+		string(claim.Status), nullStr(claim.IntendedOutput),
+		nullJSON(claim.WriteScope),
+		now.Format(time.RFC3339), newExpiry.Format(time.RFC3339),
+		now.Format(time.RFC3339),
+		nullJSON(claim.Dependencies), nullStr(claim.ProgressNotes),
+		nullStr(claim.BlockerReason),
+		now.Format(time.RFC3339), now.Format(time.RFC3339),
+	)
+	if err != nil {
+		return fmt.Errorf("insert claim %s: %w", claim.ClaimID, err)
+	}
+	return nil
+}
+
 // HeartbeatClaim renews the lease on an active claim owned by sessionID.
 // Updates last_heartbeat_at and extends lease_expires_at by leaseDuration.
 func HeartbeatClaim(db *sql.DB, claimID, sessionID string, leaseDuration time.Duration) error {

--- a/internal/hooks/harness.go
+++ b/internal/hooks/harness.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 // Harness identifies the AI coding harness that invoked this hook.
@@ -110,14 +111,24 @@ func detectHarness(payload []byte) Harness {
 // representation. Codex uses a flat JSON structure with top-level fields like
 // "hook_event_name", "cwd", and "session_id". We map those into the CloudEvent
 // fields that downstream handlers read.
+//
+// Hardening: if HTMLGRAPH_PARENT_AGENT is set to a value other than "codex"
+// (e.g. "claude-code"), we use that as AgentID rather than hard-coding "codex".
+// This prevents misclassification when a stale env or mis-routed payload reaches
+// this parser for a non-Codex harness.
 func parseCodexEvent(raw []byte) (*CloudEvent, error) {
 	var p codexPayload
 	if err := json.Unmarshal(raw, &p); err != nil {
 		return nil, fmt.Errorf("parseCodexEvent: %w", err)
 	}
 
+	agentID := "codex"
+	if parent := strings.TrimSpace(os.Getenv("HTMLGRAPH_PARENT_AGENT")); parent != "" && parent != "codex" {
+		agentID = parent
+	}
+
 	ev := &CloudEvent{
-		AgentID:        "codex",
+		AgentID:        agentID,
 		SessionID:      p.SessionID,
 		CWD:            p.CWD,
 		PermissionMode: p.PermissionMode,

--- a/internal/hooks/harness_test.go
+++ b/internal/hooks/harness_test.go
@@ -136,6 +136,10 @@ func TestParseCodexUserPrompt(t *testing.T) {
 }
 
 func TestParseCodexEventSetsAgentID(t *testing.T) {
+	// Explicitly clear HTMLGRAPH_PARENT_AGENT so this test is not affected by
+	// whatever the shell environment has set (e.g., "claude-code" in dev sessions).
+	t.Setenv("HTMLGRAPH_PARENT_AGENT", "")
+
 	ev, err := parseCodexEvent([]byte(codexSessionStartJSON))
 	if err != nil {
 		t.Fatalf("parseCodexEvent: %v", err)
@@ -143,6 +147,55 @@ func TestParseCodexEventSetsAgentID(t *testing.T) {
 
 	if ev.AgentID != "codex" {
 		t.Errorf("AgentID = %q, want codex", ev.AgentID)
+	}
+}
+
+// TestParseCodexEventAgentIDHardening covers the fix for bug-bfe41623:
+// parseCodexEvent must NOT override AgentID with "codex" when
+// HTMLGRAPH_PARENT_AGENT identifies a different harness.
+func TestParseCodexEventAgentIDHardening(t *testing.T) {
+	tests := []struct {
+		name           string
+		parentAgentEnv string // value to set in HTMLGRAPH_PARENT_AGENT ("" = clear/unset)
+		wantAgentID    string
+	}{
+		{
+			name:           "codex harness no parent agent env → AgentID=codex",
+			parentAgentEnv: "",
+			wantAgentID:    "codex",
+		},
+		{
+			name:           "codex harness HTMLGRAPH_PARENT_AGENT=codex → AgentID=codex",
+			parentAgentEnv: "codex",
+			wantAgentID:    "codex",
+		},
+		{
+			name:           "routed through codex parser but HTMLGRAPH_PARENT_AGENT=claude-code → AgentID=claude-code",
+			parentAgentEnv: "claude-code",
+			wantAgentID:    "claude-code",
+		},
+		{
+			name:           "routed through codex parser but HTMLGRAPH_PARENT_AGENT=gemini → AgentID=gemini",
+			parentAgentEnv: "gemini",
+			wantAgentID:    "gemini",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Always set (or clear) the env var so the test is not affected by
+			// whatever value happens to be inherited from the shell (e.g. "claude-code"
+			// in a live dev session, which is what triggered bug-bfe41623).
+			t.Setenv("HTMLGRAPH_PARENT_AGENT", tt.parentAgentEnv)
+
+			ev, err := parseCodexEvent([]byte(codexSessionStartJSON))
+			if err != nil {
+				t.Fatalf("parseCodexEvent: %v", err)
+			}
+			if ev.AgentID != tt.wantAgentID {
+				t.Errorf("AgentID = %q, want %q", ev.AgentID, tt.wantAgentID)
+			}
+		})
 	}
 }
 

--- a/internal/hooks/harness_test.go
+++ b/internal/hooks/harness_test.go
@@ -10,8 +10,8 @@ import (
 // /tmp/htmlgraph-codex-hook-payloads/session-start-86946.json.
 const codexSessionStartJSON = `{
 	"session_id": "019da445-8036-73c2-a8fc-dacdb57417a8",
-	"transcript_path": "/Users/shakes/.codex/sessions/2026/04/19/rollout-2026-04-19T01-45-11-019da445-8036-73c2-a8fc-dacdb57417a8.jsonl",
-	"cwd": "/Users/shakes/DevProjects/htmlgraph",
+	"transcript_path": "/Users/testuser/.codex/sessions/2026/04/19/rollout-2026-04-19T01-45-11-019da445-8036-73c2-a8fc-dacdb57417a8.jsonl",
+	"cwd": "/Users/testuser/DevProjects/htmlgraph",
 	"hook_event_name": "SessionStart",
 	"model": "gpt-5.4",
 	"permission_mode": "default",
@@ -22,8 +22,8 @@ const codexSessionStartJSON = `{
 const codexUserPromptJSON = `{
 	"session_id": "019da445-8036-73c2-a8fc-dacdb57417a8",
 	"turn_id": "019da445-a255-77e1-98c4-9d456711f47b",
-	"transcript_path": "/Users/shakes/.codex/sessions/2026/04/19/rollout-2026-04-19T01-45-11-019da445-8036-73c2-a8fc-dacdb57417a8.jsonl",
-	"cwd": "/Users/shakes/DevProjects/htmlgraph",
+	"transcript_path": "/Users/testuser/.codex/sessions/2026/04/19/rollout-2026-04-19T01-45-11-019da445-8036-73c2-a8fc-dacdb57417a8.jsonl",
+	"cwd": "/Users/testuser/DevProjects/htmlgraph",
 	"hook_event_name": "UserPromptSubmit",
 	"model": "gpt-5.4",
 	"permission_mode": "default",
@@ -33,7 +33,7 @@ const codexUserPromptJSON = `{
 // Claude CloudEvent payload — typical SessionStart shape sent by Claude Code.
 const claudeSessionStartJSON = `{
 	"session_id": "sess-abc123",
-	"cwd": "/Users/shakes/DevProjects/htmlgraph",
+	"cwd": "/Users/testuser/DevProjects/htmlgraph",
 	"permission_mode": "default",
 	"model": "claude-opus-4-5",
 	"transcript_path": "/tmp/session.jsonl",
@@ -45,7 +45,7 @@ const claudeSessionStartJSON = `{
 const geminiSessionStartJSON = `{
 	"invocation_id": "gemini-inv-abc123",
 	"session_id": "gemini-sess-xyz789",
-	"cwd": "/Users/shakes/DevProjects/htmlgraph",
+	"cwd": "/Users/testuser/DevProjects/htmlgraph",
 	"model": "gemini-2.5-pro"
 }`
 
@@ -104,8 +104,8 @@ func TestParseCodexSessionStart(t *testing.T) {
 	if ev.SessionID != "019da445-8036-73c2-a8fc-dacdb57417a8" {
 		t.Errorf("SessionID = %q, want 019da445-8036-73c2-a8fc-dacdb57417a8", ev.SessionID)
 	}
-	if ev.CWD != "/Users/shakes/DevProjects/htmlgraph" {
-		t.Errorf("CWD = %q, want /Users/shakes/DevProjects/htmlgraph", ev.CWD)
+	if ev.CWD != "/Users/testuser/DevProjects/htmlgraph" {
+		t.Errorf("CWD = %q, want /Users/testuser/DevProjects/htmlgraph", ev.CWD)
 	}
 	if ev.Model != "gpt-5.4" {
 		t.Errorf("Model = %q, want gpt-5.4", ev.Model)
@@ -211,8 +211,8 @@ func TestParseGeminiSessionStart(t *testing.T) {
 	if ev.SessionID != "gemini-sess-xyz789" {
 		t.Errorf("SessionID = %q, want gemini-sess-xyz789", ev.SessionID)
 	}
-	if ev.CWD != "/Users/shakes/DevProjects/htmlgraph" {
-		t.Errorf("CWD = %q, want /Users/shakes/DevProjects/htmlgraph", ev.CWD)
+	if ev.CWD != "/Users/testuser/DevProjects/htmlgraph" {
+		t.Errorf("CWD = %q, want /Users/testuser/DevProjects/htmlgraph", ev.CWD)
 	}
 }
 

--- a/internal/hooks/pretooluse.go
+++ b/internal/hooks/pretooluse.go
@@ -95,7 +95,7 @@ func PreToolUse(event *CloudEvent, database *sql.DB) (*HookResult, error) {
 		hasAgentClaim = ctx.FeatureID != ""
 	}
 	if ctx.IsYoloMode && !subagentGrace {
-		if warn := checkSubagentWorkItemGuard(event.ToolName, ctx.IsSubagent, hasAgentClaim); warn != "" {
+		if warn := checkSubagentWorkItemGuard(event.ToolName, ctx.IsSubagent, hasAgentClaim, ctx.SessionID, ctx.IsYoloMode, ctx.FeatureID, ctx.ClaimedItem); warn != "" {
 			return &HookResult{Decision: "block", Reason: warn}, nil
 		}
 	}
@@ -499,7 +499,7 @@ func checkProjectDivergence(event *CloudEvent, database *sql.DB, sessionID strin
 //
 // Subagents ignore prompt-based instructions to register work items before
 // writing code. Enforcing at the hook layer is the reliable alternative.
-func checkSubagentWorkItemGuard(toolName string, isSubagent, hasWorkItem bool) string {
+func checkSubagentWorkItemGuard(toolName string, isSubagent, hasWorkItem bool, sessionID string, isYoloMode bool, featureID, claimedItem string) string {
 	if !isSubagent {
 		return ""
 	}
@@ -511,8 +511,27 @@ func checkSubagentWorkItemGuard(toolName string, isSubagent, hasWorkItem bool) s
 	if hasWorkItem {
 		return ""
 	}
-	return "No active work item. Run: htmlgraph feature start <id> or " +
-		"htmlgraph feature create \"description\" --track <trk-id> before writing code."
+
+	sess := sessionID
+	if len(sess) > 8 {
+		sess = sess[:8]
+	}
+	feat := featureID
+	if feat == "" {
+		feat = "none"
+	}
+	claim := claimedItem
+	if claim == "" {
+		claim = "none"
+	}
+	return fmt.Sprintf(
+		"Write blocked: no claimed work item.\n"+
+			"  session=%s yolo=%v subagent=%v\n"+
+			"  feature=%s  claim=%s\n"+
+			"To unblock: htmlgraph feature start <id>  (or: htmlgraph feature create \"...\" --track <trk-id>)",
+		sess, isYoloMode, isSubagent,
+		feat, claim,
+	)
 }
 
 // isWriteTool returns true for tools that can modify the filesystem or execute

--- a/internal/hooks/pretooluse_test.go
+++ b/internal/hooks/pretooluse_test.go
@@ -215,7 +215,7 @@ func TestCheckSubagentWorkItemGuard(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := checkSubagentWorkItemGuard(tt.tool, tt.isSubagent, tt.hasWorkItem)
+			result := checkSubagentWorkItemGuard(tt.tool, tt.isSubagent, tt.hasWorkItem, "sess-abc123", true, "feat-xyz", "feat-xyz")
 			if tt.blocked && result == "" {
 				t.Errorf("expected block for tool=%s isSubagent=%v hasWorkItem=%v, got allow",
 					tt.tool, tt.isSubagent, tt.hasWorkItem)
@@ -223,6 +223,83 @@ func TestCheckSubagentWorkItemGuard(t *testing.T) {
 			if !tt.blocked && result != "" {
 				t.Errorf("expected allow for tool=%s isSubagent=%v hasWorkItem=%v, got block: %s",
 					tt.tool, tt.isSubagent, tt.hasWorkItem, result)
+			}
+		})
+	}
+}
+
+func TestCheckSubagentWorkItemGuard_DiagnosticFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		sessionID   string
+		isYoloMode  bool
+		isSubagent  bool
+		featureID   string
+		claimedItem string
+		wantSession string // expected session prefix in message
+		wantFeature string
+		wantClaim   string
+	}{
+		{
+			name:        "all fields populated",
+			sessionID:   "abcdef1234567890",
+			isYoloMode:  true,
+			isSubagent:  true,
+			featureID:   "feat-aabbccdd",
+			claimedItem: "",
+			wantSession: "abcdef12",
+			wantFeature: "feat-aabbccdd",
+			wantClaim:   "none",
+		},
+		{
+			name:        "no feature no claim",
+			sessionID:   "short",
+			isYoloMode:  false,
+			isSubagent:  true,
+			featureID:   "",
+			claimedItem: "",
+			wantSession: "short",
+			wantFeature: "none",
+			wantClaim:   "none",
+		},
+		{
+			name:        "claim present no feature",
+			sessionID:   "sess-00001111",
+			isYoloMode:  true,
+			isSubagent:  true,
+			featureID:   "",
+			claimedItem: "bug-99887766",
+			wantSession: "sess-000",
+			wantFeature: "none",
+			wantClaim:   "bug-99887766",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkSubagentWorkItemGuard("Write", tt.isSubagent, false, tt.sessionID, tt.isYoloMode, tt.featureID, tt.claimedItem)
+			if result == "" {
+				t.Fatal("expected block message, got empty string")
+			}
+			for _, field := range []string{tt.wantSession, tt.wantFeature, tt.wantClaim} {
+				if !strings.Contains(result, field) {
+					t.Errorf("block message missing %q\nfull message:\n%s", field, result)
+				}
+			}
+			// Verify yolo and subagent booleans appear.
+			yoloStr := "yolo=false"
+			if tt.isYoloMode {
+				yoloStr = "yolo=true"
+			}
+			subagentStr := "subagent=false"
+			if tt.isSubagent {
+				subagentStr = "subagent=true"
+			}
+			if !strings.Contains(result, yoloStr) {
+				t.Errorf("block message missing %q\nfull message:\n%s", yoloStr, result)
+			}
+			if !strings.Contains(result, subagentStr) {
+				t.Errorf("block message missing %q\nfull message:\n%s", subagentStr, result)
 			}
 		})
 	}

--- a/internal/hooks/session_html_test.go
+++ b/internal/hooks/session_html_test.go
@@ -360,8 +360,8 @@ func TestRenderIngestedSessionHTML_Shape(t *testing.T) {
 			{Ordinal: 1, Role: "assistant", Timestamp: msgTs.Add(5 * time.Second)},
 		},
 		ToolCalls: []models.ToolCall{
-			{MessageOrdinal: 1, ToolName: "Read", ToolUseID: "tu-1", InputJSON: `{"file_path":"/tmp/a.go"}`},
-			{MessageOrdinal: 1, ToolName: "Edit", ToolUseID: "tu-2", InputJSON: `{"file_path":"/tmp/a.go"}`},
+			{MessageOrdinal: 1, ToolName: "Read", ToolUseID: "tu-1", InputJSON: `{"file_path":"/mock/a.go"}`},
+			{MessageOrdinal: 1, ToolName: "Edit", ToolUseID: "tu-2", InputJSON: `{"file_path":"/mock/a.go"}`},
 			{MessageOrdinal: 1, ToolName: "Bash", ToolUseID: "tu-3", InputJSON: `{"command":"echo hi"}`},
 		},
 		Model: "claude-sonnet-4-5",

--- a/internal/hooks/session_start.go
+++ b/internal/hooks/session_start.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shakestzd/htmlgraph/internal/db"
 	"github.com/shakestzd/htmlgraph/internal/models"
 	"github.com/shakestzd/htmlgraph/internal/paths"
+	"github.com/shakestzd/htmlgraph/internal/worktree"
 )
 
 // ActiveSessionData is the JSON structure written to .htmlgraph/.active-session
@@ -134,6 +135,16 @@ func SessionStart(event *CloudEvent, database *sql.DB, projectDir string) (*Hook
 
 	now := time.Now().UTC()
 	shortID := sessionID[:minSessionLen(sessionID)]
+
+	// Repair stale worktree .git gitdir pointer before any git operations.
+	// When a worktree is created on one machine (e.g. macOS) and opened on
+	// another (e.g. Linux devcontainer), the absolute path in the .git file
+	// becomes stale. Repair it now so all downstream git commands succeed.
+	if event.CWD != "" && event.CWD != projectDir {
+		if err := worktree.RepairGitdirFromRepoRoot(event.CWD, projectDir); err != nil {
+			debugLog(projectDir, "[session-start] worktree gitdir repair failed (cwd=%s): %v", event.CWD, err)
+		}
+	}
 
 	// Launch headCommit in a goroutine — I/O-bound, no data dependency with writeEnvVars.
 	commitCh := make(chan string, 1)

--- a/internal/ingest/discover.go
+++ b/internal/ingest/discover.go
@@ -147,7 +147,7 @@ func decodeProjectName(encoded string) string {
 // dash-encoded project directory name.
 // Claude encodes paths by replacing "/" with "-", so the leading "-" represents
 // the root separator.
-// e.g. "-Users-shakes-DevProjects-htmlgraph" → "/Users/shakes/DevProjects/htmlgraph"
+// e.g. "-Users-shakes-DevProjects-htmlgraph" → "/Users/testuser/DevProjects/htmlgraph"
 func decodeProjectPath(encoded string) string {
 	if encoded == "" {
 		return ""
@@ -155,7 +155,7 @@ func decodeProjectPath(encoded string) string {
 	// Strip a leading dash (represents the root "/") then replace remaining dashes.
 	// We replace "-" with "/" which reconstructs the path from the encoding.
 	// Claude encodes absolute paths starting with "/" as "-..." so:
-	// "-Users-shakes-DevProjects-htmlgraph" → "/Users/shakes/DevProjects/htmlgraph"
+	// "-Users-shakes-DevProjects-htmlgraph" → "/Users/testuser/DevProjects/htmlgraph"
 	if strings.HasPrefix(encoded, "-") {
 		return "/" + strings.ReplaceAll(encoded[1:], "-", "/")
 	}

--- a/internal/ingest/discover_test.go
+++ b/internal/ingest/discover_test.go
@@ -76,8 +76,8 @@ func TestDecodeProjectPath(t *testing.T) {
 		expected string
 	}{
 		{
-			encoded:  "-Users-shakes-DevProjects-htmlgraph",
-			expected: "/Users/shakes/DevProjects/htmlgraph",
+			encoded:  "-Users-testuser-DevProjects-htmlgraph",
+			expected: "/Users/testuser/DevProjects/htmlgraph",
 		},
 		{
 			encoded:  "-Users-alice-code-myapp",
@@ -95,8 +95,8 @@ func TestDecodeProjectPath(t *testing.T) {
 		// in Claude's encoding — "foo-bar" encodes as "-foo-bar" just like
 		// "/foo/bar" would, so the decode is a best-effort reconstruction.
 		{
-			encoded:  "-Users-shakes-DevProjects-my-project",
-			expected: "/Users/shakes/DevProjects/my/project",
+			encoded:  "-Users-testuser-DevProjects-my-project",
+			expected: "/Users/testuser/DevProjects/my/project",
 		},
 	}
 

--- a/internal/ingest/parser_test.go
+++ b/internal/ingest/parser_test.go
@@ -53,7 +53,7 @@ func TestParse_UserAndAssistant(t *testing.T) {
 }
 
 func TestParse_ToolUse(t *testing.T) {
-	jsonl := `{"type":"assistant","uuid":"a1","parentUuid":"u1","message":{"model":"claude-sonnet-4-6","role":"assistant","content":[{"type":"tool_use","id":"toolu_123","name":"Read","input":{"file_path":"/tmp/test.go"}},{"type":"tool_use","id":"toolu_456","name":"Bash","input":{"command":"go test"}}],"usage":{"input_tokens":10,"output_tokens":20}},"timestamp":"2026-03-27T20:00:00.000Z","sessionId":"sess-2"}`
+	jsonl := `{"type":"assistant","uuid":"a1","parentUuid":"u1","message":{"model":"claude-sonnet-4-6","role":"assistant","content":[{"type":"tool_use","id":"toolu_123","name":"Read","input":{"file_path":"/mock/test.go"}},{"type":"tool_use","id":"toolu_456","name":"Bash","input":{"command":"go test"}}],"usage":{"input_tokens":10,"output_tokens":20}},"timestamp":"2026-03-27T20:00:00.000Z","sessionId":"sess-2"}`
 
 	result, err := parse(strings.NewReader(jsonl))
 	if err != nil {

--- a/internal/otel/receiver/writer_test.go
+++ b/internal/otel/receiver/writer_test.go
@@ -255,7 +255,7 @@ func TestWriter_OrphanSpanCreatePlaceholder(t *testing.T) {
 		AgentID:   agentID,
 		AgentType: "haiku-coder",
 		SessionID: sessionID,
-		CWD:       "/tmp/test",
+		CWD:       "/mock/test",
 		CreatedAt: time.Now().UnixMicro(),
 	}
 	if err := db.UpsertPendingSubagentStart(readDB, pending); err != nil {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -1,6 +1,6 @@
 // Package terminal manages ttyd sidecar processes for the embedded terminal
 // feature. Each Start call spawns a new ttyd process on a free localhost port
-// running htmlgraph claude in the given project directory. Stop signals the
+// running the selected agent in the given project directory. Stop signals the
 // process; StopAll is called on graceful server shutdown.
 package terminal
 
@@ -14,11 +14,32 @@ import (
 	"time"
 )
 
+// StartRequest holds the parameters for starting a terminal session.
+// Zero-valued fields fall back to MVP defaults: agent=claude, mode=dev,
+// cwd=server projectDir, workItem=empty.
+type StartRequest struct {
+	// Agent selects which AI tool to run (claude, codex, gemini, yolo).
+	// Defaults to "claude" when empty.
+	Agent string
+	// Mode controls launch flags (dev, normal, auto).
+	// Defaults to "dev" when empty.
+	Mode string
+	// CWD is the working directory for the session.
+	// Defaults to the server's project directory when empty.
+	CWD string
+	// WorkItem, when non-empty, prepends "htmlgraph feature start <id>; "
+	// to the shell command for attribution.
+	WorkItem string
+}
+
 // session tracks a running ttyd process.
 type session struct {
 	cmd      *exec.Cmd
 	port     int
 	workItem string
+	agent    string
+	mode     string
+	cwd      string
 }
 
 // Manager owns the lifecycle of ttyd sidecar processes.
@@ -64,10 +85,58 @@ func waitForPort(port int, timeout time.Duration) error {
 	return fmt.Errorf("ttyd did not bind %s within %s", addr, timeout)
 }
 
-// Start spawns a ttyd process on a free port running htmlgraph claude (or,
-// when workItem is non-empty, first starting the given work item). Returns
-// the port and pid on success.
-func (m *Manager) Start(projectDir, workItem string) (port int, pid int, err error) {
+// buildShellCmd constructs the shell one-liner that ttyd will run inside bash -lc.
+//
+// Rules:
+//   - agent=claude (default) → htmlgraph claude [--dev]
+//   - agent=codex → htmlgraph codex [--dev]
+//   - agent=gemini → htmlgraph gemini [--dev]
+//   - agent=yolo → claude --permission-mode bypassPermissions (no htmlgraph yolo wrapper)
+//   - mode=dev (default) → --dev flag appended (not applicable to yolo)
+//   - mode=normal → no flag
+//   - workItem non-empty → prepends "htmlgraph feature start <id>; " for ALL agents
+func buildShellCmd(agent, mode, workItem string) string {
+	if agent == "" {
+		agent = "claude"
+	}
+	if mode == "" {
+		mode = "dev"
+	}
+
+	var base string
+	switch agent {
+	case "yolo":
+		// yolo uses claude directly with bypassPermissions; no htmlgraph wrapper.
+		base = "claude --permission-mode bypassPermissions"
+	default:
+		base = "htmlgraph " + agent
+		if mode == "dev" {
+			base += " --dev"
+		}
+	}
+
+	if workItem != "" {
+		return "htmlgraph feature start " + workItem + " >/dev/null 2>&1; " + base
+	}
+	return base
+}
+
+// Start spawns a ttyd process on a free port running the agent described by req.
+// Zero-valued fields in req fall back to MVP defaults (agent=claude, mode=dev,
+// cwd=defaultDir). Returns the port and pid on success.
+func (m *Manager) Start(req StartRequest, defaultDir string) (port int, pid int, err error) {
+	// Apply defaults for zero-valued fields.
+	if req.Agent == "" {
+		req.Agent = "claude"
+	}
+	if req.Mode == "" {
+		req.Mode = "dev"
+	}
+	workDir := defaultDir
+	if req.CWD != "" {
+		workDir = req.CWD
+	}
+
 	// Ensure ttyd is available before doing anything else.
 	if _, err = exec.LookPath("ttyd"); err != nil {
 		return 0, 0, fmt.Errorf("ttyd not found on PATH — install with: brew install ttyd")
@@ -78,27 +147,30 @@ func (m *Manager) Start(projectDir, workItem string) (port int, pid int, err err
 		return 0, 0, fmt.Errorf("could not find free port: %w", err)
 	}
 
-	// Build the shell one-liner that ttyd will run inside bash -lc.
-	shellCmd := "htmlgraph claude --dev"
-	if workItem != "" {
-		shellCmd = "htmlgraph feature start " + workItem + " >/dev/null 2>&1; htmlgraph claude --dev"
-	}
+	shellCmd := buildShellCmd(req.Agent, req.Mode, req.WorkItem)
 
 	cmd := exec.Command(
 		"ttyd",
 		"-p", strconv.Itoa(port),
-		"-W",              // writable (allows input)
+		"-W",               // writable (allows input)
 		"-i", "127.0.0.1", // bind to localhost only
 		"bash", "-lc", shellCmd,
 	)
-	cmd.Dir = projectDir
+	cmd.Dir = workDir
 
 	if err = cmd.Start(); err != nil {
 		return 0, 0, fmt.Errorf("failed to start ttyd: %w", err)
 	}
 
 	pid = cmd.Process.Pid
-	s := &session{cmd: cmd, port: port, workItem: workItem}
+	s := &session{
+		cmd:      cmd,
+		port:     port,
+		workItem: req.WorkItem,
+		agent:    req.Agent,
+		mode:     req.Mode,
+		cwd:      workDir,
+	}
 
 	m.mu.Lock()
 	m.sessions[pid] = s

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -51,7 +51,7 @@ func TestStartRequestZeroValue(t *testing.T) {
 	}
 
 	// CWD falls back to defaultDir when req.CWD is empty.
-	defaultDir := "/tmp/test-project"
+	defaultDir := "/mock/test-project"
 	cwd := req.CWD
 	if cwd == "" {
 		cwd = defaultDir

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -1,0 +1,68 @@
+package terminal
+
+import (
+	"testing"
+)
+
+// TestBuildShellCmd covers the full matrix from the slice-1 spec.
+func TestBuildShellCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		agent    string
+		mode     string
+		workItem string
+		want     string
+	}{
+		{"defaults", "", "", "", "htmlgraph claude --dev"},
+		{"claude dev", "claude", "dev", "", "htmlgraph claude --dev"},
+		{"claude normal", "claude", "normal", "", "htmlgraph claude"},
+		{"codex dev", "codex", "dev", "", "htmlgraph codex --dev"},
+		{"gemini dev", "gemini", "dev", "", "htmlgraph gemini --dev"},
+		{"yolo bypasses wrapper", "yolo", "dev", "", "claude --permission-mode bypassPermissions"},
+		{"work item prefix claude", "claude", "dev", "feat-abc", "htmlgraph feature start feat-abc >/dev/null 2>&1; htmlgraph claude --dev"},
+		{"work item prefix codex", "codex", "dev", "feat-abc", "htmlgraph feature start feat-abc >/dev/null 2>&1; htmlgraph codex --dev"},
+		{"work item prefix gemini", "gemini", "dev", "feat-abc", "htmlgraph feature start feat-abc >/dev/null 2>&1; htmlgraph gemini --dev"},
+		{"work item prefix yolo", "yolo", "dev", "feat-abc", "htmlgraph feature start feat-abc >/dev/null 2>&1; claude --permission-mode bypassPermissions"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildShellCmd(tc.agent, tc.mode, tc.workItem)
+			if got != tc.want {
+				t.Errorf("buildShellCmd(%q, %q, %q)\n  got:  %q\n  want: %q",
+					tc.agent, tc.mode, tc.workItem, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStartRequestZeroValue verifies that a zero-value StartRequest with defaultDir
+// resolves CWD to defaultDir and produces "htmlgraph claude --dev".
+func TestStartRequestZeroValue(t *testing.T) {
+	var req StartRequest
+
+	// Resolve agent/mode defaults as Manager.Start does.
+	agent := req.Agent
+	if agent == "" {
+		agent = "claude"
+	}
+	mode := req.Mode
+	if mode == "" {
+		mode = "dev"
+	}
+
+	// CWD falls back to defaultDir when req.CWD is empty.
+	defaultDir := "/tmp/test-project"
+	cwd := req.CWD
+	if cwd == "" {
+		cwd = defaultDir
+	}
+	if cwd != defaultDir {
+		t.Errorf("zero StartRequest CWD should fall back to defaultDir %q, got %q", defaultDir, cwd)
+	}
+
+	got := buildShellCmd(agent, mode, req.WorkItem)
+	want := "htmlgraph claude --dev"
+	if got != want {
+		t.Errorf("zero StartRequest should produce %q, got %q", want, got)
+	}
+}

--- a/internal/worktree/repair.go
+++ b/internal/worktree/repair.go
@@ -48,11 +48,19 @@ func RepairGitdir(worktreePath, mainGitDir string) error {
 		return nil
 	}
 
-	// Compute the correct gitdir: <mainGitDir>/worktrees/<worktree-basename>.
-	// The worktree basename may include subdirectory segments for agent worktrees
-	// (e.g. .claude/worktrees/trk-xxx/agent-yyy). Git names the worktrees entry
-	// after the directory basename only, so we use filepath.Base.
-	worktreeName := filepath.Base(worktreePath)
+	// Compute the correct gitdir: <mainGitDir>/worktrees/<name>.
+	//
+	// Important — preserve git's own disambiguated name. When two worktrees
+	// share a basename (e.g. two `agent-task` worktrees on different tracks),
+	// git names the later admin dir `agent-task1`, `agent-task2`, etc. The
+	// stale .git pointer on the current machine still carries that correct
+	// name — we just need a new *prefix*. Taking `filepath.Base(worktreePath)`
+	// instead would rewrite the second worktree to point at the first one's
+	// admin dir, silently corrupting branch metadata for both.
+	//
+	// So: derive the admin-dir basename from the existing (stale) gitdir,
+	// and only swap out the leading path.
+	worktreeName := filepath.Base(currentGitdir)
 	correctGitdir := filepath.Join(mainGitDir, "worktrees", worktreeName)
 
 	// Verify the computed path actually exists before writing.

--- a/internal/worktree/repair.go
+++ b/internal/worktree/repair.go
@@ -1,0 +1,89 @@
+package worktree
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RepairGitdir checks whether the worktree at worktreePath has a valid .git
+// gitdir pointer and rewrites it if the path no longer exists (cross-machine
+// path drift, e.g. macOS path opened inside a Linux devcontainer).
+//
+// The .git file in a linked worktree is a one-line text file of the form:
+//
+//	gitdir: /absolute/path/to/.git/worktrees/<name>
+//
+// When a worktree is created on macOS and then opened inside a Linux
+// devcontainer, the absolute path becomes stale. RepairGitdir detects this
+// and rewrites the path using the current repo root derived from mainGitDir.
+//
+// mainGitDir is the absolute path to the main repo's .git directory (e.g.
+// /workspaces/myrepo/.git). Pass the result of locating the main .git from
+// repoRoot.
+//
+// Returns nil when no repair was needed or repair succeeded. Returns an error
+// only when the file is present but cannot be read or written.
+func RepairGitdir(worktreePath, mainGitDir string) error {
+	gitFile := filepath.Join(worktreePath, ".git")
+
+	content, err := os.ReadFile(gitFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // Not a worktree or already a directory — nothing to do.
+		}
+		return fmt.Errorf("read %s: %w", gitFile, err)
+	}
+
+	line := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(line, "gitdir: ") {
+		return nil // Unexpected format — leave it alone.
+	}
+
+	currentGitdir := strings.TrimPrefix(line, "gitdir: ")
+
+	// Fast path: gitdir already points to an existing path.
+	if _, err := os.Stat(currentGitdir); err == nil {
+		return nil
+	}
+
+	// Compute the correct gitdir: <mainGitDir>/worktrees/<worktree-basename>.
+	// The worktree basename may include subdirectory segments for agent worktrees
+	// (e.g. .claude/worktrees/trk-xxx/agent-yyy). Git names the worktrees entry
+	// after the directory basename only, so we use filepath.Base.
+	worktreeName := filepath.Base(worktreePath)
+	correctGitdir := filepath.Join(mainGitDir, "worktrees", worktreeName)
+
+	// Verify the computed path actually exists before writing.
+	if _, err := os.Stat(correctGitdir); err != nil {
+		return fmt.Errorf("stale gitdir %q and computed replacement %q does not exist: %w",
+			currentGitdir, correctGitdir, err)
+	}
+
+	newContent := "gitdir: " + correctGitdir + "\n"
+	if err := os.WriteFile(gitFile, []byte(newContent), 0644); err != nil {
+		return fmt.Errorf("rewrite %s: %w", gitFile, err)
+	}
+
+	return nil
+}
+
+// RepairGitdirFromRepoRoot is a convenience wrapper around RepairGitdir that
+// derives mainGitDir from repoRoot (the directory containing the top-level
+// .git directory or file).
+//
+// Returns nil when no repair was needed or repair succeeded. Returns an error
+// when the main .git directory cannot be located or the repair fails.
+func RepairGitdirFromRepoRoot(worktreePath, repoRoot string) error {
+	mainGitDir := filepath.Join(repoRoot, ".git")
+	info, err := os.Stat(mainGitDir)
+	if err != nil {
+		return fmt.Errorf("locate main .git at %s: %w", mainGitDir, err)
+	}
+	if !info.IsDir() {
+		// repoRoot is itself a worktree — resolve common dir via git.
+		return fmt.Errorf("expected %s to be a directory (main repo .git), not a file", mainGitDir)
+	}
+	return RepairGitdir(worktreePath, mainGitDir)
+}

--- a/internal/worktree/repair_test.go
+++ b/internal/worktree/repair_test.go
@@ -1,0 +1,160 @@
+package worktree_test
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shakestzd/htmlgraph/internal/worktree"
+)
+
+// TestRepairGitdirStalePath is the primary TDD test: create a real worktree,
+// overwrite its .git file with a bogus absolute path, call RepairGitdir, and
+// assert the file is corrected.
+func TestRepairGitdirStalePath(t *testing.T) {
+	dir := setupGitRepo(t)
+
+	// Create a real worktree so git registers it under .git/worktrees/.
+	worktreePath, err := worktree.EnsureForTrack("trk-repair111", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("EnsureForTrack: %v", err)
+	}
+
+	// Overwrite the .git file with a stale cross-machine path.
+	gitFile := filepath.Join(worktreePath, ".git")
+	bogusGitdir := "/nonexistent/cross/machine/path/.git/worktrees/trk-repair111"
+	if err := os.WriteFile(gitFile, []byte("gitdir: "+bogusGitdir+"\n"), 0644); err != nil {
+		t.Fatalf("overwrite .git: %v", err)
+	}
+
+	// Call repair.
+	mainGitDir := filepath.Join(dir, ".git")
+	if err := worktree.RepairGitdir(worktreePath, mainGitDir); err != nil {
+		t.Fatalf("RepairGitdir: %v", err)
+	}
+
+	// Assert the .git file now contains a valid gitdir.
+	content, err := os.ReadFile(gitFile)
+	if err != nil {
+		t.Fatalf("read .git after repair: %v", err)
+	}
+
+	line := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(line, "gitdir: ") {
+		t.Fatalf("repaired .git has unexpected format: %q", line)
+	}
+
+	repairedGitdir := strings.TrimPrefix(line, "gitdir: ")
+
+	// The repaired path must exist on disk.
+	if _, err := os.Stat(repairedGitdir); err != nil {
+		t.Errorf("repaired gitdir %q does not exist: %v", repairedGitdir, err)
+	}
+
+	// The repaired path must be under the main repo's .git/worktrees/.
+	expectedPrefix := filepath.Join(mainGitDir, "worktrees")
+	if !strings.HasPrefix(repairedGitdir, expectedPrefix) {
+		t.Errorf("repaired gitdir %q not under %q", repairedGitdir, expectedPrefix)
+	}
+}
+
+// TestRepairGitdirNoOpWhenValid verifies that repair is a no-op when the
+// gitdir already points to an existing path.
+func TestRepairGitdirNoOpWhenValid(t *testing.T) {
+	dir := setupGitRepo(t)
+
+	worktreePath, err := worktree.EnsureForTrack("trk-repair222", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("EnsureForTrack: %v", err)
+	}
+
+	// Read the original .git content before repair.
+	gitFile := filepath.Join(worktreePath, ".git")
+	originalContent, err := os.ReadFile(gitFile)
+	if err != nil {
+		t.Fatalf("read original .git: %v", err)
+	}
+
+	mainGitDir := filepath.Join(dir, ".git")
+	if err := worktree.RepairGitdir(worktreePath, mainGitDir); err != nil {
+		t.Fatalf("RepairGitdir (no-op): %v", err)
+	}
+
+	afterContent, err := os.ReadFile(gitFile)
+	if err != nil {
+		t.Fatalf("read .git after repair: %v", err)
+	}
+
+	if string(originalContent) != string(afterContent) {
+		t.Errorf("file changed on no-op repair:\nbefore: %q\nafter:  %q",
+			originalContent, afterContent)
+	}
+}
+
+// TestRepairGitdirMissingFile verifies that repair returns nil (not an error)
+// when the .git file does not exist.
+func TestRepairGitdirMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	mainGitDir := filepath.Join(dir, ".git")
+
+	if err := worktree.RepairGitdir("/nonexistent/worktree", mainGitDir); err != nil {
+		t.Errorf("expected nil error for missing .git file, got: %v", err)
+	}
+}
+
+// TestRepairGitdirUnrecognizedFormat verifies that repair is a no-op when
+// the .git file content does not start with "gitdir: ".
+func TestRepairGitdirUnrecognizedFormat(t *testing.T) {
+	dir := t.TempDir()
+	worktreePath := dir
+
+	gitFile := filepath.Join(worktreePath, ".git")
+	if err := os.WriteFile(gitFile, []byte("not a gitdir line\n"), 0644); err != nil {
+		t.Fatalf("write fake .git: %v", err)
+	}
+
+	mainGitDir := filepath.Join(dir, "fake.git")
+	if err := worktree.RepairGitdir(worktreePath, mainGitDir); err != nil {
+		t.Errorf("expected nil error for unrecognized format, got: %v", err)
+	}
+
+	// File must be unchanged.
+	content, _ := os.ReadFile(gitFile)
+	if string(content) != "not a gitdir line\n" {
+		t.Errorf("file was modified: %q", content)
+	}
+}
+
+// TestRepairGitdirFromRepoRoot verifies the convenience wrapper that derives
+// mainGitDir from the repo root.
+func TestRepairGitdirFromRepoRoot(t *testing.T) {
+	dir := setupGitRepo(t)
+
+	worktreePath, err := worktree.EnsureForTrack("trk-repair333", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("EnsureForTrack: %v", err)
+	}
+
+	// Overwrite with a stale path.
+	gitFile := filepath.Join(worktreePath, ".git")
+	if err := os.WriteFile(gitFile, []byte("gitdir: /old/machine/path/.git/worktrees/trk-repair333\n"), 0644); err != nil {
+		t.Fatalf("overwrite .git: %v", err)
+	}
+
+	if err := worktree.RepairGitdirFromRepoRoot(worktreePath, dir); err != nil {
+		t.Fatalf("RepairGitdirFromRepoRoot: %v", err)
+	}
+
+	content, err := os.ReadFile(gitFile)
+	if err != nil {
+		t.Fatalf("read .git after repair: %v", err)
+	}
+
+	line := strings.TrimSpace(string(content))
+	repairedGitdir := strings.TrimPrefix(line, "gitdir: ")
+	if _, err := os.Stat(repairedGitdir); err != nil {
+		t.Errorf("repaired gitdir %q does not exist: %v", repairedGitdir, err)
+	}
+}

--- a/internal/worktree/repair_test.go
+++ b/internal/worktree/repair_test.go
@@ -158,3 +158,69 @@ func TestRepairGitdirFromRepoRoot(t *testing.T) {
 		t.Errorf("repaired gitdir %q does not exist: %v", repairedGitdir, err)
 	}
 }
+
+// TestRepairGitdirBasenameCollision guards against the bug where repair
+// derives the admin-dir name from filepath.Base(worktreePath) instead of the
+// existing gitdir pointer. Two worktrees can share a basename (git
+// disambiguates the admin dir with a numeric suffix, e.g. agent-task vs
+// agent-task1); using the worktree path's basename would silently rewrite
+// the second worktree's .git to point at the first worktree's admin dir.
+//
+// Reproduces the review finding on PR #54: both agent-task worktrees live
+// in directories named `agent-task` but git named the admin dirs
+// `agent-task` and `agent-task1`. Repair must preserve the existing admin
+// name (read from the stale gitdir).
+func TestRepairGitdirBasenameCollision(t *testing.T) {
+	dir := setupGitRepo(t)
+	mainGitDir := filepath.Join(dir, ".git")
+
+	// Simulate two worktrees whose paths have the same basename but whose
+	// admin dirs are disambiguated by git (agent-task, agent-task1). In a
+	// real setup, git writes those two admin dirs itself; we fabricate them
+	// here so the test is self-contained.
+	wt1 := filepath.Join(dir, "trackA", "agent-task")
+	wt2 := filepath.Join(dir, "trackB", "agent-task")
+	for _, p := range []string{wt1, wt2} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+	adminA := filepath.Join(mainGitDir, "worktrees", "agent-task")
+	adminB := filepath.Join(mainGitDir, "worktrees", "agent-task1")
+	for _, p := range []string{adminA, adminB} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir admin %s: %v", p, err)
+		}
+	}
+
+	// Both worktrees carry stale cross-machine paths but the suffix of each
+	// stale pointer still carries the correct admin-dir name.
+	stale1 := "/old/machine/.git/worktrees/agent-task"
+	stale2 := "/old/machine/.git/worktrees/agent-task1"
+	if err := os.WriteFile(filepath.Join(wt1, ".git"), []byte("gitdir: "+stale1+"\n"), 0o644); err != nil {
+		t.Fatalf("write wt1 .git: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wt2, ".git"), []byte("gitdir: "+stale2+"\n"), 0o644); err != nil {
+		t.Fatalf("write wt2 .git: %v", err)
+	}
+
+	if err := worktree.RepairGitdir(wt1, mainGitDir); err != nil {
+		t.Fatalf("repair wt1: %v", err)
+	}
+	if err := worktree.RepairGitdir(wt2, mainGitDir); err != nil {
+		t.Fatalf("repair wt2: %v", err)
+	}
+
+	got1, _ := os.ReadFile(filepath.Join(wt1, ".git"))
+	got2, _ := os.ReadFile(filepath.Join(wt2, ".git"))
+	want1 := "gitdir: " + adminA + "\n"
+	want2 := "gitdir: " + adminB + "\n"
+
+	if string(got1) != want1 {
+		t.Errorf("wt1 repaired to %q, want %q", got1, want1)
+	}
+	if string(got2) != want2 {
+		t.Errorf("wt2 repaired to %q, want %q — "+
+			"basename-collision regression (review comment on PR #54)", got2, want2)
+	}
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -1,0 +1,186 @@
+// Package worktree provides helpers to create and reuse git worktrees for
+// HtmlGraph work items (features, tracks, and agent tasks).
+//
+// All three public functions are idempotent: calling them on an already-existing
+// worktree returns the existing path without error. Progress messages are written
+// to the io.Writer passed by the caller; pass io.Discard to suppress all output.
+package worktree
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shakestzd/htmlgraph/internal/htmlparse"
+)
+
+// EnsureForFeature ensures a git worktree exists for the given feature and returns its path.
+// When the feature belongs to a parent track, the track worktree is created/reused instead.
+// Progress is written to w; pass io.Discard to suppress output.
+func EnsureForFeature(featureID, repoRoot string, w io.Writer) (string, error) {
+	// If the feature has a parent track, delegate to the track worktree.
+	trackID := resolveTrackForFeature(featureID, repoRoot)
+	if trackID != "" {
+		return EnsureForTrack(trackID, repoRoot, w)
+	}
+
+	worktreePath := filepath.Join(repoRoot, ".claude", "worktrees", featureID)
+	branchName := "yolo-" + featureID
+
+	// Reuse existing worktree.
+	if _, err := os.Stat(worktreePath); err == nil {
+		fmt.Fprintf(w, "  Worktree: %s (reusing existing)\n", worktreePath)
+		return worktreePath, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(worktreePath), 0755); err != nil {
+		return "", fmt.Errorf("could not create worktrees directory: %w", err)
+	}
+
+	cmd := exec.Command("git", "-C", repoRoot, "worktree", "add", worktreePath, "-b", branchName)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("git worktree add failed: %w\n%s", err, out)
+	}
+
+	fmt.Fprintf(w, "  Worktree: %s (branch: %s)\n", worktreePath, branchName)
+	excludeHtmlgraphFromWorktree(worktreePath, w)
+	reindexWorktree(worktreePath, w)
+
+	return worktreePath, nil
+}
+
+// EnsureForTrack ensures a git worktree exists for the given track and returns its path.
+// Progress is written to w; pass io.Discard to suppress output.
+func EnsureForTrack(trackID, repoRoot string, w io.Writer) (string, error) {
+	worktreePath := filepath.Join(repoRoot, ".claude", "worktrees", trackID)
+	branchName := trackID // Track worktrees use the track ID as the branch name.
+
+	// Reuse existing worktree.
+	if _, err := os.Stat(worktreePath); err == nil {
+		fmt.Fprintf(w, "  Worktree: %s (reusing existing)\n", worktreePath)
+		return worktreePath, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(worktreePath), 0755); err != nil {
+		return "", fmt.Errorf("could not create worktrees directory: %w", err)
+	}
+
+	cmd := exec.Command("git", "-C", repoRoot, "worktree", "add", worktreePath, "-b", branchName)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("git worktree add failed: %w\n%s", err, out)
+	}
+
+	fmt.Fprintf(w, "  Worktree: %s (branch: %s)\n", worktreePath, branchName)
+	excludeHtmlgraphFromWorktree(worktreePath, w)
+	reindexWorktree(worktreePath, w)
+
+	return worktreePath, nil
+}
+
+// EnsureForAgent ensures a git worktree exists for the given agent task and returns its path.
+// The worktree branches from the track branch and is placed at
+// .claude/worktrees/<trackID>/agent-<taskName>.
+// Progress is written to w; pass io.Discard to suppress output.
+func EnsureForAgent(trackID, taskName, repoRoot string, w io.Writer) (string, error) {
+	agentBranch := "agent-" + trackID + "-" + taskName
+	worktreePath := filepath.Join(repoRoot, ".claude", "worktrees", trackID, "agent-"+taskName)
+
+	// Reuse existing worktree.
+	if _, err := os.Stat(worktreePath); err == nil {
+		fmt.Fprintf(w, "  Agent worktree: %s (reusing existing)\n", worktreePath)
+		return worktreePath, nil
+	}
+
+	// Track branch must exist before creating an agent branch from it.
+	if err := exec.Command("git", "-C", repoRoot, "rev-parse", "--verify", trackID).Run(); err != nil {
+		return "", fmt.Errorf("track branch %s not found: create track worktree first with htmlgraph yolo --track %s", trackID, trackID)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(worktreePath), 0755); err != nil {
+		return "", fmt.Errorf("could not create agent worktrees directory: %w", err)
+	}
+
+	cmd := exec.Command("git", "-C", repoRoot, "worktree", "add", worktreePath, "-b", agentBranch, trackID)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("git worktree add failed: %w\n%s", err, out)
+	}
+
+	fmt.Fprintf(w, "  Agent worktree: %s (branch: %s, from: %s)\n", worktreePath, agentBranch, trackID)
+	return worktreePath, nil
+}
+
+// resolveTrackForFeature reads a feature HTML file and returns its data-track-id attribute.
+// If the feature file doesn't exist or has no track ID, returns empty string.
+func resolveTrackForFeature(featureID, projectRoot string) string {
+	featureFile := filepath.Join(projectRoot, ".htmlgraph", "features", featureID+".html")
+	node, err := htmlparse.ParseFile(featureFile)
+	if err != nil {
+		// File not found or parse error — gracefully return empty.
+		return ""
+	}
+	return node.TrackID
+}
+
+// excludeHtmlgraphFromWorktree adds .htmlgraph/ to the worktree's local git exclude file.
+// Best-effort: errors are written to w but do not abort.
+func excludeHtmlgraphFromWorktree(worktreePath string, w io.Writer) {
+	gitFile := filepath.Join(worktreePath, ".git")
+	content, err := os.ReadFile(gitFile)
+	if err != nil {
+		fmt.Fprintf(w, "  Warning: could not read .git file for exclude setup: %v\n", err)
+		return
+	}
+
+	gitdirLine := strings.TrimSpace(string(content))
+	gitdir := strings.TrimPrefix(gitdirLine, "gitdir: ")
+	if gitdir == gitdirLine {
+		return // Not a worktree — no gitdir prefix found.
+	}
+
+	excludePath := filepath.Join(gitdir, "info", "exclude")
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0755); err != nil {
+		fmt.Fprintf(w, "  Warning: could not create exclude directory: %v\n", err)
+		return
+	}
+
+	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Fprintf(w, "  Warning: could not open exclude file: %v\n", err)
+		return
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString("\n.htmlgraph/\n"); err != nil {
+		fmt.Fprintf(w, "  Warning: could not write to exclude file: %v\n", err)
+	}
+}
+
+// reindexWorktree runs `htmlgraph reindex` in the given worktree directory so
+// the worktree's SQLite cache is current before Claude launches. Best-effort:
+// failures are written to w but do not abort.
+// Skipped when running under `go test` to avoid subprocess forks in unit tests.
+func reindexWorktree(worktreeDir string, w io.Writer) {
+	if testing.Testing() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(w, "  Warning: could not determine executable path for reindex: %v\n", err)
+		return
+	}
+	reindexCmd := exec.CommandContext(ctx, exe, "reindex")
+	reindexCmd.Dir = worktreeDir
+	if err := reindexCmd.Run(); err != nil {
+		fmt.Fprintf(w, "  Warning: reindex in worktree failed: %v\n", err)
+	}
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -14,11 +14,16 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/shakestzd/htmlgraph/internal/htmlparse"
 )
+
+// skipReindexEnv, when set to any non-empty value, disables the reindex
+// subprocess that otherwise runs after a worktree is created. Tests set this
+// to avoid forking the htmlgraph binary during unit runs. Using an env var
+// keeps the production code free of the testing import.
+const skipReindexEnv = "HTMLGRAPH_WORKTREE_SKIP_REINDEX"
 
 // EnsureForFeature ensures a git worktree exists for the given feature and returns its path.
 // When the feature belongs to a parent track, the track worktree is created/reused instead.
@@ -164,9 +169,10 @@ func excludeHtmlgraphFromWorktree(worktreePath string, w io.Writer) {
 // reindexWorktree runs `htmlgraph reindex` in the given worktree directory so
 // the worktree's SQLite cache is current before Claude launches. Best-effort:
 // failures are written to w but do not abort.
-// Skipped when running under `go test` to avoid subprocess forks in unit tests.
+// Skipped when HTMLGRAPH_WORKTREE_SKIP_REINDEX is set — tests use this to
+// avoid subprocess forks during unit runs.
 func reindexWorktree(worktreeDir string, w io.Writer) {
-	if testing.Testing() {
+	if os.Getenv(skipReindexEnv) != "" {
 		return
 	}
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -19,11 +19,22 @@ import (
 	"github.com/shakestzd/htmlgraph/internal/htmlparse"
 )
 
-// skipReindexEnv, when set to any non-empty value, disables the reindex
-// subprocess that otherwise runs after a worktree is created. Tests set this
-// to avoid forking the htmlgraph binary during unit runs. Using an env var
-// keeps the production code free of the testing import.
+// skipReindexEnv is an explicit override for the reindex subprocess. When
+// set to any non-empty value, reindexWorktree becomes a no-op. Useful for
+// benchmarks or adhoc scripts; tests rely on the auto-detection below
+// instead.
 const skipReindexEnv = "HTMLGRAPH_WORKTREE_SKIP_REINDEX"
+
+// isGoTestBinary reports whether the current process is a go-test binary,
+// detected by the conventional ".test" suffix that go test produces.
+// Centralizes the test-mode skip so any package using this worktree code
+// from within `go test` automatically skips the reindex subprocess — no
+// per-test-helper setup required. Keeps the "testing" import out of
+// production code.
+func isGoTestBinary() bool {
+	return strings.HasSuffix(os.Args[0], ".test") ||
+		strings.Contains(filepath.Base(os.Args[0]), ".test.")
+}
 
 // EnsureForFeature ensures a git worktree exists for the given feature and returns its path.
 // When the feature belongs to a parent track, the track worktree is created/reused instead.
@@ -169,10 +180,17 @@ func excludeHtmlgraphFromWorktree(worktreePath string, w io.Writer) {
 // reindexWorktree runs `htmlgraph reindex` in the given worktree directory so
 // the worktree's SQLite cache is current before Claude launches. Best-effort:
 // failures are written to w but do not abort.
-// Skipped when HTMLGRAPH_WORKTREE_SKIP_REINDEX is set — tests use this to
-// avoid subprocess forks during unit runs.
+//
+// Auto-skipped when:
+//   - the process is a go-test binary (any test file in any package),
+//   - or HTMLGRAPH_WORKTREE_SKIP_REINDEX is explicitly set.
+//
+// Under `go test`, os.Executable() returns the test binary path; invoking
+// it with `reindex` would recursively re-run tests. The auto-detection
+// covers every consumer test — not just internal/worktree — without
+// requiring per-test-helper env plumbing.
 func reindexWorktree(worktreeDir string, w io.Writer) {
-	if os.Getenv(skipReindexEnv) != "" {
+	if isGoTestBinary() || os.Getenv(skipReindexEnv) != "" {
 		return
 	}
 

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 // setupGitRepo creates a temp git repo with an initial commit and returns its path.
+// (The post-creation reindex subprocess is auto-skipped under go test via
+// isGoTestBinary in worktree.go — no explicit env-var setup needed here.)
 func setupGitRepo(t *testing.T) string {
 	t.Helper()
-	// Avoid the reindex subprocess fork that runs after worktree creation.
-	t.Setenv("HTMLGRAPH_WORKTREE_SKIP_REINDEX", "1")
 	dir := t.TempDir()
 
 	cmds := [][]string{

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -15,6 +15,8 @@ import (
 // setupGitRepo creates a temp git repo with an initial commit and returns its path.
 func setupGitRepo(t *testing.T) string {
 	t.Helper()
+	// Avoid the reindex subprocess fork that runs after worktree creation.
+	t.Setenv("HTMLGRAPH_WORKTREE_SKIP_REINDEX", "1")
 	dir := t.TempDir()
 
 	cmds := [][]string{

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1,0 +1,218 @@
+package worktree_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shakestzd/htmlgraph/internal/worktree"
+)
+
+// setupGitRepo creates a temp git repo with an initial commit and returns its path.
+func setupGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	cmds := [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+	}
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v failed: %s", args, out)
+		}
+	}
+
+	f, err := os.Create(filepath.Join(dir, "README.md"))
+	if err != nil {
+		t.Fatalf("create README: %v", err)
+	}
+	f.WriteString("# Test")
+	f.Close()
+
+	exec.Command("git", "-C", dir, "add", ".").Run() //nolint:errcheck
+	cmd := exec.Command("git", "-C", dir, "commit", "-m", "initial")
+	cmd.Dir = dir
+	cmd.Run() //nolint:errcheck
+
+	return dir
+}
+
+// writeFeatureHTML writes a minimal feature HTML file. If trackID is empty, data-track-id is omitted.
+func writeFeatureHTML(t *testing.T, dir, featureID, trackID string) {
+	t.Helper()
+	featureDir := filepath.Join(dir, ".htmlgraph", "features")
+	if err := os.MkdirAll(featureDir, 0755); err != nil {
+		t.Fatalf("mkdir features: %v", err)
+	}
+	trackAttr := ""
+	if trackID != "" {
+		trackAttr = ` data-track-id="` + trackID + `"`
+	}
+	html := `<article id="` + featureID + `"` + trackAttr + ` data-status="todo">` +
+		`<header><h1>Test Feature</h1></header>` +
+		`<section data-content><p>Description</p></section>` +
+		`</article>`
+	path := filepath.Join(featureDir, featureID+".html")
+	if err := os.WriteFile(path, []byte(html), 0644); err != nil {
+		t.Fatalf("write feature HTML: %v", err)
+	}
+}
+
+// TestEnsureForFeatureIdempotent verifies that the first call creates the worktree
+// and the second call returns the same path without re-creating.
+func TestEnsureForFeatureIdempotent(t *testing.T) {
+	dir := setupGitRepo(t)
+	writeFeatureHTML(t, dir, "feat-aaa", "")
+
+	path1, err := worktree.EnsureForFeature("feat-aaa", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("first EnsureForFeature: %v", err)
+	}
+
+	expected := filepath.Join(dir, ".claude", "worktrees", "feat-aaa")
+	if path1 != expected {
+		t.Errorf("path: got %q, want %q", path1, expected)
+	}
+	if _, err := os.Stat(path1); err != nil {
+		t.Errorf("worktree dir does not exist: %v", err)
+	}
+
+	// Second call is idempotent.
+	path2, err := worktree.EnsureForFeature("feat-aaa", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("second EnsureForFeature: %v", err)
+	}
+	if path1 != path2 {
+		t.Errorf("paths differ on second call: %q vs %q", path1, path2)
+	}
+}
+
+// TestEnsureForFeatureResolvesParentTrack verifies that when a feature has a parent track,
+// EnsureForFeature returns the track worktree path, not the feature path.
+func TestEnsureForFeatureResolvesParentTrack(t *testing.T) {
+	dir := setupGitRepo(t)
+	writeFeatureHTML(t, dir, "feat-ccc", "trk-parent111")
+
+	path, err := worktree.EnsureForFeature("feat-ccc", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("EnsureForFeature: %v", err)
+	}
+
+	expectedTrackPath := filepath.Join(dir, ".claude", "worktrees", "trk-parent111")
+	if path != expectedTrackPath {
+		t.Errorf("path: got %q, want track path %q", path, expectedTrackPath)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("track worktree dir does not exist: %v", err)
+	}
+	// Feature worktree should NOT exist.
+	featurePath := filepath.Join(dir, ".claude", "worktrees", "feat-ccc")
+	if _, err := os.Stat(featurePath); err == nil {
+		t.Error("feature worktree should NOT exist when feature has a parent track")
+	}
+}
+
+// TestEnsureForTrackIdempotent verifies that repeated calls to EnsureForTrack return the same path.
+func TestEnsureForTrackIdempotent(t *testing.T) {
+	dir := setupGitRepo(t)
+
+	path1, err := worktree.EnsureForTrack("trk-ttt111", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("first EnsureForTrack: %v", err)
+	}
+
+	path2, err := worktree.EnsureForTrack("trk-ttt111", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("second EnsureForTrack: %v", err)
+	}
+
+	if path1 != path2 {
+		t.Errorf("paths differ: %q vs %q", path1, path2)
+	}
+
+	expected := filepath.Join(dir, ".claude", "worktrees", "trk-ttt111")
+	if path1 != expected {
+		t.Errorf("path: got %q, want %q", path1, expected)
+	}
+}
+
+// TestEnsureForAgentSignature verifies EnsureForAgent signature, naming convention,
+// and that it creates the expected worktree path.
+func TestEnsureForAgentSignature(t *testing.T) {
+	dir := setupGitRepo(t)
+
+	// Create the track branch that the agent will branch from.
+	exec.Command("git", "-C", dir, "branch", "trk-agent111").Run() //nolint:errcheck
+
+	path, err := worktree.EnsureForAgent("trk-agent111", "slice-3", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("EnsureForAgent: %v", err)
+	}
+
+	expected := filepath.Join(dir, ".claude", "worktrees", "trk-agent111", "agent-slice-3")
+	if path != expected {
+		t.Errorf("path: got %q, want %q", path, expected)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("agent worktree dir does not exist: %v", err)
+	}
+}
+
+// TestProgressWriterDiscardQuiet verifies that passing io.Discard causes no stdout leakage.
+func TestProgressWriterDiscardQuiet(t *testing.T) {
+	dir := setupGitRepo(t)
+	writeFeatureHTML(t, dir, "feat-quiet", "")
+
+	// Capture stdout via pipe.
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	_, errF := worktree.EnsureForFeature("feat-quiet", dir, io.Discard)
+	_, errT := worktree.EnsureForTrack("trk-quiet", dir, io.Discard)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	if errF != nil {
+		t.Fatalf("EnsureForFeature: %v", errF)
+	}
+	if errT != nil {
+		t.Fatalf("EnsureForTrack: %v", errT)
+	}
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no stdout output when using io.Discard; got: %q", buf.String())
+	}
+}
+
+// TestEnsureForFeatureWriterReceivesProgress verifies that progress is written to the writer.
+func TestEnsureForFeatureWriterReceivesProgress(t *testing.T) {
+	dir := setupGitRepo(t)
+	writeFeatureHTML(t, dir, "feat-progress", "")
+
+	var buf bytes.Buffer
+	_, err := worktree.EnsureForFeature("feat-progress", dir, &buf)
+	if err != nil {
+		t.Fatalf("EnsureForFeature: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "feat-progress") {
+		t.Errorf("expected writer to receive progress containing feat-progress; got: %q", output)
+	}
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "htmlgraph",
-  "version": "0.55.6",
+  "version": "0.55.5",
   "description": "Local-first observability and coordination platform for AI-assisted development. Go binary hooks for near-zero cold start.",
   "author": {
     "name": "Shakes Dlamini"

--- a/plugin/commands/git-commit.md
+++ b/plugin/commands/git-commit.md
@@ -29,8 +29,7 @@ Commit changes using Bash-copilot first, haiku-coder as fallback.
 ### Step 1: Analyze what to commit
 
 ```bash
-git diff --stat HEAD
-git status --short
+git diff --stat HEAD && git status --short
 ```
 
 Select source files to stage. Exclude `.htmlgraph/` directory unless explicitly requested.

--- a/plugin/commands/git-commit.md
+++ b/plugin/commands/git-commit.md
@@ -29,7 +29,7 @@ Commit changes using Bash-copilot first, haiku-coder as fallback.
 ### Step 1: Analyze what to commit
 
 ```bash
-git diff --stat HEAD && git status --short
+git diff --stat HEAD; git status --short
 ```
 
 Select source files to stage. Exclude `.htmlgraph/` directory unless explicitly requested.

--- a/plugin/skills/execute/SKILL.md
+++ b/plugin/skills/execute/SKILL.md
@@ -76,10 +76,10 @@ When executing features that originated from a plan, you must first resolve the 
 
 Before creating any tasks, resolve the track's human title by running:
 ```
-Bash("htmlgraph track show <trk-id> --format json")
+Bash("htmlgraph track show <trk-id> --format json | jq -r .title")
 ```
 
-Extract the `.title` field. Use it (not the raw track ID) as the outer `Agent()` description when spawning the top-level coordinator:
+If `jq` is not available, use plain `htmlgraph track show <trk-id>` and parse the title from the second line of the header block. Use the resolved title (not the raw track ID) as the outer `Agent()` description when spawning the top-level coordinator:
 
 ```
 Agent(description="Multi-Project MVP: execute plan", ...)  # ✓ GOOD

--- a/plugin/skills/execute/SKILL.md
+++ b/plugin/skills/execute/SKILL.md
@@ -19,6 +19,17 @@ When running in a worktree, `HTMLGRAPH_PROJECT_DIR` is set automatically. All `h
 
 ---
 
+## Efficiency Rules (read before dispatching)
+
+Every tool call spends a turn. The goal is to dispatch the first subagent within **≤5 tool calls**. To hit that budget:
+
+1. **One call, not ten.** Use `htmlgraph execute-preview <trk-id> --format json` to get the track, linked features/bugs/plans, and current git state in a single invocation. Do not call `htmlgraph track show`, `htmlgraph feature show`, `htmlgraph plan show`, and `git status` separately before the first dispatch.
+2. **Batch git-state probes.** If execute-preview doesn't cover a probe you need, chain with `&&` in one Bash call — never one tool call per git subcommand.
+3. **Don't feature-show more than twice in a row.** If you find yourself calling `htmlgraph feature show` for every linked feature, stop and re-read the preview JSON — the status you need is already there.
+4. **Don't retry flag variants.** If a flag fails, check the skill for the real flag name before trying a second guess. This skill is validated by a build-time smoke test — prescribed flags are real.
+
+---
+
 ## Work Item Attribution (MANDATORY)
 
 Before dispatching any agents, verify attribution is set:
@@ -72,14 +83,11 @@ If no tasks exist yet, create them from the plan (see `/htmlgraph:plan`).
 
 When executing features that originated from a plan, you must first resolve the track title, then create tasks with readable subject fields.
 
-**Resolve track title before dispatching:**
+**Resolve the track title in the same call that fetched everything else:**
 
-Before creating any tasks, resolve the track's human title by running:
-```
-Bash("htmlgraph track show <trk-id> --format json | jq -r .title")
-```
+You already called `htmlgraph execute-preview <trk-id> --format json` in the first discovery step. The track's human title is `.track.title` in that payload — reuse it. Do not issue a second `htmlgraph track show` call just for the title.
 
-If `jq` is not available, use plain `htmlgraph track show <trk-id>` and parse the title from the second line of the header block. Use the resolved title (not the raw track ID) as the outer `Agent()` description when spawning the top-level coordinator:
+Use the title (not the raw track ID) as the outer `Agent()` description when spawning the top-level coordinator:
 
 ```
 Agent(description="Multi-Project MVP: execute plan", ...)  # ✓ GOOD

--- a/plugin/skills/execute/SKILL.md
+++ b/plugin/skills/execute/SKILL.md
@@ -450,17 +450,13 @@ Status categories: **ready** (pending, no blockedBy) | **in_progress** | **block
 ## Cleanup After Completion
 
 ```bash
-# Prune all merged worktrees
-git worktree prune
+# Prune merged worktrees and confirm clean state in one call
+git worktree prune && git worktree list
 
-# Remove a specific worktree
-git worktree remove <path>
+# Remove a specific worktree and its branch (chain to avoid leaving orphans)
+git worktree remove <path> && git branch -D worktree-agent-XXXX
 
-# Remove stale branches
-git branch -D worktree-agent-XXXX
-
-# Confirm clean state + run quality gates
-git worktree list
+# Final quality gates
 go build ./... && go vet ./... && go test ./...
 ```
 

--- a/scripts/check-host-paths.sh
+++ b/scripts/check-host-paths.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# check-host-paths.sh — scan committed artifacts for host-local absolute paths.
+#
+# Scans files under .htmlgraph/ and .claude/ for patterns that indicate
+# host-specific absolute paths that should never be committed.
+#
+# PATTERNS DETECTED:
+#   /Users/<anything>/          — macOS home directories
+#   /home/<user>/               — Linux home directories (except /home/runner/ for CI)
+#   /workspaces/<username>/     — GitHub Codespaces workspace paths
+#   /private/var/folders/       — macOS temp directories
+#
+# ALLOWLIST:
+#   Files listed in scripts/host-paths-allowlist.txt (relative to repo root)
+#   are skipped entirely. The allowlist covers files that legitimately
+#   document or describe host-local paths (e.g. bug reports about this issue).
+#
+# EXIT CODES:
+#   0  — no violations found (prints "OK — N files scanned")
+#   1  — one or more violations found (prints "file:line: <matched-path>")
+#
+# USAGE:
+#   scripts/check-host-paths.sh                    # scan entire scope
+#   scripts/check-host-paths.sh --staged           # scan only git-staged files
+#   scripts/check-host-paths.sh path/to/file       # scan specific file(s)
+#
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ALLOWLIST_FILE="$REPO_ROOT/scripts/host-paths-allowlist.txt"
+STAGED_ONLY=0
+EXPLICIT_FILES=()
+
+# Parse arguments
+for arg in "$@"; do
+    if [[ "$arg" == "--staged" ]]; then
+        STAGED_ONLY=1
+    else
+        EXPLICIT_FILES+=("$arg")
+    fi
+done
+
+# Build allowlist set (relative paths from repo root)
+declare -A ALLOWLIST
+if [[ -f "$ALLOWLIST_FILE" ]]; then
+    while IFS= read -r line; do
+        # Skip comments and blank lines
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line// }" ]] && continue
+        ALLOWLIST["$line"]=1
+    done < "$ALLOWLIST_FILE"
+fi
+
+# Host-local path patterns (grep extended regex)
+# Note: /home/runner/ is excluded (GitHub Actions CI user)
+PATTERN='/Users/[^/[:space:]]+/|/home/(?!runner/)[^/[:space:]]+/|/workspaces/[^/[:space:]]+/|/private/var/folders/'
+
+# Collect files to scan
+declare -a FILES_TO_SCAN
+
+if [[ ${#EXPLICIT_FILES[@]} -gt 0 ]]; then
+    FILES_TO_SCAN=("${EXPLICIT_FILES[@]}")
+elif [[ "$STAGED_ONLY" -eq 1 ]]; then
+    while IFS= read -r f; do
+        # Only include files matching our scope
+        if [[ "$f" == .htmlgraph/* || "$f" == .claude/* ]]; then
+            FILES_TO_SCAN+=("$REPO_ROOT/$f")
+        fi
+    done < <(git -C "$REPO_ROOT" diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
+else
+    # Full scan: .htmlgraph/** and .claude/**
+    while IFS= read -r f; do
+        FILES_TO_SCAN+=("$f")
+    done < <(find "$REPO_ROOT/.htmlgraph" "$REPO_ROOT/.claude" \
+        -type f \
+        ! -name "htmlgraph.db" \
+        ! -name "settings.local.json" \
+        2>/dev/null || true)
+fi
+
+# Filter out allowlisted files and scan
+VIOLATIONS=0
+SCANNED=0
+
+for abs_file in "${FILES_TO_SCAN[@]}"; do
+    # Skip if file doesn't exist (e.g. deleted staged file)
+    [[ -f "$abs_file" ]] || continue
+
+    # Compute relative path for allowlist lookup
+    rel_file="${abs_file#"$REPO_ROOT"/}"
+
+    # Skip allowlisted files
+    if [[ -n "${ALLOWLIST[$rel_file]+x}" ]]; then
+        continue
+    fi
+
+    SCANNED=$((SCANNED + 1))
+
+    # Scan for host-local patterns using perl (supports lookahead for /home/runner/ exclusion)
+    while IFS= read -r hit; do
+        echo "$hit"
+        VIOLATIONS=$((VIOLATIONS + 1))
+    done < <(perl -ne '
+        while (m{(/Users/[^/\s]+/|/home/(?!runner/)[^/\s]+/|/workspaces/[^/\s]+/|/private/var/folders/)}g) {
+            print ARGV . ":" . $. . ": " . $1 . "\n";
+        }
+    ' "$abs_file" 2>/dev/null || true)
+done
+
+if [[ "$VIOLATIONS" -gt 0 ]]; then
+    echo ""
+    echo "FAIL: $VIOLATIONS host-local path violation(s) found in $SCANNED file(s) scanned."
+    echo "      These paths must not be committed — they are machine-specific."
+    echo "      To allowlist a file, add its repo-relative path to scripts/host-paths-allowlist.txt"
+    exit 1
+fi
+
+echo "OK — $SCANNED file(s) scanned, no host-local path violations found."


### PR DESCRIPTION
## Summary

- Closes 11 bugs on `trk-787f57d3` plus one follow-up (`bug-1300cace`) addressing roborev job 8 findings — 12 commits, ~2400 LOC net.
- Retires two systemic classes at source: a pre-commit host-path guardrail (`bug-4b6d8369`) and a build-time skill-flag smoke test (`bug-61dc9267`) that would have caught `bug-7ca3638b` before it merged.
- Collapses the `/htmlgraph:execute` discovery sequence from ~10 calls to 1 via the new `htmlgraph execute-preview` command, and rewrites the execute SKILL to hit that budget.

## What's in the branch

| Commit | Bug | Category |
|---|---|---|
| `0ea527ba` | `bug-f4760452` (P3) | Scrub host-local absolute paths from two committed artifacts |
| `c95eef2a` | `bug-32c47098` (P2) | Add `--format json` to `track/feature/bug/plan/spike show` |
| `0e082b78` | `bug-e1c968fe` (P1) | Auto-repair stale worktree `.git` gitdir on `SessionStart` (cross-host) |
| `0577bd40` | `bug-eb3e50f6` (P2) | Hermetic test fixtures — replace `/tmp/` + `/Users/shakes` across 14 files |
| `104f1761` | `bug-7ca3638b` (P0) | Remove non-existent `--format json` reference from execute SKILL |
| `12d46849` | `bug-4b6d8369` (P1) | **Systemic:** `htmlgraph check host-paths` pre-commit guardrail |
| `e07ba647` | `bug-5150e42a` (P2) | Cross-env absolute-path drift class audit doc |
| `9b3ce320` | `bug-0403e704` (P1) | New `htmlgraph execute-preview` — one-call orchestrator context |
| `74a968b6` | `bug-61dc9267` (P1) | **Systemic:** build-time skill-flag validator |
| `ab6f013e` | `bug-cf929f1a` (P1) | Rewrite execute SKILL for ≤5 tool calls to first dispatch |
| `825ca401` | `bug-f07a612e` (P2) | Chain redundant sequential git/htmlgraph calls in skills |
| `6f02ed26` | `bug-1300cace` | Roborev job 8 follow-up (5 findings: plan discovery, directory-backed tracks, `spk-` prefix, git-common-dir, `&&` short-circuit) |

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` green
- [x] New tests cover: `--format json` output, worktree gitdir repair, execute-preview envelope + directory-backed tracks + plan-via-`data-feature-id`, skill-flag validator (positive + negative fixtures), hermetic fixtures
- [x] Roborev job 8 closed after follow-up commit
- [ ] Rebase onto `main` — branch is 7 commits behind merge-base `3fff8d86`; needs `git rebase main` or merge commit before landing
- [ ] Human review of the audit doc (`docs/cross-env-path-drift-audit.md`) and the two open follow-ups it records

## Notes

- Branch base is `3fff8d86`; `main` is at `4e9a824c`. Diffstat against `main` will show some unrelated removals due to the gap — these are commits on `main` not in this branch (cockpit/dashboard/agents work), not changes introduced here.
- Not merged — ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)