### PR TITLE
fix(db): remove silent in-tree DB fallback + dashboard XSS + OTel/hook tree merge

### DIFF
--- a/cmd/htmlgraph/api_tree.go
+++ b/cmd/htmlgraph/api_tree.go
@@ -24,6 +24,12 @@ type turn struct {
 	Stats     turnStats        `json:"stats"`
 }
 
+// hookOtelDedupWindowMicros is the timestamp window used to consider a
+// hook UserQuery row "anchored" by an OTel interaction span when the hook
+// row has no step_id to match exactly. Five seconds is generous compared
+// to the actual sub-second offset between matching events.
+const hookOtelDedupWindowMicros int64 = 5_000_000
+
 // eventColumns is the shared SELECT column list for agent_events (aliased as e).
 const eventColumns = `e.event_id, e.agent_id, e.event_type, e.timestamp, e.tool_name,
 	COALESCE(e.input_summary, ''), COALESCE(e.output_summary, ''),
@@ -167,26 +173,35 @@ func buildEventTreeOtel(database *sql.DB, limit int) []turn {
 	return turns
 }
 
-// buildEventTreeHookUnanchored returns hook-based UserQuery turns whose
-// step_id does NOT match an OTel interaction span. New sessions that emit
-// both an OTel anchor AND a hook UserQuery are surfaced through
-// buildEventTreeOtel; this function captures the older / hook-only
-// sessions so they are not dropped when mixed with OTel data.
+// buildEventTreeHookUnanchored returns hook-based UserQuery turns that do
+// NOT correspond to an OTel interaction span. Anchoring is detected with
+// two complementary checks so deduplication holds even when hook events
+// arrive without a step_id:
+//
+//  1. step_id match — when the hook UserQuery carries the OTel trace_id,
+//     skip if any interaction span shares it.
+//  2. session+timestamp window — when step_id is empty, skip if any
+//     interaction span exists in the same session within
+//     hookOtelDedupWindowMicros of the hook event's timestamp.
+//
+// Buildings before OTel emission and pure hook-only sessions still pass
+// both checks and remain visible in /api/events/tree.
 func buildEventTreeHookUnanchored(database *sql.DB, limit int) []turn {
 	rows, err := database.Query(`
 		SELECT `+eventColumns+`
 		FROM agent_events e
 		WHERE e.tool_name = 'UserQuery'
-		  AND (
-		    e.step_id IS NULL OR e.step_id = ''
-		    OR NOT EXISTS (
-		      SELECT 1 FROM otel_signals s
-		      WHERE s.kind = 'span' AND s.canonical = 'interaction'
-		        AND s.trace_id = e.step_id
-		    )
+		  AND NOT EXISTS (
+		    SELECT 1 FROM otel_signals s
+		    WHERE s.kind = 'span' AND s.canonical = 'interaction'
+		      AND s.session_id = e.session_id
+		      AND (
+		        (e.step_id IS NOT NULL AND e.step_id != '' AND s.trace_id = e.step_id)
+		        OR ABS(s.ts_micros - CAST(strftime('%s', e.timestamp) AS INTEGER) * 1000000) < ?
+		      )
 		  )
 		ORDER BY e.timestamp DESC
-		LIMIT ?`, limit)
+		LIMIT ?`, hookOtelDedupWindowMicros, limit)
 	if err != nil {
 		return []turn{}
 	}

--- a/cmd/htmlgraph/api_tree.go
+++ b/cmd/htmlgraph/api_tree.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 )
@@ -47,15 +48,32 @@ func treeHandler(database *sql.DB) http.HandlerFunc {
 	}
 }
 
-// buildEventTree tries OTel interaction spans as turn anchors first.
-// When no interaction spans exist, it falls back to hook-based UserQuery
-// rows so older sessions without OTel data continue to render correctly.
+// buildEventTree merges OTel interaction-span turns with hook-based UserQuery
+// turns that have no OTel anchor, then returns the most recent `limit` by
+// timestamp. Mixed databases (sessions partially anchored in OTel, older
+// sessions purely hook-driven) are rendered together rather than the
+// older sessions being silently dropped once any OTel span is present.
 func buildEventTree(database *sql.DB, limit int) []turn {
-	turns := buildEventTreeOtel(database, limit)
-	if len(turns) > 0 {
-		return turns
+	otelTurns := buildEventTreeOtel(database, limit)
+	hookTurns := buildEventTreeHookUnanchored(database, limit)
+
+	merged := append(otelTurns, hookTurns...)
+	if len(merged) == 0 {
+		return []turn{}
 	}
-	return buildEventTreeHook(database, limit)
+
+	// Sort DESC by timestamp (RFC3339 strings are lexicographically sortable
+	// in ascending chronological order; reverse for newest-first).
+	sort.SliceStable(merged, func(i, j int) bool {
+		ti, _ := merged[i].UserQuery["timestamp"].(string)
+		tj, _ := merged[j].UserQuery["timestamp"].(string)
+		return ti > tj
+	})
+
+	if len(merged) > limit {
+		merged = merged[:limit]
+	}
+	return merged
 }
 
 // buildEventTreeOtel builds the turn list using OTel interaction spans as
@@ -149,13 +167,24 @@ func buildEventTreeOtel(database *sql.DB, limit int) []turn {
 	return turns
 }
 
-// buildEventTreeHook is the original hook-based implementation, kept as a
-// fallback for sessions that predate OTel instrumentation.
-func buildEventTreeHook(database *sql.DB, limit int) []turn {
+// buildEventTreeHookUnanchored returns hook-based UserQuery turns whose
+// step_id does NOT match an OTel interaction span. New sessions that emit
+// both an OTel anchor AND a hook UserQuery are surfaced through
+// buildEventTreeOtel; this function captures the older / hook-only
+// sessions so they are not dropped when mixed with OTel data.
+func buildEventTreeHookUnanchored(database *sql.DB, limit int) []turn {
 	rows, err := database.Query(`
 		SELECT `+eventColumns+`
 		FROM agent_events e
 		WHERE e.tool_name = 'UserQuery'
+		  AND (
+		    e.step_id IS NULL OR e.step_id = ''
+		    OR NOT EXISTS (
+		      SELECT 1 FROM otel_signals s
+		      WHERE s.kind = 'span' AND s.canonical = 'interaction'
+		        AND s.trace_id = e.step_id
+		    )
+		  )
 		ORDER BY e.timestamp DESC
 		LIMIT ?`, limit)
 	if err != nil {

--- a/cmd/htmlgraph/api_tree_test.go
+++ b/cmd/htmlgraph/api_tree_test.go
@@ -256,6 +256,103 @@ func TestBuildEventTree_OtelPromptFromTrace(t *testing.T) {
 	}
 }
 
+// TestBuildEventTree_MixedOtelAndHook verifies the merge logic: OTel-anchored
+// sessions, hook-only sessions, and the regression case where a session emits
+// both an OTel interaction span AND a hook UserQuery row with empty step_id
+// (which used to surface the hook row as a duplicate prompt).
+func TestBuildEventTree_MixedOtelAndHook(t *testing.T) {
+	database := openTreeTestDB(t)
+	defer database.Close()
+
+	// Second session for the hook-only case.
+	now := time.Now().UTC()
+	hookOnlySess := &models.Session{
+		SessionID:     "sess-hook-only",
+		AgentAssigned: "claude-code",
+		CreatedAt:     now,
+		Status:        "active",
+	}
+	if err := db.InsertSession(database, hookOnlySess); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	// Three turns at distinct timestamps so DESC sort is unambiguous.
+	otelTs := now.Add(-30 * time.Second)
+	hookOnlyTs := now.Add(-20 * time.Second)
+	dupHookTs := now.Add(-10 * time.Second)
+
+	// 1. OTel interaction span with a paired hook UserQuery whose step_id
+	//    matches the trace_id (the well-formed case).
+	mustExec(t, database,
+		`INSERT INTO otel_signals
+		 (signal_id, harness, session_id, kind, canonical, native, ts_micros, trace_id, span_id, attrs_json)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"sig-i1", "claude-code", "sess-test",
+		"span", "interaction", "interaction",
+		otelTs.UnixMicro(), "trace-otel-1", "span-i1",
+		`{"user_prompt":"first prompt"}`)
+	mustExec(t, database,
+		`INSERT INTO agent_events (event_id, agent_id, event_type, timestamp, tool_name, session_id, status, step_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		"uq-otel-1", "claude-code", "tool_call", otelTs.Format(time.RFC3339),
+		"UserQuery", "sess-test", "recorded", "trace-otel-1")
+
+	// 2. Hook-only session — no OTel anywhere. Must be retained.
+	mustExec(t, database,
+		`INSERT INTO agent_events (event_id, agent_id, event_type, timestamp, tool_name, session_id, status)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"uq-hook-only", "claude-code", "tool_call", hookOnlyTs.Format(time.RFC3339),
+		"UserQuery", "sess-hook-only", "recorded")
+
+	// 3. Regression: a session that has an OTel interaction span AND a hook
+	//    UserQuery row with EMPTY step_id near the same timestamp. The
+	//    session+timestamp window check must dedup it.
+	mustExec(t, database,
+		`INSERT INTO otel_signals
+		 (signal_id, harness, session_id, kind, canonical, native, ts_micros, trace_id, span_id, attrs_json)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"sig-i2", "claude-code", "sess-test",
+		"span", "interaction", "interaction",
+		dupHookTs.UnixMicro(), "trace-otel-2", "span-i2",
+		`{"user_prompt":"third prompt"}`)
+	mustExec(t, database,
+		`INSERT INTO agent_events (event_id, agent_id, event_type, timestamp, tool_name, session_id, status, step_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		"uq-dup-empty-step", "claude-code", "tool_call", dupHookTs.Format(time.RFC3339),
+		"UserQuery", "sess-test", "recorded", "")
+
+	turns := buildEventTree(database, 50)
+
+	// Expected: two OTel turns (sig-i1, sig-i2) + one hook-only turn (uq-hook-only).
+	// The empty-step hook row (uq-dup-empty-step) must be deduped.
+	if len(turns) != 3 {
+		var ids []string
+		for _, t := range turns {
+			if id, ok := t.UserQuery["event_id"].(string); ok {
+				ids = append(ids, id)
+			}
+		}
+		t.Fatalf("got %d turns, want 3 (event_ids=%v)", len(turns), ids)
+	}
+
+	for _, tn := range turns {
+		if id, _ := tn.UserQuery["event_id"].(string); id == "uq-dup-empty-step" {
+			t.Errorf("hook UserQuery with empty step_id was not deduped against the same-session OTel interaction span")
+		}
+	}
+
+	// Sanity: hook-only session's turn is present.
+	foundHookOnly := false
+	for _, tn := range turns {
+		if id, _ := tn.UserQuery["event_id"].(string); id == "uq-hook-only" {
+			foundHookOnly = true
+		}
+	}
+	if !foundHookOnly {
+		t.Error("hook-only session's UserQuery turn missing — merge dropped unanchored hook turns")
+	}
+}
+
 func TestComputeStats_CountsNestedChildren(t *testing.T) {
 	children := []map[string]any{
 		{

--- a/cmd/htmlgraph/hook.go
+++ b/cmd/htmlgraph/hook.go
@@ -92,7 +92,13 @@ func hookSubcmd(
 				if !hooks.IsHtmlGraphProject(projectDir) {
 					return fallback, nil
 				}
-				database, err := db.Open(hooks.DBPath(projectDir))
+				dbPath, err := hooks.DBPath(projectDir)
+				if err != nil {
+					hooks.LogError(use, event.SessionID,
+						fmt.Sprintf("DBPath failed: %v", err))
+					return fallback, nil
+				}
+				database, err := db.Open(dbPath)
 				if err != nil {
 					hooks.LogError(use, event.SessionID,
 						fmt.Sprintf("db.Open failed: %v", err))
@@ -125,7 +131,13 @@ func hookSubcmdWithProject(
 				if !hooks.IsHtmlGraphProject(projectDir) {
 					return fallback, nil
 				}
-				database, err := db.Open(hooks.DBPath(projectDir))
+				dbPath, err := hooks.DBPath(projectDir)
+				if err != nil {
+					hooks.LogError(use, event.SessionID,
+						fmt.Sprintf("DBPath failed: %v", err))
+					return fallback, nil
+				}
+				database, err := db.Open(dbPath)
 				if err != nil {
 					hooks.LogError(use, event.SessionID,
 						fmt.Sprintf("db.Open failed: %v", err))
@@ -155,7 +167,13 @@ func hookTrackEventCmd(fallback *hooks.HookResult) *cobra.Command {
 				if !hooks.IsHtmlGraphProject(projectDir) {
 					return fallback, nil
 				}
-				database, err := db.Open(hooks.DBPath(projectDir))
+				dbPath, err := hooks.DBPath(projectDir)
+				if err != nil {
+					hooks.LogError("track-event", event.SessionID,
+						fmt.Sprintf("DBPath failed: %v", err))
+					return fallback, nil
+				}
+				database, err := db.Open(dbPath)
 				if err != nil {
 					hooks.LogError("track-event", event.SessionID,
 						fmt.Sprintf("db.Open failed: %v", err))

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -161,15 +161,15 @@ func IsHtmlGraphProject(projectDir string) bool {
 // Delegates to storage.CanonicalDBPath so the DB always lives in the host
 // OS cache dir (never inside the project tree), ensuring WAL/SHM mmap
 // works regardless of the project filesystem (virtiofs, NFS, FUSE, etc.).
-// Falls back to the legacy project-local path only if the cache dir lookup
-// fails (which should not happen in practice).
-func DBPath(projectDir string) string {
-	p, err := storage.CanonicalDBPath(projectDir)
-	if err != nil {
-		// Degrade: return legacy path so hooks keep working even if UserCacheDir fails.
-		return filepath.Join(projectDir, ".htmlgraph", ".db", storage.DBFileName)
-	}
-	return p
+//
+// Returns an error when os.UserCacheDir() fails. There is intentionally no
+// silent fallback to a project-local path: a fallback caused bug-62f14f8c
+// where the indexer wrote to ~/.cache/htmlgraph/<hash>/htmlgraph.db while
+// the YOLO PreToolUse gate read .htmlgraph/.db/htmlgraph.db, leaving the
+// gate's view of agent_events permanently stale. Callers must propagate
+// the error (typically by skipping the hook with the configured fallback).
+func DBPath(projectDir string) (string, error) {
+	return storage.CanonicalDBPath(projectDir)
 }
 
 // NormaliseSessionID extracts a UUID from a path-style session_id that Claude

--- a/internal/storage/dbpath_test.go
+++ b/internal/storage/dbpath_test.go
@@ -1,6 +1,7 @@
 package storage_test
 
 import (
+	"fmt"
 	"go/build"
 	"os"
 	"path/filepath"
@@ -11,10 +12,27 @@ import (
 )
 
 // TestNoInlineDBPathConstruction walks cmd/ and internal/ (skipping the
-// storage package and _test.go files) and fails if any .go file contains
-// the literal "htmlgraph.db" outside the storage package.  This enforces
-// that every future caller goes through storage.CanonicalDBPath /
-// storage.DBFileName rather than constructing the path inline.
+// storage package and _test.go files) and fails when any .go file
+// constructs a DB path outside storage.CanonicalDBPath. Three patterns
+// are forbidden in production code outside internal/storage:
+//
+//  1. Lines containing the literal "htmlgraph.db" string. Production
+//     code must reference storage.DBFileName, and even then only outside
+//     a filepath.Join (rule 2).
+//  2. Lines that contain BOTH filepath.Join and storage.DBFileName.
+//     This catches the regression class fixed by bug-62f14f8c, where
+//     internal/hooks/runner.go silently fell back to constructing
+//     .htmlgraph/.db/htmlgraph.db whenever os.UserCacheDir() errored.
+//     Comparison sites (e.g. `if base == storage.DBFileName`) remain
+//     allowed because they do not synthesize a path.
+//  3. Lines containing ".htmlgraph/.db" or ".db/htmlgraph" — the legacy
+//     in-tree DB locations should never appear in callers; only
+//     storage.LegacyProjectDBPaths (inside internal/storage) may
+//     reference them, for the orphan-detection warning.
+//
+// LIMITATION: rule 2 is line-based, so a multi-line filepath.Join that
+// places storage.DBFileName on its own line slips through. Keep
+// filepath.Join calls single-line in production code.
 func TestNoInlineDBPathConstruction(t *testing.T) {
 	// Resolve module root from GOPATH or the source location.
 	root := filepath.Join(build.Default.GOPATH, "src", "github.com", "shakestzd", "htmlgraph")
@@ -44,7 +62,22 @@ func TestNoInlineDBPathConstruction(t *testing.T) {
 	// The storage package itself is the one place allowed to define DBFileName.
 	storagePkg := filepath.Join(root, "internal", "storage")
 
-	var violations []string
+	type violation struct {
+		path    string
+		line    int
+		pattern string
+	}
+	// linePatterns flag a single line whenever it contains the substring.
+	// filepathJoinDBFileName is checked separately because it requires both
+	// substrings on the same line (legitimate comparison sites use only
+	// storage.DBFileName, which is allowed).
+	linePatterns := []string{
+		`"htmlgraph.db"`,   // literal filename
+		`".htmlgraph/.db"`, // legacy ext4-volume path segment
+		`".db/htmlgraph"`,  // partial path hinting at legacy layout
+	}
+
+	var violations []violation
 	for _, dir := range scanDirs {
 		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -69,9 +102,23 @@ func TestNoInlineDBPathConstruction(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			if strings.Contains(string(data), `"htmlgraph.db"`) {
-				rel, _ := filepath.Rel(root, path)
-				violations = append(violations, rel)
+			rel, _ := filepath.Rel(root, path)
+			for i, line := range strings.Split(string(data), "\n") {
+				for _, pat := range linePatterns {
+					if strings.Contains(line, pat) {
+						violations = append(violations, violation{path: rel, line: i + 1, pattern: pat})
+					}
+				}
+				// filepath.Join + storage.DBFileName on one line = path synthesis.
+				// Comparison sites (line contains storage.DBFileName but no
+				// filepath.Join) are allowed.
+				if strings.Contains(line, "filepath.Join") && strings.Contains(line, "storage.DBFileName") {
+					violations = append(violations, violation{
+						path:    rel,
+						line:    i + 1,
+						pattern: "filepath.Join(...storage.DBFileName...)",
+					})
+				}
 			}
 			return nil
 		})
@@ -81,8 +128,12 @@ func TestNoInlineDBPathConstruction(t *testing.T) {
 	}
 
 	if len(violations) > 0 {
-		t.Errorf("files contain inline %q (use storage.DBFileName or storage.CanonicalDBPath):\n  %s",
-			"htmlgraph.db", strings.Join(violations, "\n  "))
+		var lines []string
+		for _, v := range violations {
+			lines = append(lines, fmt.Sprintf("%s:%d contains forbidden pattern %s", v.path, v.line, v.pattern))
+		}
+		t.Errorf("non-canonical DB-path construction outside internal/storage "+
+			"(use storage.CanonicalDBPath):\n  %s", strings.Join(lines, "\n  "))
 	}
 }
 

--- a/plugin/static/components.js
+++ b/plugin/static/components.js
@@ -70,25 +70,53 @@ class HgActivityFeed extends HTMLElement {
       const data = await resp.json();
       const events = data.events || [];
       const feed = this.querySelector('.hg-feed');
+      // Build DOM nodes via textContent/dataset rather than innerHTML so
+      // OTel-sourced summaries — which now include raw user prompts and
+      // tool content — cannot inject HTML or script into the dashboard.
+      feed.replaceChildren();
       if (!events.length) {
-        feed.innerHTML = '<p class="hg-feed-empty">No recent activity</p>';
+        const empty = document.createElement('p');
+        empty.className = 'hg-feed-empty';
+        empty.textContent = 'No recent activity';
+        feed.appendChild(empty);
         return;
       }
-      feed.innerHTML = events.map(e => {
-        const label = e.tool_name || e.type || 'event';
-        const summary = e.summary || '';
-        const durBadge = e.duration_ms > 0
-          ? `<span class="hg-feed-badge hg-feed-badge-dur">${e.duration_ms}ms</span>` : '';
-        const costBadge = e.cost_usd > 0
-          ? `<span class="hg-feed-badge hg-feed-badge-cost">$${e.cost_usd.toFixed(3)}</span>` : '';
-        return `
-          <div class="hg-feed-item" data-event-type="${e.type || ''}" data-source="${e.source || ''}">
-            <span class="hg-feed-time">${new Date(e.timestamp).toLocaleTimeString()}</span>
-            <span class="hg-feed-tool">${label}</span>
-            ${durBadge}${costBadge}
-            <span class="hg-feed-summary">${summary}</span>
-          </div>`;
-      }).join('');
+      for (const e of events) {
+        const item = document.createElement('div');
+        item.className = 'hg-feed-item';
+        item.dataset.eventType = e.type || '';
+        item.dataset.source = e.source || '';
+
+        const time = document.createElement('span');
+        time.className = 'hg-feed-time';
+        time.textContent = new Date(e.timestamp).toLocaleTimeString();
+        item.appendChild(time);
+
+        const tool = document.createElement('span');
+        tool.className = 'hg-feed-tool';
+        tool.textContent = e.tool_name || e.type || 'event';
+        item.appendChild(tool);
+
+        if (e.duration_ms > 0) {
+          const dur = document.createElement('span');
+          dur.className = 'hg-feed-badge hg-feed-badge-dur';
+          dur.textContent = `${e.duration_ms}ms`;
+          item.appendChild(dur);
+        }
+        if (e.cost_usd > 0) {
+          const cost = document.createElement('span');
+          cost.className = 'hg-feed-badge hg-feed-badge-cost';
+          cost.textContent = `$${e.cost_usd.toFixed(3)}`;
+          item.appendChild(cost);
+        }
+
+        const summary = document.createElement('span');
+        summary.className = 'hg-feed-summary';
+        summary.textContent = e.summary || '';
+        item.appendChild(summary);
+
+        feed.appendChild(item);
+      }
     } catch (_) { /* server not available */ }
   }
 }


### PR DESCRIPTION
## Summary

Three fixes from session bug-62f14f8c → bug-c58ab226 → roborev jobs 4 + 6, cherry-picked onto `main` after the duplicate work in `8d6417ba` was dropped.

- **`043767e5` fix(db): remove silent in-tree DB fallback; widen path guard** — `internal/hooks/runner.go` `DBPath()` silently fell back to `.htmlgraph/.db/htmlgraph.db` when `storage.CanonicalDBPath` errored, splitting writes between the cache-dir DB (where the OTel indexer wrote) and the legacy in-tree DB (where the YOLO PreToolUse gate read). The gate's view of `agent_events` stayed hours stale, falsely blocking commits with "tests must pass" long after `go test ./...` had passed. Removed the fallback (now propagates the error; three callers in `cmd/htmlgraph/hook.go` log + return the configured fallback HookResult). Extended the static guard `TestNoInlineDBPathConstruction` (originally added in `bug-a312db4d`) to also reject `filepath.Join(...storage.DBFileName...)` and the legacy path segments `.htmlgraph/.db` / `.db/htmlgraph` — the original guard only flagged the literal `"htmlgraph.db"` string and missed the regression because `runner.go` composed the path via the `DBFileName` constant.
- **`8b13091d` fix(api_tree, dashboard): merge OTel+hook tree, escape activity feed XSS** — `cmd/htmlgraph/api_tree.go` `buildEventTree` merges OTel interaction-span turns with hook `UserQuery` turns whose `step_id` has no matching OTel anchor, sorts DESC by RFC3339 timestamp, then applies the limit. Previously, once any OTel span existed all hook turns were dropped — older / hook-only sessions disappeared from `/api/events/tree`. `plugin/static/components.js` `HgActivityFeed` builds DOM nodes with `textContent`/`dataset` rather than `innerHTML`; OTel summaries now include raw prompts/tool content, so locally stored content can no longer execute as HTML. (Other fixes from the original `bug-c58ab226` commit — resume `--name`, yolo feature worktree, slug ASCII — were dropped on cherry-pick because main `8d6417ba` landed equivalent fixes earlier.)
- **`99740947` fix(api_tree): dedup hook UserQuery rows with empty step_id (roborev job 6)** — Tightened the merge: a single `NOT EXISTS` matches either `step_id == trace_id` OR `session_id + |hook_ts - span_ts| < 5s`, so empty-`step_id` hook UserQuery rows in a session that already has an OTel interaction span are suppressed. Adds `TestBuildEventTree_MixedOtelAndHook` covering OTel-anchored, hook-only, and the empty-step regression case.

## Verification

- `go build ./... && go vet ./... && go test ./...` — all green locally.
- Live verification of the DB-path fix in `043767e5`: moved `.htmlgraph/htmlgraph.db` and `.htmlgraph/.db/htmlgraph.db` aside, fired hooks (CLI + Bash tool calls), `htmlgraph status` no longer prints `legacy SQLite file` warnings and the legacy paths do not reappear; only `~/.cache/htmlgraph/<hash>/htmlgraph.db` is written.
- Roborev jobs 4 (commented) and 6 (commented + closed) on the original session branch.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `internal/storage/dbpath_test.go::TestNoInlineDBPathConstruction` catches a reintroduced `filepath.Join(..., storage.DBFileName)` (verified by temporarily reintroducing the regression)
- [x] `cmd/htmlgraph/api_tree_test.go::TestBuildEventTree_MixedOtelAndHook` — OTel+hook merge dedup on empty step_id
- [x] Live: `.htmlgraph/.db/htmlgraph.db` does not reappear after hook activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)