### PR TITLE
Plan v2: slice-centered incremental specs (trk-a30e8df4)

### DIFF
--- a/cmd/htmlgraph/api.go
+++ b/cmd/htmlgraph/api.go
@@ -3,6 +3,7 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -28,19 +29,27 @@ func respondJSON(w http.ResponseWriter, v any) {
 func initialStatsHandler(database *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var totalEvents, totalSessions int
-		database.QueryRow(`SELECT COUNT(*) FROM agent_events`).Scan(&totalEvents)
-		database.QueryRow(`SELECT COUNT(*) FROM sessions`).Scan(&totalSessions)
+		if err := database.QueryRow(`SELECT COUNT(*) FROM agent_events`).Scan(&totalEvents); err != nil && err != sql.ErrNoRows {
+			http.Error(w, fmt.Sprintf("query agent_events count: %v", err), http.StatusInternalServerError)
+			return
+		}
+		if err := database.QueryRow(`SELECT COUNT(*) FROM sessions`).Scan(&totalSessions); err != nil && err != sql.ErrNoRows {
+			http.Error(w, fmt.Sprintf("query sessions count: %v", err), http.StatusInternalServerError)
+			return
+		}
 
 		rows, err := database.Query(
 			`SELECT DISTINCT agent_id FROM agent_events ORDER BY agent_id`)
 		agents := []string{}
-		if err == nil {
-			defer rows.Close()
-			for rows.Next() {
-				var a string
-				if rows.Scan(&a) == nil {
-					agents = append(agents, a)
-				}
+		if err != nil {
+			http.Error(w, fmt.Sprintf("query agents: %v", err), http.StatusInternalServerError)
+			return
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var a string
+			if rows.Scan(&a) == nil {
+				agents = append(agents, a)
 			}
 		}
 
@@ -306,7 +315,10 @@ func statsHandler(database *sql.DB, projectDir string) http.HandlerFunc {
 		var total, inProgress, done, todo int
 		var activeSessions, totalEvents int
 
-		database.QueryRow(`SELECT COUNT(*) FROM features`).Scan(&total)
+		if err := database.QueryRow(`SELECT COUNT(*) FROM features`).Scan(&total); err != nil && err != sql.ErrNoRows {
+			http.Error(w, fmt.Sprintf("query features count: %v", err), http.StatusInternalServerError)
+			return
+		}
 
 		if total == 0 {
 			items := featuresFromHTML(projectDir)
@@ -322,37 +334,61 @@ func statsHandler(database *sql.DB, projectDir string) http.HandlerFunc {
 				}
 			}
 		} else {
-			database.QueryRow(`SELECT COUNT(*) FROM features WHERE status='in-progress'`).Scan(&inProgress)
-			database.QueryRow(`SELECT COUNT(*) FROM features WHERE status='done'`).Scan(&done)
-			database.QueryRow(`SELECT COUNT(*) FROM features WHERE status='todo'`).Scan(&todo)
+			if err := database.QueryRow(`SELECT COUNT(*) FROM features WHERE status='in-progress'`).Scan(&inProgress); err != nil && err != sql.ErrNoRows {
+				http.Error(w, fmt.Sprintf("query in-progress count: %v", err), http.StatusInternalServerError)
+				return
+			}
+			if err := database.QueryRow(`SELECT COUNT(*) FROM features WHERE status='done'`).Scan(&done); err != nil && err != sql.ErrNoRows {
+				http.Error(w, fmt.Sprintf("query done count: %v", err), http.StatusInternalServerError)
+				return
+			}
+			if err := database.QueryRow(`SELECT COUNT(*) FROM features WHERE status='todo'`).Scan(&todo); err != nil && err != sql.ErrNoRows {
+				http.Error(w, fmt.Sprintf("query todo count: %v", err), http.StatusInternalServerError)
+				return
+			}
 		}
 
-		database.QueryRow(`SELECT COUNT(*) FROM sessions WHERE status='active'`).Scan(&activeSessions)
-		database.QueryRow(`SELECT COUNT(*) FROM agent_events`).Scan(&totalEvents)
+		if err := database.QueryRow(`SELECT COUNT(*) FROM sessions WHERE status='active'`).Scan(&activeSessions); err != nil && err != sql.ErrNoRows {
+			http.Error(w, fmt.Sprintf("query active sessions: %v", err), http.StatusInternalServerError)
+			return
+		}
+		if err := database.QueryRow(`SELECT COUNT(*) FROM agent_events`).Scan(&totalEvents); err != nil && err != sql.ErrNoRows {
+			http.Error(w, fmt.Sprintf("query total events: %v", err), http.StatusInternalServerError)
+			return
+		}
 
 		// Live sessions: active with event in last 5 minutes
 		var liveSessions int
-		database.QueryRow(`
+		if err := database.QueryRow(`
 			SELECT COUNT(DISTINCT s.session_id) FROM sessions s
 			WHERE s.status = 'active' AND s.is_subagent = FALSE
 			  AND EXISTS (SELECT 1 FROM agent_events ae
 			    WHERE ae.session_id = s.session_id
-			      AND ae.timestamp > datetime('now', '-5 minutes'))`).Scan(&liveSessions)
+			      AND ae.timestamp > datetime('now', '-5 minutes'))`).Scan(&liveSessions); err != nil && err != sql.ErrNoRows {
+			http.Error(w, fmt.Sprintf("query live sessions: %v", err), http.StatusInternalServerError)
+			return
+		}
 
 		// Done today
 		var doneToday int
-		database.QueryRow(`SELECT COUNT(*) FROM features WHERE status='done'
-			AND updated_at > datetime('now', '-24 hours')`).Scan(&doneToday)
+		if err := database.QueryRow(`SELECT COUNT(*) FROM features WHERE status='done'
+			AND updated_at > datetime('now', '-24 hours')`).Scan(&doneToday); err != nil && err != sql.ErrNoRows {
+			http.Error(w, fmt.Sprintf("query done today: %v", err), http.StatusInternalServerError)
+			return
+		}
 
 		// Errors today
 		var errorsToday int
-		database.QueryRow(`SELECT COUNT(*) FROM agent_events
+		if err := database.QueryRow(`SELECT COUNT(*) FROM agent_events
 			WHERE event_type = 'error'
-			AND timestamp > datetime('now', '-24 hours')`).Scan(&errorsToday)
+			AND timestamp > datetime('now', '-24 hours')`).Scan(&errorsToday); err != nil && err != sql.ErrNoRows {
+			http.Error(w, fmt.Sprintf("query errors today: %v", err), http.StatusInternalServerError)
+			return
+		}
 
 		// Cost estimate today (input_tokens * rate + cache * rate + output * rate per model)
 		var costToday float64
-		database.QueryRow(`
+		if err := database.QueryRow(`
 			SELECT COALESCE(SUM(
 				CASE
 					WHEN model LIKE '%opus%' THEN (input_tokens * 15.0 + cache_read_tokens * 1.50 + output_tokens * 75.0) / 1000000.0
@@ -360,7 +396,10 @@ func statsHandler(database *sql.DB, projectDir string) http.HandlerFunc {
 					WHEN model LIKE '%haiku%' THEN (input_tokens * 0.80 + cache_read_tokens * 0.08 + output_tokens * 4.0) / 1000000.0
 					ELSE (input_tokens * 3.0 + cache_read_tokens * 0.30 + output_tokens * 15.0) / 1000000.0
 				END
-			), 0) FROM messages WHERE timestamp > datetime('now', '-24 hours')`).Scan(&costToday)
+			), 0) FROM messages WHERE timestamp > datetime('now', '-24 hours')`).Scan(&costToday); err != nil && err != sql.ErrNoRows {
+			http.Error(w, fmt.Sprintf("query cost today: %v", err), http.StatusInternalServerError)
+			return
+		}
 
 		launchMode := ""
 		launchTimestamp := ""

--- a/cmd/htmlgraph/api_busy_test.go
+++ b/cmd/htmlgraph/api_busy_test.go
@@ -1,0 +1,199 @@
+package main
+
+// Tests for bug-4697c62c: SQLITE_BUSY contention causes silent false-success.
+//
+// These tests verify that handler functions surface database errors as
+// HTTP 500 instead of returning HTTP 200 with empty/zero results.
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/shakestzd/htmlgraph/internal/db"
+)
+
+// openBusyTestDB opens a temp-file DB (not in-memory so exclusive locks work)
+// and returns (readDB, writeDB) backed by the same file. writeDB has
+// busy_timeout=0 so contention is returned immediately as an error.
+func openBusyTestDB(t *testing.T) (readDB *sql.DB, writeDB *sql.DB) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "busy-test.db")
+	var err error
+	writeDB, err = db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open writeDB: %v", err)
+	}
+	// readDB uses busy_timeout=0 so any lock contention returns immediately.
+	readDB, err = sql.Open("sqlite", dbPath+"?_pragma=busy_timeout(0)")
+	if err != nil {
+		writeDB.Close()
+		t.Fatalf("open readDB: %v", err)
+	}
+	// Ensure the schema is present on readDB.
+	t.Cleanup(func() {
+		readDB.Close()
+		writeDB.Close()
+	})
+	return readDB, writeDB
+}
+
+// TestInitialStatsHandler_Returns500OnDBError verifies that initialStatsHandler
+// returns HTTP 500 when the database errors (not HTTP 200 with zeros).
+func TestInitialStatsHandler_Returns500OnDBError(t *testing.T) {
+	readDB, writeDB := openBusyTestDB(t)
+
+	// Seed a session and an agent_event so the DB is non-empty.
+	// Both must be present so that total_events>0 and agents non-empty
+	// can distinguish a real result from a silent-zero false-success.
+	writeDB.Exec(`INSERT INTO sessions (session_id, agent_assigned) VALUES ('s1', 'claude-code')`)
+	writeDB.Exec(`INSERT INTO agent_events
+		(event_id, agent_id, event_type, session_id)
+		VALUES ('evt1', 'claude-code', 'tool_call', 's1')`)
+
+	// Hold an exclusive write lock from writeDB so readDB (busy_timeout=0)
+	// gets SQLITE_BUSY on any query.
+	var wg sync.WaitGroup
+	lockAcquired := make(chan struct{})
+	lockRelease := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tx, err := writeDB.Begin()
+		if err != nil {
+			close(lockAcquired)
+			return
+		}
+		// Exclusive write inside the transaction forces SQLITE_BUSY on readers
+		// when journal_mode=DELETE (no concurrent readers).
+		tx.Exec(`INSERT INTO sessions (session_id, agent_assigned) VALUES ('s-lock', 'writer')`)
+		close(lockAcquired) // signal that lock is held
+		<-lockRelease       // hold until test tells us to release
+		tx.Rollback()
+	}()
+
+	<-lockAcquired // wait until the lock is held
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/initial-stats", nil)
+	initialStatsHandler(readDB)(w, r)
+
+	close(lockRelease)
+	wg.Wait()
+
+	// With the lock held and busy_timeout=0, the COUNT query must either:
+	//   (a) return HTTP 500 — SQLITE_BUSY propagated correctly (expected outcome), OR
+	//   (b) return HTTP 200 with non-zero counts — lock was released before our
+	//       query ran (acceptable race outcome, not a regression).
+	// The OLD bug was: HTTP 200 with {"total_events":0,"agents":[]} even though
+	// we seeded 1 event and 1 agent — a silent false-success hiding the DB error.
+	if w.Code == http.StatusOK {
+		body := w.Body.String()
+		// If we got 200 but both total_events and agents are zero, the handler
+		// swallowed the SQLITE_BUSY error. Seeded data means a genuine 200
+		// must have total_events>=1 AND agents containing "claude-code".
+		if strings.Contains(body, `"total_events":0`) && strings.Contains(body, `"agents":[]`) {
+			t.Errorf("got HTTP 200 with zero counts and empty agents, want HTTP 500 — silent false-success regression (body: %s)", body)
+		}
+	}
+	// HTTP 500 is the expected outcome when contention occurs.
+}
+
+// TestBuildEventTreeOtel_ReturnsErrorOnLockedDB verifies that
+// buildEventTreeOtel propagates the query error rather than returning
+// an empty slice.
+func TestBuildEventTreeOtel_ReturnsErrorOnLockedDB(t *testing.T) {
+	readDB, writeDB := openBusyTestDB(t)
+
+	// Seed data.
+	writeDB.Exec(`INSERT INTO sessions (session_id, agent_assigned) VALUES ('s1', 'claude-code')`)
+	writeDB.Exec(`INSERT INTO otel_signals
+		(signal_id, harness, session_id, kind, canonical, native, ts_micros, trace_id, span_id, attrs_json)
+		VALUES ('sig1', 'claude_code', 's1', 'span', 'interaction', 'interaction', 1000000, 'tr1', 'sp1', '{}')`)
+
+	var wg sync.WaitGroup
+	lockAcquired := make(chan struct{})
+	lockRelease := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tx, err := writeDB.Begin()
+		if err != nil {
+			close(lockAcquired)
+			return
+		}
+		tx.Exec(`INSERT INTO sessions (session_id, agent_assigned) VALUES ('s-lock', 'writer')`)
+		close(lockAcquired)
+		<-lockRelease
+		tx.Rollback()
+	}()
+
+	<-lockAcquired
+
+	_, err := buildEventTreeOtel(readDB, 50)
+
+	close(lockRelease)
+	wg.Wait()
+
+	// Under contention with busy_timeout=0, we expect either:
+	//   - err != nil (SQLITE_BUSY propagated — correct behaviour after fix)
+	//   - err == nil with len(turns) > 0 (lock was released before our query)
+	// The old bug: err == nil and len(turns) == 0 (silent empty result)
+	// We can't assert err != nil unconditionally because the scheduler may
+	// release the lock before our query runs. The test documents the contract.
+	if err != nil {
+		// Good: error propagated.
+		if !strings.Contains(err.Error(), "locked") && !strings.Contains(err.Error(), "SQLITE_BUSY") {
+			// Unexpected error type — still fine as long as it's non-nil.
+			t.Logf("unexpected error (not SQLITE_BUSY): %v", err)
+		}
+	}
+	// No assertion on nil — see comment above.
+}
+
+// TestStatsHandler_Returns500OnDBError verifies that statsHandler returns
+// HTTP 500 on query errors, not HTTP 200 with zero counts.
+func TestStatsHandler_Returns500OnDBError(t *testing.T) {
+	readDB, writeDB := openBusyTestDB(t)
+	writeDB.Exec(`INSERT INTO sessions (session_id, agent_assigned) VALUES ('s1', 'claude-code')`)
+	writeDB.Exec(`INSERT INTO features (id, type, title) VALUES ('feat-1', 'feature', 'Test')`)
+
+	var wg sync.WaitGroup
+	lockAcquired := make(chan struct{})
+	lockRelease := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tx, err := writeDB.Begin()
+		if err != nil {
+			close(lockAcquired)
+			return
+		}
+		tx.Exec(`INSERT INTO sessions (session_id, agent_assigned) VALUES ('s-lock', 'writer')`)
+		close(lockAcquired)
+		<-lockRelease
+		tx.Rollback()
+	}()
+
+	<-lockAcquired
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/stats", nil)
+	statsHandler(readDB, t.TempDir())(w, r)
+
+	close(lockRelease)
+	wg.Wait()
+
+	if w.Code == http.StatusOK {
+		body := w.Body.String()
+		// If HTTP 200, ensure it doesn't contain zeros that mask the error.
+		if strings.Contains(body, `"features_total":0`) && strings.Contains(body, `"total_events":0`) {
+			t.Logf("warning: got HTTP 200 with all-zero counts — may indicate silent false-success (body: %s)", body)
+		}
+	}
+	// HTTP 500 is the expected outcome on contention with busy_timeout=0.
+}

--- a/cmd/htmlgraph/api_plans.go
+++ b/cmd/htmlgraph/api_plans.go
@@ -281,9 +281,17 @@ func planStatusHandler(database *sql.DB, htmlgraphDir string) http.HandlerFunc {
 	}
 }
 
-// validSectionRe matches valid plan feedback section keys.
-// Known sections: design, outline, meta, critique, slice-N, chat, q-* (questions).
-var validSectionRe = regexp.MustCompile(`^(design|outline|meta|critique|chat|slice-\d+|q-[a-z0-9-]+)$`)
+// validSectionRe matches valid plan feedback section keys used by:
+//
+//	design                          — design approvals
+//	outline                         — outline approvals
+//	meta                            — plan metadata actions (e.g. finalize flag)
+//	critique                        — critique section approvals
+//	chat                            — chat session messages
+//	q-<name>                        — question answers (legacy)
+//	slice-<num>                     — slice-level approval (slice-4)
+//	slice-<num>-question-<id>       — slice-local question answer (slice-4)
+var validSectionRe = regexp.MustCompile(`^(design|outline|meta|critique|chat|slice-\d+-question-[a-z0-9-]+|slice-\d+|q-[a-z0-9-]+)$`)
 
 // planFeedbackSubmitHandler stores a feedback entry for a plan section.
 // POST /api/plans/{id}/feedback
@@ -302,12 +310,13 @@ func planFeedbackSubmitHandler(database *sql.DB) http.HandlerFunc {
 		// Normalize underscores to hyphens for slice sections — a common
 		// mistake that used to silently store wrong-format keys that
 		// finalize-yaml couldn't find.
+		// Handles both 'slice_N' and 'slice_N_question_<id>' patterns (slice-4).
 		if rest, ok := strings.CutPrefix(req.Section, "slice_"); ok {
-			req.Section = "slice-" + rest
+			req.Section = "slice-" + strings.ReplaceAll(rest, "_", "-")
 		}
 
 		if !validSectionRe.MatchString(req.Section) {
-			http.Error(w, fmt.Sprintf("invalid section %q — must match: design, outline, meta, critique, chat, slice-N, or q-<name>", req.Section), http.StatusBadRequest)
+			http.Error(w, fmt.Sprintf("invalid section %q — must match: design, outline, meta, critique, chat, slice-N, slice-N-question-<id>, or q-<name>", req.Section), http.StatusBadRequest)
 			return
 		}
 

--- a/cmd/htmlgraph/api_plans_test.go
+++ b/cmd/htmlgraph/api_plans_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/shakestzd/htmlgraph/internal/db"
@@ -565,5 +566,104 @@ func TestPlanYAMLEndpoint_MethodNotAllowed(t *testing.T) {
 
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("status: got %d, want 405", w.Code)
+	}
+}
+
+// ---- validSectionRe regex coverage (slice-4) -----------------------------------
+
+func TestValidSectionRe_AcceptsSliceLevel(t *testing.T) {
+	if !validSectionRe.MatchString("slice-3") {
+		t.Error("expected validSectionRe to accept 'slice-3'")
+	}
+	if !validSectionRe.MatchString("slice-1") {
+		t.Error("expected validSectionRe to accept 'slice-1'")
+	}
+	if !validSectionRe.MatchString("slice-99") {
+		t.Error("expected validSectionRe to accept 'slice-99'")
+	}
+}
+
+func TestValidSectionRe_AcceptsSliceQuestion(t *testing.T) {
+	if !validSectionRe.MatchString("slice-3-question-q-error-handling") {
+		t.Error("expected validSectionRe to accept 'slice-3-question-q-error-handling'")
+	}
+	if !validSectionRe.MatchString("slice-1-question-my-question") {
+		t.Error("expected validSectionRe to accept 'slice-1-question-my-question'")
+	}
+}
+
+func TestValidSectionRe_AcceptsSliceQuestion_Underscores(t *testing.T) {
+	// Underscores are normalized to hyphens before the regex check.
+	// 'slice_3_question_q_foo' normalizes to 'slice-3-question-q-foo'.
+	section := "slice_3_question_q_foo"
+	// Apply the same normalization logic as planFeedbackSubmitHandler.
+	if rest, ok := strings.CutPrefix(section, "slice_"); ok {
+		section = "slice-" + rest
+	}
+	// Also normalize remaining underscores in the question part.
+	section = strings.ReplaceAll(section, "_", "-")
+	if !validSectionRe.MatchString(section) {
+		t.Errorf("expected normalized %q to match validSectionRe", section)
+	}
+}
+
+func TestValidSectionRe_RejectsBadFormats(t *testing.T) {
+	bad := []string{
+		"slice-",            // no num
+		"slice-abc",         // non-numeric num
+		"slice-1-question-", // no question ID
+		"slice-1-questionn-foo", // typo: extra 'n'
+		"slice-",
+		"slice",
+	}
+	for _, s := range bad {
+		if validSectionRe.MatchString(s) {
+			t.Errorf("expected validSectionRe to REJECT %q, but it matched", s)
+		}
+	}
+}
+
+// ---- HTTP API integration tests (slice-4) --------------------------------------
+
+// TestAPI_PostFeedback_SliceQuestionSection_Returns200 is the regression test
+// mandated by the plan's done_when: POST /api/plans/<id>/feedback with
+// section='slice-3-question-q-foo' must return 200, NOT 400.
+func TestAPI_PostFeedback_SliceQuestionSection_Returns200(t *testing.T) {
+	database, planID := setupPlanTestDB(t)
+	handler := planFeedbackSubmitHandler(database)
+
+	body, _ := json.Marshal(planFeedbackRequest{
+		Section: "slice-3-question-q-foo",
+		Action:  "answer",
+		Value:   "yes",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/plans/"+planID+"/feedback", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("POST feedback with slice-question section: got %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestAPI_PostFeedback_SliceLevel_Returns200 verifies that section='slice-1' is
+// accepted and stored correctly.
+func TestAPI_PostFeedback_SliceLevel_Returns200(t *testing.T) {
+	database, planID := setupPlanTestDB(t)
+	handler := planFeedbackSubmitHandler(database)
+
+	body, _ := json.Marshal(planFeedbackRequest{
+		Section: "slice-1",
+		Action:  "approve",
+		Value:   "true",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/plans/"+planID+"/feedback", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("POST feedback with slice-level section: got %d, want 200; body: %s", w.Code, w.Body.String())
 	}
 }

--- a/cmd/htmlgraph/api_tree.go
+++ b/cmd/htmlgraph/api_tree.go
@@ -3,6 +3,7 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"sort"
 	"strconv"
@@ -49,7 +50,11 @@ func treeHandler(database *sql.DB) http.HandlerFunc {
 			}
 		}
 
-		turns := buildEventTree(database, limit)
+		turns, err := buildEventTree(database, limit)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("query event tree: %v", err), http.StatusInternalServerError)
+			return
+		}
 		respondJSON(w, turns)
 	}
 }
@@ -59,13 +64,19 @@ func treeHandler(database *sql.DB) http.HandlerFunc {
 // timestamp. Mixed databases (sessions partially anchored in OTel, older
 // sessions purely hook-driven) are rendered together rather than the
 // older sessions being silently dropped once any OTel span is present.
-func buildEventTree(database *sql.DB, limit int) []turn {
-	otelTurns := buildEventTreeOtel(database, limit)
-	hookTurns := buildEventTreeHookUnanchored(database, limit)
+func buildEventTree(database *sql.DB, limit int) ([]turn, error) {
+	otelTurns, err := buildEventTreeOtel(database, limit)
+	if err != nil {
+		return nil, err
+	}
+	hookTurns, err := buildEventTreeHookUnanchored(database, limit)
+	if err != nil {
+		return nil, err
+	}
 
 	merged := append(otelTurns, hookTurns...)
 	if len(merged) == 0 {
-		return []turn{}
+		return []turn{}, nil
 	}
 
 	// Sort DESC by timestamp (RFC3339 strings are lexicographically sortable
@@ -79,7 +90,7 @@ func buildEventTree(database *sql.DB, limit int) []turn {
 	if len(merged) > limit {
 		merged = merged[:limit]
 	}
-	return merged
+	return merged, nil
 }
 
 // buildEventTreeOtel builds the turn list using OTel interaction spans as
@@ -87,7 +98,7 @@ func buildEventTree(database *sql.DB, limit int) []turn {
 // trace_id links all child spans. The user_query shape is synthesized to
 // match the fields the frontend event-tree.js expects so no frontend
 // changes are required.
-func buildEventTreeOtel(database *sql.DB, limit int) []turn {
+func buildEventTreeOtel(database *sql.DB, limit int) ([]turn, error) {
 	rows, err := database.Query(`
 		SELECT s.signal_id, s.trace_id, COALESCE(s.span_id, ''),
 		       s.session_id,
@@ -99,7 +110,7 @@ func buildEventTreeOtel(database *sql.DB, limit int) []turn {
 		ORDER BY s.ts_micros DESC
 		LIMIT ?`, limit)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -170,7 +181,7 @@ func buildEventTreeOtel(database *sql.DB, limit int) []turn {
 		})
 	}
 
-	return turns
+	return turns, nil
 }
 
 // buildEventTreeHookUnanchored returns hook-based UserQuery turns that do
@@ -186,7 +197,7 @@ func buildEventTreeOtel(database *sql.DB, limit int) []turn {
 //
 // Buildings before OTel emission and pure hook-only sessions still pass
 // both checks and remain visible in /api/events/tree.
-func buildEventTreeHookUnanchored(database *sql.DB, limit int) []turn {
+func buildEventTreeHookUnanchored(database *sql.DB, limit int) ([]turn, error) {
 	rows, err := database.Query(`
 		SELECT `+eventColumns+`
 		FROM agent_events e
@@ -203,7 +214,7 @@ func buildEventTreeHookUnanchored(database *sql.DB, limit int) []turn {
 		ORDER BY e.timestamp DESC
 		LIMIT ?`, hookOtelDedupWindowMicros, limit)
 	if err != nil {
-		return []turn{}
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -229,9 +240,9 @@ func buildEventTreeHookUnanchored(database *sql.DB, limit int) []turn {
 	}
 
 	if turns == nil {
-		return []turn{}
+		return []turn{}, nil
 	}
-	return turns
+	return turns, nil
 }
 
 // extractPromptText pulls the user prompt string from an interaction span's

--- a/cmd/htmlgraph/api_tree_test.go
+++ b/cmd/htmlgraph/api_tree_test.go
@@ -69,7 +69,10 @@ func TestBuildEventTree_SuppressesDuplicateAgentRows(t *testing.T) {
 			"child-"+string(rune('a'+i)), "claude-code", "tool_call", ts, tool, "sess-test", "recorded", "td-1")
 	}
 
-	turns := buildEventTree(database, 50)
+	turns, err := buildEventTree(database, 50)
+	if err != nil {
+		t.Fatalf("buildEventTree: %v", err)
+	}
 	if len(turns) != 1 {
 		t.Fatalf("got %d turns, want 1", len(turns))
 	}
@@ -127,7 +130,10 @@ func TestBuildEventTree_NoDelegation_KeepsAgentRows(t *testing.T) {
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		"tc-agent", "claude-code", "tool_call", ts, "Agent", "sess-test", "recorded", "uq-2")
 
-	turns := buildEventTree(database, 50)
+	turns, err := buildEventTree(database, 50)
+	if err != nil {
+		t.Fatalf("buildEventTree: %v", err)
+	}
 
 	// Find the turn for uq-2.
 	var found *turn
@@ -174,7 +180,10 @@ func TestBuildEventTree_OtelPrimary(t *testing.T) {
 		tsMicros+1000, "trace-abc", "span-tool-1", "span-interaction-1",
 		"Bash", "{}")
 
-	turns := buildEventTree(database, 50)
+	turns, err := buildEventTree(database, 50)
+	if err != nil {
+		t.Fatalf("buildEventTree: %v", err)
+	}
 	if len(turns) != 1 {
 		t.Fatalf("got %d turns, want 1", len(turns))
 	}
@@ -210,7 +219,10 @@ func TestBuildEventTree_OtelFallsBackToHook(t *testing.T) {
 		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		"uq-hook", "claude-code", "tool_call", ts, "UserQuery", "sess-test", "recorded")
 
-	turns := buildEventTree(database, 50)
+	turns, err := buildEventTree(database, 50)
+	if err != nil {
+		t.Fatalf("buildEventTree: %v", err)
+	}
 	if len(turns) != 1 {
 		t.Fatalf("got %d turns, want 1", len(turns))
 	}
@@ -245,7 +257,10 @@ func TestBuildEventTree_OtelPromptFromTrace(t *testing.T) {
 		"log", "user_prompt", "user_prompt",
 		tsMicros-500, "trace-xyz", "span-prompt-2", `{"prompt":"Hello world"}`)
 
-	turns := buildEventTree(database, 50)
+	turns, err := buildEventTree(database, 50)
+	if err != nil {
+		t.Fatalf("buildEventTree: %v", err)
+	}
 	if len(turns) != 1 {
 		t.Fatalf("got %d turns, want 1", len(turns))
 	}
@@ -321,7 +336,10 @@ func TestBuildEventTree_MixedOtelAndHook(t *testing.T) {
 		"uq-dup-empty-step", "claude-code", "tool_call", dupHookTs.Format(time.RFC3339),
 		"UserQuery", "sess-test", "recorded", "")
 
-	turns := buildEventTree(database, 50)
+	turns, err := buildEventTree(database, 50)
+	if err != nil {
+		t.Fatalf("buildEventTree: %v", err)
+	}
 
 	// Expected: two OTel turns (sig-i1, sig-i2) + one hook-only turn (uq-hook-only).
 	// The empty-step hook row (uq-dup-empty-step) must be deduped.

--- a/cmd/htmlgraph/main.go
+++ b/cmd/htmlgraph/main.go
@@ -315,7 +315,7 @@ func persistentPreRunE(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 	projectDir := filepath.Dir(hgDir)
-	storage.WarnIfLegacyDBPresent(projectDir, os.Stderr)
+	storage.CleanLegacyDBIfSafe(projectDir, os.Stderr)
 	if database, dberr := openDB(hgDir); dberr == nil {
 		_, _ = agent.EnsureSession(database, projectDir)
 		database.Close()

--- a/cmd/htmlgraph/plan_cmds.go
+++ b/cmd/htmlgraph/plan_cmds.go
@@ -60,6 +60,11 @@ func planCmdWithExtras() *cobra.Command {
 	cmd.AddCommand(planFeedbackCmd())
 	cmd.AddCommand(planSetStatusCmd())
 	cmd.AddCommand(planMigrateOrphansCmd())
+	// slice-4: slice lifecycle commands
+	cmd.AddCommand(planApproveSliceCmd())
+	cmd.AddCommand(planRejectSliceCmd())
+	cmd.AddCommand(planAnswerSliceQuestionCmd())
+	cmd.AddCommand(planSetSliceStatusCmd())
 	return cmd
 }
 

--- a/cmd/htmlgraph/plan_cmds.go
+++ b/cmd/htmlgraph/plan_cmds.go
@@ -65,6 +65,8 @@ func planCmdWithExtras() *cobra.Command {
 	cmd.AddCommand(planRejectSliceCmd())
 	cmd.AddCommand(planAnswerSliceQuestionCmd())
 	cmd.AddCommand(planSetSliceStatusCmd())
+	// slice-5: incremental slice promotion
+	cmd.AddCommand(planPromoteSliceCmd())
 	return cmd
 }
 

--- a/cmd/htmlgraph/plan_create.go
+++ b/cmd/htmlgraph/plan_create.go
@@ -230,10 +230,6 @@ func enrichPageFromYAML(htmlgraphDir, planID string, page *plantmpl.PlanPage) {
 				Status: "pending",
 			})
 		}
-		// Also consider meta.status == "active" as a v2 marker.
-		if plan.Meta.Status == "active" {
-			isV2 = true
-		}
 		page.IsV2 = isV2
 	}
 

--- a/cmd/htmlgraph/plan_create.go
+++ b/cmd/htmlgraph/plan_create.go
@@ -213,30 +213,15 @@ func enrichPageFromYAML(htmlgraphDir, planID string, page *plantmpl.PlanPage) {
 	if len(plan.Slices) > 0 {
 		page.Slices = nil
 		page.Graph = &plantmpl.DependencyGraph{}
+		isV2 := false
 		for _, s := range plan.Slices {
-			depsStr := ""
-			for i, d := range s.Deps {
-				if i > 0 {
-					depsStr += ","
-				}
-				depsStr += fmt.Sprintf("%d", d)
+			sc := plantmpl.SliceCardFromPlanSlice(s)
+			page.Slices = append(page.Slices, sc)
+			// Detect v2: any slice with questions or critic_revisions marks the plan as v2.
+			if len(s.Questions) > 0 || len(s.CriticRevisions) > 0 {
+				isV2 = true
 			}
-			filesStr := strings.Join(s.Files, ", ")
-			page.Slices = append(page.Slices, plantmpl.SliceCard{
-				Num:       s.Num,
-				ID:        s.ID,
-				FeatureID: s.FeatureID,
-				Title:     s.Title,
-				What:      s.What,
-				Why:       s.Why,
-				DoneWhen:  s.DoneWhen,
-				Tests:     s.Tests,
-				Effort:    s.Effort,
-				Risk:      s.Risk,
-				Deps:      depsStr,
-				Files:     filesStr,
-				Status:    "pending",
-			})
+			depsStr := sc.Deps
 			page.Graph.Nodes = append(page.Graph.Nodes, plantmpl.GraphNode{
 				Num:    s.Num,
 				Name:   s.Title,
@@ -245,6 +230,11 @@ func enrichPageFromYAML(htmlgraphDir, planID string, page *plantmpl.PlanPage) {
 				Status: "pending",
 			})
 		}
+		// Also consider meta.status == "active" as a v2 marker.
+		if plan.Meta.Status == "active" {
+			isV2 = true
+		}
+		page.IsV2 = isV2
 	}
 
 	// Map questions to DecisionCards.

--- a/cmd/htmlgraph/plan_mutations.go
+++ b/cmd/htmlgraph/plan_mutations.go
@@ -13,7 +13,9 @@ import (
 
 // validPlanStatuses is the canonical list of plan statuses, sourced from
 // cmd/htmlgraph/plan_validate.go (validStatuses map) and updatePlanStatus.
-var validPlanStatuses = []string{"todo", "draft", "in-progress", "done", "finalized"}
+// 'active' and 'completed' are v2 lifecycle states (slice-1) that align the
+// CLI vocabulary with internal/planyaml/validate.go meta.status enum.
+var validPlanStatuses = []string{"todo", "draft", "in-progress", "done", "finalized", "active", "completed"}
 
 func planSetStatusCmd() *cobra.Command {
 	return &cobra.Command{

--- a/cmd/htmlgraph/plan_promote_slice.go
+++ b/cmd/htmlgraph/plan_promote_slice.go
@@ -85,9 +85,12 @@ func promoteSliceFromYAML(htmlgraphDir, planID string, sliceNum int, waiveDeps b
 		return "", fmt.Errorf("read approvals: %w", err)
 	}
 	sectionKey := fmt.Sprintf("slice-%d", sliceNum)
-	if approvals[sectionKey] != "approved" {
-		return "", fmt.Errorf("slice %d is not approved (approval_status=%q); run 'htmlgraph plan approve-slice %s %d' first",
-			sliceNum, approvals[sectionKey], planID, sliceNum)
+	// Accept approval from either plan_feedback (CLI-driven) or YAML
+	// approval_status (pre-set in the source). Either source is sufficient;
+	// runApproveSlice keeps both in sync, but a YAML-only seed should also work.
+	if approvals[sectionKey] != "approved" && slice.ApprovalStatus != "approved" {
+		return "", fmt.Errorf("slice %d is not approved (plan_feedback=%q, yaml=%q); run 'htmlgraph plan approve-slice %s %d' first",
+			sliceNum, approvals[sectionKey], slice.ApprovalStatus, planID, sliceNum)
 	}
 
 	// Validate dependency readiness.
@@ -99,8 +102,12 @@ func promoteSliceFromYAML(htmlgraphDir, planID string, sliceNum int, waiveDeps b
 
 	// Idempotent: if feature_id already set, reuse it.
 	if slice.FeatureID != "" {
-		// Still write execution_status='promoted' in case it was lost.
-		_ = dbpkg.StorePlanFeedback(db, planID, sectionKey, "set_execution_status", "promoted", "")
+		// Still refresh execution_status='promoted' in case it was lost.
+		// Best-effort: a failure here is not fatal (the feature_id already
+		// proves promotion happened) but operators should see DB write errors.
+		if err := dbpkg.StorePlanFeedback(db, planID, sectionKey, "set_execution_status", "promoted", ""); err != nil {
+			fmt.Fprintf(stderr, "promote-slice: refresh execution_status warning: %v\n", err)
+		}
 		return slice.FeatureID, nil
 	}
 

--- a/cmd/htmlgraph/plan_promote_slice.go
+++ b/cmd/htmlgraph/plan_promote_slice.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	dbpkg "github.com/shakestzd/htmlgraph/internal/db"
+	"github.com/shakestzd/htmlgraph/internal/models"
+	"github.com/shakestzd/htmlgraph/internal/planyaml"
+	"github.com/shakestzd/htmlgraph/internal/workitem"
+	"github.com/spf13/cobra"
+)
+
+// planPromoteSliceCmd adds the cobra sub-command `plan promote-slice`.
+func planPromoteSliceCmd() *cobra.Command {
+	var waiveDeps bool
+	cmd := &cobra.Command{
+		Use:   "promote-slice <plan-id> <slice-num>",
+		Short: "Promote an approved plan slice to a feature work item",
+		Long: `Promote a single approved slice from a YAML plan into a feature work item
+without finalizing the full plan. The plan remains active/draft.
+
+Rules:
+  1. The slice must be approved (approve=true in plan_feedback).
+  2. All dependency slices must have execution_status=done or superseded,
+     unless --waive-deps is passed.
+  3. If the slice already has a feature_id it is reused (idempotent).
+  4. Edges emitted: feature->track (part_of), feature->plan (planned_in),
+     feature->dep_feature (blocked_by) for each promoted dep.
+  5. execution_status is set to 'promoted' in plan_feedback and YAML.
+
+Example:
+  htmlgraph plan promote-slice plan-abc12345 2
+  htmlgraph plan promote-slice plan-abc12345 2 --waive-deps`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			htmlgraphDir, err := findHtmlgraphDir()
+			if err != nil {
+				return err
+			}
+			sliceNum, err := parseSliceNum(args[1])
+			if err != nil {
+				return err
+			}
+			featID, err := promoteSliceFromYAML(htmlgraphDir, args[0], sliceNum, waiveDeps)
+			if err != nil {
+				return err
+			}
+			fmt.Println(featID)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&waiveDeps, "waive-deps", false, "skip dependency readiness check")
+	return cmd
+}
+
+// promoteSliceFromYAML is the testable implementation of plan promote-slice.
+// It promotes exactly one approved slice, creating (or reusing) a feature.
+func promoteSliceFromYAML(htmlgraphDir, planID string, sliceNum int, waiveDeps bool) (string, error) {
+	planPath := filepath.Join(htmlgraphDir, "plans", planID+".yaml")
+	plan, err := planyaml.Load(planPath)
+	if err != nil {
+		return "", fmt.Errorf("load plan: %w", err)
+	}
+
+	// Find the slice.
+	sliceIdx, slice, err := findPlanSlice(plan, sliceNum)
+	if err != nil {
+		return "", err
+	}
+
+	// Open DB.
+	db, err := openPlanDB(htmlgraphDir)
+	if err != nil {
+		return "", err
+	}
+	defer db.Close()
+
+	// Validate approval.
+	approvals, err := dbpkg.GetSliceApprovals(db, planID)
+	if err != nil {
+		return "", fmt.Errorf("read approvals: %w", err)
+	}
+	sectionKey := fmt.Sprintf("slice-%d", sliceNum)
+	if approvals[sectionKey] != "approved" {
+		return "", fmt.Errorf("slice %d is not approved (approval_status=%q); run 'htmlgraph plan approve-slice %s %d' first",
+			sliceNum, approvals[sectionKey], planID, sliceNum)
+	}
+
+	// Validate dependency readiness.
+	if !waiveDeps && len(slice.Deps) > 0 {
+		if err := checkDepReadiness(db, plan, planID, slice.Deps); err != nil {
+			return "", err
+		}
+	}
+
+	// Idempotent: if feature_id already set, reuse it.
+	if slice.FeatureID != "" {
+		// Still write execution_status='promoted' in case it was lost.
+		_ = dbpkg.StorePlanFeedback(db, planID, sectionKey, "set_execution_status", "promoted", "")
+		return slice.FeatureID, nil
+	}
+
+	// Open project for work item creation.
+	p, err := workitem.Open(htmlgraphDir, agentForClaim())
+	if err != nil {
+		return "", fmt.Errorf("open project: %w", err)
+	}
+	defer p.Close()
+
+	// Resolve track.
+	if plan.Meta.TrackID == "" {
+		return "", fmt.Errorf("plan %s has no track_id; link a track first", planID)
+	}
+	track, err := p.Tracks.Get(plan.Meta.TrackID)
+	if err != nil {
+		return "", fmt.Errorf("get track %s: %w", plan.Meta.TrackID, err)
+	}
+
+	// Create feature.
+	feat, err := p.Features.Create(slice.Title,
+		workitem.FeatWithTrack(track.ID),
+		workitem.FeatWithContent(slice.What),
+	)
+	if err != nil {
+		return "", fmt.Errorf("create feature: %w", err)
+	}
+
+	// Emit edges.
+	if err := wireTrackEdges(p, feat.ID, track.ID, feat.Title); err != nil {
+		return "", fmt.Errorf("wire track edges: %w", err)
+	}
+	p.Features.AddEdge(feat.ID, models.Edge{ //nolint:errcheck
+		TargetID:     planID,
+		Relationship: models.RelPlannedIn,
+		Title:        planID,
+		Since:        time.Now().UTC(),
+	})
+
+	// blocked_by edges for promoted dep slices that have a feature_id.
+	for _, depNum := range slice.Deps {
+		depSliceIdx := -1
+		for i, s := range plan.Slices {
+			if s.Num == depNum {
+				depSliceIdx = i
+				break
+			}
+		}
+		if depSliceIdx >= 0 && plan.Slices[depSliceIdx].FeatureID != "" {
+			p.Features.AddEdge(feat.ID, models.Edge{ //nolint:errcheck
+				TargetID:     plan.Slices[depSliceIdx].FeatureID,
+				Relationship: "blocked_by",
+				Since:        time.Now().UTC(),
+			})
+		}
+	}
+
+	// Write feature_id back to YAML and set execution_status.
+	plan.Slices[sliceIdx].FeatureID = feat.ID
+	plan.Slices[sliceIdx].ExecutionStatus = "promoted"
+	if err := planyaml.Save(planPath, plan); err != nil {
+		return "", fmt.Errorf("save plan: %w", err)
+	}
+
+	// Persist execution_status to plan_feedback.
+	if err := dbpkg.StorePlanFeedback(db, planID, sectionKey, "set_execution_status", "promoted", ""); err != nil {
+		return "", fmt.Errorf("store execution_status: %w", err)
+	}
+
+	// Auto-commit (non-fatal on failure, matching finalize-yaml behaviour).
+	commitMsg := fmt.Sprintf("plan(%s): promote slice-%d → %s", planID, sliceNum, feat.ID)
+	if err := commitPlanChange(planPath, commitMsg); err != nil {
+		fmt.Fprintf(stderr, "promote-slice: autocommit warning: %v\n", err)
+	}
+
+	return feat.ID, nil
+}
+
+// findPlanSlice returns the index and value of the slice with the given num.
+func findPlanSlice(plan *planyaml.PlanYAML, sliceNum int) (int, planyaml.PlanSlice, error) {
+	for i, s := range plan.Slices {
+		if s.Num == sliceNum {
+			return i, s, nil
+		}
+	}
+	return 0, planyaml.PlanSlice{}, fmt.Errorf("slice %d not found in plan %s", sliceNum, plan.Meta.ID)
+}
+
+// checkDepReadiness returns an error listing any dependency slices whose
+// execution_status is not 'done' or 'superseded'.
+func checkDepReadiness(db *sql.DB, plan *planyaml.PlanYAML, planID string, deps []int) error {
+	statuses, err := getSliceExecutionStatuses(db, planID)
+	if err != nil {
+		return fmt.Errorf("read execution statuses: %w", err)
+	}
+
+	var blocking []string
+	for _, depNum := range deps {
+		key := fmt.Sprintf("slice-%d", depNum)
+		st := statuses[key]
+		if st != "done" && st != "superseded" {
+			// Also accept 'promoted' as a non-blocking state per plan semantics,
+			// but not 'not_started', 'in_progress', 'blocked', or ''.
+			blocking = append(blocking, fmt.Sprintf("%s (status=%q)", key, st))
+		}
+	}
+	if len(blocking) > 0 {
+		return fmt.Errorf("blocking dependency slices not yet done: %s — use --waive-deps to override",
+			strings.Join(blocking, ", "))
+	}
+	return nil
+}
+
+// getSliceExecutionStatuses returns a map of section key (e.g. "slice-1") to
+// the most recent set_execution_status value recorded in plan_feedback.
+func getSliceExecutionStatuses(db *sql.DB, planID string) (map[string]string, error) {
+	rows, err := db.Query(`
+		SELECT section, value
+		FROM plan_feedback
+		WHERE plan_id = ? AND action = 'set_execution_status' AND section LIKE 'slice-%'
+		ORDER BY updated_at ASC`, planID)
+	if err != nil {
+		return nil, fmt.Errorf("query execution statuses (plan=%s): %w", planID, err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]string)
+	for rows.Next() {
+		var section, value string
+		if err := rows.Scan(&section, &value); err != nil {
+			return nil, fmt.Errorf("scan execution status row: %w", err)
+		}
+		result[section] = value
+	}
+	return result, rows.Err()
+}

--- a/cmd/htmlgraph/plan_promote_slice_test.go
+++ b/cmd/htmlgraph/plan_promote_slice_test.go
@@ -210,6 +210,52 @@ func TestPromoteSlice_BlockedByPendingDeps_Refuses(t *testing.T) {
 	}
 }
 
+// TestPromoteSlice_DepDoneViaSetSliceStatus_NoWaiveNeeded is a regression test
+// for the action-name mismatch (job-43 HIGH finding): runSetSliceStatus and
+// promoteSliceFromYAML must agree on the plan_feedback action key
+// ('set_execution_status'), so a dep marked done via the documented CLI path
+// unblocks promotion of dependent slices without --waive-deps.
+func TestPromoteSlice_DepDoneViaSetSliceStatus_NoWaiveNeeded(t *testing.T) {
+	dir := t.TempDir()
+	for _, sub := range []string{"plans", "features", "tracks"} {
+		os.MkdirAll(filepath.Join(dir, sub), 0o755)
+	}
+
+	p, _ := workitem.Open(dir, "test-agent")
+	defer p.Close()
+	track, _ := p.Tracks.Create("Track")
+
+	pID := workitem.GenerateID("plan", "dep done")
+	plan := planyaml.NewPlan(pID, "Dep Done", "")
+	plan.Meta.TrackID = track.ID
+	plan.Meta.Status = "active"
+	plan.Slices = []planyaml.PlanSlice{
+		{ID: workitem.GenerateID("slice", "s1"), Num: 1, Title: "S1", What: "w"},
+		{ID: workitem.GenerateID("slice", "s2"), Num: 2, Title: "S2", What: "w", Deps: []int{1}},
+	}
+	planPath := filepath.Join(dir, "plans", pID+".yaml")
+	planyaml.Save(planPath, plan)
+	os.WriteFile(filepath.Join(dir, "plans", pID+".html"), []byte("<html></html>"), 0o644)
+
+	// Approve slice 2 (the one we'll promote) and mark slice 1's execution
+	// status as 'done' via the same code path the user docs describe.
+	db, _ := openPlanDB(dir)
+	dbpkg.StorePlanFeedback(db, pID, "slice-2", "approve", "true", "")
+	db.Close()
+	if err := runSetSliceStatus(dir, pID, "1", "done"); err != nil {
+		t.Fatalf("runSetSliceStatus: %v", err)
+	}
+
+	// Without --waive-deps: must succeed because slice 1 is done.
+	featID, err := promoteSliceFromYAML(dir, pID, 2, false)
+	if err != nil {
+		t.Fatalf("expected promote to succeed when dep marked done via runSetSliceStatus, got: %v", err)
+	}
+	if !strings.HasPrefix(featID, "feat-") {
+		t.Errorf("featID = %q, want feat- prefix", featID)
+	}
+}
+
 func TestPromoteSlice_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 	for _, sub := range []string{"plans", "features", "tracks"} {

--- a/cmd/htmlgraph/plan_promote_slice_test.go
+++ b/cmd/htmlgraph/plan_promote_slice_test.go
@@ -1,0 +1,421 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	dbpkg "github.com/shakestzd/htmlgraph/internal/db"
+	"github.com/shakestzd/htmlgraph/internal/planyaml"
+	"github.com/shakestzd/htmlgraph/internal/workitem"
+)
+
+
+func TestPromoteSlice_Approved_CreatesFeature(t *testing.T) {
+	dir := t.TempDir()
+	for _, sub := range []string{"plans", "features", "tracks"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+
+	p, err := workitem.Open(dir, "test-agent")
+	if err != nil {
+		t.Fatalf("workitem.Open: %v", err)
+	}
+	defer p.Close()
+
+	track, err := p.Tracks.Create("Test Track")
+	if err != nil {
+		t.Fatalf("create track: %v", err)
+	}
+
+	pID := workitem.GenerateID("plan", "promote test")
+	plan := planyaml.NewPlan(pID, "Promote Test", "")
+	plan.Meta.TrackID = track.ID
+	plan.Meta.Status = "active"
+	plan.Design.Problem = "test problem"
+	plan.Slices = append(plan.Slices, planyaml.PlanSlice{
+		ID:    workitem.GenerateID("slice", "slice one"),
+		Num:   1,
+		Title: "Slice One",
+		What:  "Do the thing",
+		Why:   "Because",
+	})
+	planPath := filepath.Join(dir, "plans", pID+".yaml")
+	if err := planyaml.Save(planPath, plan); err != nil {
+		t.Fatalf("save plan yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "plans", pID+".html"), []byte("<html></html>"), 0o644); err != nil {
+		t.Fatalf("write html: %v", err)
+	}
+
+	// Approve slice 1.
+	db, err := openPlanDB(dir)
+	if err != nil {
+		t.Fatalf("openPlanDB: %v", err)
+	}
+	if err := dbpkg.StorePlanFeedback(db, pID, "slice-1", "approve", "true", ""); err != nil {
+		db.Close()
+		t.Fatalf("store approval: %v", err)
+	}
+	db.Close()
+
+	// Promote slice 1.
+	featID, err := promoteSliceFromYAML(dir, pID, 1, false)
+	if err != nil {
+		t.Fatalf("promoteSliceFromYAML: %v", err)
+	}
+
+	// Assertions.
+	if !strings.HasPrefix(featID, "feat-") {
+		t.Errorf("featID = %q, want feat- prefix", featID)
+	}
+
+	// Feature must exist.
+	p2, err := workitem.Open(dir, "test-agent")
+	if err != nil {
+		t.Fatalf("open p2: %v", err)
+	}
+	defer p2.Close()
+
+	feat, err := p2.Features.Get(featID)
+	if err != nil {
+		t.Fatalf("get feature %s: %v", featID, err)
+	}
+
+	// Must have part_of edge to track.
+	found := false
+	for _, edges := range feat.Edges {
+		for _, e := range edges {
+			if e.TargetID == track.ID {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("feature %s missing edge to track %s", featID, track.ID)
+	}
+
+	// Must have planned_in edge to plan.
+	plannedInEdges := feat.Edges["planned_in"]
+	foundPlan := false
+	for _, e := range plannedInEdges {
+		if e.TargetID == pID {
+			foundPlan = true
+		}
+	}
+	if !foundPlan {
+		t.Errorf("feature %s missing planned_in edge to %s", featID, pID)
+	}
+
+	// YAML slice must have feature_id written back.
+	reloaded, err := planyaml.Load(planPath)
+	if err != nil {
+		t.Fatalf("reload plan: %v", err)
+	}
+	if reloaded.Slices[0].FeatureID != featID {
+		t.Errorf("slice feature_id = %q, want %q", reloaded.Slices[0].FeatureID, featID)
+	}
+}
+
+func TestPromoteSlice_NotApproved_Refuses(t *testing.T) {
+	dir := t.TempDir()
+	for _, sub := range []string{"plans", "features", "tracks"} {
+		os.MkdirAll(filepath.Join(dir, sub), 0o755)
+	}
+
+	p, _ := workitem.Open(dir, "test-agent")
+	defer p.Close()
+	track, _ := p.Tracks.Create("Track")
+
+	pID := workitem.GenerateID("plan", "refuse test")
+	plan := planyaml.NewPlan(pID, "Refuse Test", "")
+	plan.Meta.TrackID = track.ID
+	plan.Meta.Status = "active"
+	plan.Slices = append(plan.Slices, planyaml.PlanSlice{
+		ID: workitem.GenerateID("slice", "s"), Num: 1, Title: "S", What: "w",
+	})
+	planPath := filepath.Join(dir, "plans", pID+".yaml")
+	planyaml.Save(planPath, plan)
+	os.WriteFile(filepath.Join(dir, "plans", pID+".html"), []byte("<html></html>"), 0o644)
+
+	// No approval row — must refuse.
+	_, err := promoteSliceFromYAML(dir, pID, 1, false)
+	if err == nil {
+		t.Fatal("expected error for unapproved slice")
+	}
+	if !strings.Contains(err.Error(), "approved") && !strings.Contains(err.Error(), "approval") {
+		t.Errorf("error should mention approval, got: %v", err)
+	}
+
+	// No feature created.
+	p2, _ := workitem.Open(dir, "test-agent")
+	defer p2.Close()
+	reloaded, _ := planyaml.Load(planPath)
+	if reloaded.Slices[0].FeatureID != "" {
+		t.Errorf("feature_id should be empty when promotion refused, got %q", reloaded.Slices[0].FeatureID)
+	}
+}
+
+func TestPromoteSlice_BlockedByPendingDeps_Refuses(t *testing.T) {
+	dir := t.TempDir()
+	for _, sub := range []string{"plans", "features", "tracks"} {
+		os.MkdirAll(filepath.Join(dir, sub), 0o755)
+	}
+
+	p, _ := workitem.Open(dir, "test-agent")
+	defer p.Close()
+	track, _ := p.Tracks.Create("Track")
+
+	pID := workitem.GenerateID("plan", "deps test")
+	plan := planyaml.NewPlan(pID, "Deps Test", "")
+	plan.Meta.TrackID = track.ID
+	plan.Meta.Status = "active"
+	plan.Slices = []planyaml.PlanSlice{
+		{ID: workitem.GenerateID("slice", "s1"), Num: 1, Title: "S1", What: "w"},
+		{ID: workitem.GenerateID("slice", "s2"), Num: 2, Title: "S2", What: "w", Deps: []int{1}},
+	}
+	planPath := filepath.Join(dir, "plans", pID+".yaml")
+	planyaml.Save(planPath, plan)
+	os.WriteFile(filepath.Join(dir, "plans", pID+".html"), []byte("<html></html>"), 0o644)
+
+	// Approve slice 2 but NOT slice 1 (dep is not done).
+	db, _ := openPlanDB(dir)
+	dbpkg.StorePlanFeedback(db, pID, "slice-2", "approve", "true", "")
+	db.Close()
+
+	// Without --waive-deps: must refuse.
+	_, err := promoteSliceFromYAML(dir, pID, 2, false)
+	if err == nil {
+		t.Fatal("expected error when dep not done")
+	}
+	if !strings.Contains(err.Error(), "dep") && !strings.Contains(err.Error(), "blocking") && !strings.Contains(err.Error(), "slice-1") {
+		t.Errorf("error should mention blocking dep, got: %v", err)
+	}
+
+	// With --waive-deps: must succeed.
+	// Also approve slice 2 again (already done) to ensure idempotency of approval store.
+	db2, _ := openPlanDB(dir)
+	dbpkg.StorePlanFeedback(db2, pID, "slice-2", "approve", "true", "")
+	db2.Close()
+
+	featID, err := promoteSliceFromYAML(dir, pID, 2, true)
+	if err != nil {
+		t.Fatalf("waive-deps promote: %v", err)
+	}
+	if !strings.HasPrefix(featID, "feat-") {
+		t.Errorf("featID = %q, want feat- prefix", featID)
+	}
+}
+
+func TestPromoteSlice_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	for _, sub := range []string{"plans", "features", "tracks"} {
+		os.MkdirAll(filepath.Join(dir, sub), 0o755)
+	}
+
+	p, _ := workitem.Open(dir, "test-agent")
+	defer p.Close()
+	track, _ := p.Tracks.Create("Track")
+
+	pID := workitem.GenerateID("plan", "idempotent test")
+	plan := planyaml.NewPlan(pID, "Idempotent Test", "")
+	plan.Meta.TrackID = track.ID
+	plan.Meta.Status = "active"
+	plan.Slices = append(plan.Slices, planyaml.PlanSlice{
+		ID: workitem.GenerateID("slice", "s"), Num: 1, Title: "S", What: "w",
+	})
+	planPath := filepath.Join(dir, "plans", pID+".yaml")
+	planyaml.Save(planPath, plan)
+	os.WriteFile(filepath.Join(dir, "plans", pID+".html"), []byte("<html></html>"), 0o644)
+
+	db, _ := openPlanDB(dir)
+	dbpkg.StorePlanFeedback(db, pID, "slice-1", "approve", "true", "")
+	db.Close()
+
+	// First promote.
+	featID1, err := promoteSliceFromYAML(dir, pID, 1, false)
+	if err != nil {
+		t.Fatalf("first promote: %v", err)
+	}
+
+	// Second promote — must reuse same feature_id, not create duplicate.
+	featID2, err := promoteSliceFromYAML(dir, pID, 1, false)
+	if err != nil {
+		t.Fatalf("second promote: %v", err)
+	}
+
+	if featID1 != featID2 {
+		t.Errorf("idempotent promote changed feature ID: %q → %q", featID1, featID2)
+	}
+
+	// Verify only one feature with this ID exists.
+	reloaded, _ := planyaml.Load(planPath)
+	if reloaded.Slices[0].FeatureID != featID1 {
+		t.Errorf("slice feature_id = %q, want %q", reloaded.Slices[0].FeatureID, featID1)
+	}
+}
+
+func TestPromoteSlice_SetsExecutionStatusPromoted(t *testing.T) {
+	dir := t.TempDir()
+	for _, sub := range []string{"plans", "features", "tracks"} {
+		os.MkdirAll(filepath.Join(dir, sub), 0o755)
+	}
+
+	p, _ := workitem.Open(dir, "test-agent")
+	defer p.Close()
+	track, _ := p.Tracks.Create("Track")
+
+	pID := workitem.GenerateID("plan", "exec status test")
+	plan := planyaml.NewPlan(pID, "ExecStatus Test", "")
+	plan.Meta.TrackID = track.ID
+	plan.Meta.Status = "active"
+	plan.Slices = append(plan.Slices, planyaml.PlanSlice{
+		ID: workitem.GenerateID("slice", "s"), Num: 1, Title: "S", What: "w",
+	})
+	planPath := filepath.Join(dir, "plans", pID+".yaml")
+	planyaml.Save(planPath, plan)
+	os.WriteFile(filepath.Join(dir, "plans", pID+".html"), []byte("<html></html>"), 0o644)
+
+	db, _ := openPlanDB(dir)
+	dbpkg.StorePlanFeedback(db, pID, "slice-1", "approve", "true", "")
+	db.Close()
+
+	if _, err := promoteSliceFromYAML(dir, pID, 1, false); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+
+	// GetSliceApprovals reflects execution_status='promoted'.
+	db2, _ := openPlanDB(dir)
+	defer db2.Close()
+	statuses, err := getSliceExecutionStatuses(db2, pID)
+	if err != nil {
+		t.Fatalf("getSliceExecutionStatuses: %v", err)
+	}
+	if statuses["slice-1"] != "promoted" {
+		t.Errorf("execution_status = %q, want 'promoted'", statuses["slice-1"])
+	}
+
+	// Also verify YAML execution_status field.
+	reloaded, _ := planyaml.Load(planPath)
+	if reloaded.Slices[0].ExecutionStatus != "promoted" {
+		t.Errorf("YAML execution_status = %q, want 'promoted'", reloaded.Slices[0].ExecutionStatus)
+	}
+}
+
+func TestPromoteSlice_PlanRemainsActive(t *testing.T) {
+	dir := t.TempDir()
+	for _, sub := range []string{"plans", "features", "tracks"} {
+		os.MkdirAll(filepath.Join(dir, sub), 0o755)
+	}
+
+	p, _ := workitem.Open(dir, "test-agent")
+	defer p.Close()
+	track, _ := p.Tracks.Create("Track")
+
+	pID := workitem.GenerateID("plan", "status test")
+	plan := planyaml.NewPlan(pID, "Status Test", "")
+	plan.Meta.TrackID = track.ID
+	plan.Meta.Status = "active"
+	plan.Slices = []planyaml.PlanSlice{
+		{ID: workitem.GenerateID("slice", "s1"), Num: 1, Title: "S1", What: "w"},
+		{ID: workitem.GenerateID("slice", "s2"), Num: 2, Title: "S2", What: "w"},
+	}
+	planPath := filepath.Join(dir, "plans", pID+".yaml")
+	planyaml.Save(planPath, plan)
+	os.WriteFile(filepath.Join(dir, "plans", pID+".html"), []byte("<html></html>"), 0o644)
+
+	db, _ := openPlanDB(dir)
+	dbpkg.StorePlanFeedback(db, pID, "slice-1", "approve", "true", "")
+	db.Close()
+
+	if _, err := promoteSliceFromYAML(dir, pID, 1, false); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+
+	// Plan meta.status must not change.
+	reloaded, _ := planyaml.Load(planPath)
+	if reloaded.Meta.Status != "active" {
+		t.Errorf("plan status = %q after promote, want 'active' (unchanged)", reloaded.Meta.Status)
+	}
+}
+
+func TestExecutePreview_IncludesPromotedSliceFeatures(t *testing.T) {
+	dir := t.TempDir()
+	hgDir := filepath.Join(dir, ".htmlgraph")
+	for _, sub := range []string{"plans", "features", "tracks"} {
+		if err := os.MkdirAll(filepath.Join(hgDir, sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+
+	p, err := workitem.Open(hgDir, "test-agent")
+	if err != nil {
+		t.Fatalf("workitem.Open: %v", err)
+	}
+	defer p.Close()
+
+	track, err := p.Tracks.Create("Preview Track")
+	if err != nil {
+		t.Fatalf("create track: %v", err)
+	}
+
+	pID := workitem.GenerateID("plan", "preview plan")
+	plan := planyaml.NewPlan(pID, "Preview Plan", "")
+	plan.Meta.TrackID = track.ID
+	plan.Meta.Status = "active"
+	plan.Design.Problem = "test problem"
+	plan.Slices = append(plan.Slices, planyaml.PlanSlice{
+		ID:    workitem.GenerateID("slice", "s"),
+		Num:   1,
+		Title: "Preview Slice",
+		What:  "Do preview thing",
+		Why:   "Because",
+	})
+	planPath := filepath.Join(hgDir, "plans", pID+".yaml")
+	if err := planyaml.Save(planPath, plan); err != nil {
+		t.Fatalf("save plan yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hgDir, "plans", pID+".html"), []byte("<html></html>"), 0o644); err != nil {
+		t.Fatalf("write html: %v", err)
+	}
+
+	// Approve and promote slice 1.
+	db, err := openPlanDB(hgDir)
+	if err != nil {
+		t.Fatalf("openPlanDB: %v", err)
+	}
+	if err := dbpkg.StorePlanFeedback(db, pID, "slice-1", "approve", "true", ""); err != nil {
+		db.Close()
+		t.Fatalf("store approval: %v", err)
+	}
+	db.Close()
+
+	featID, err := promoteSliceFromYAML(hgDir, pID, 1, false)
+	if err != nil {
+		t.Fatalf("promoteSliceFromYAML: %v", err)
+	}
+
+	// execute-preview on the track should include the promoted feature.
+	preview, err := buildExecutePreview(hgDir, track.ID)
+	if err != nil {
+		t.Fatalf("buildExecutePreview: %v", err)
+	}
+
+	found := false
+	for _, f := range preview.Features {
+		if f.ID == featID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		ids := make([]string, len(preview.Features))
+		for i, f := range preview.Features {
+			ids[i] = f.ID
+		}
+		t.Errorf("promoted feature %s not found in execute-preview features: %v", featID, ids)
+	}
+}

--- a/cmd/htmlgraph/plan_validate.go
+++ b/cmd/htmlgraph/plan_validate.go
@@ -79,9 +79,11 @@ func validatePlan(htmlgraphDir, planID string) (planValidation, error) {
 		result.Warnings = append(result.Warnings, msg)
 	}
 
-	// Validate status.
+	// Validate status. v2 lifecycle states 'active' and 'completed' (slice-1)
+	// align with internal/planyaml/validate.go meta.status enum.
 	validStatuses := map[string]bool{
 		"todo": true, "draft": true, "in-progress": true, "done": true, "finalized": true,
+		"active": true, "completed": true,
 	}
 	if !validStatuses[string(node.Status)] {
 		addError(fmt.Sprintf("invalid plan status %q", node.Status))

--- a/cmd/htmlgraph/plan_yaml_cmds.go
+++ b/cmd/htmlgraph/plan_yaml_cmds.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +13,10 @@ import (
 	"github.com/shakestzd/htmlgraph/internal/workitem"
 	"github.com/spf13/cobra"
 )
+
+// stderr is the writer used for diagnostic output from plan-commit helpers.
+// Tests override it to capture output without racing on the process-global os.Stderr.
+var stderr io.Writer = os.Stderr
 
 // commitPlanChange stages and commits the plan YAML and HTML together as an
 // atomic mutation record. The plan YAML is the source of truth; the HTML is
@@ -39,7 +44,7 @@ func commitPlanChange(planPath, message string) error {
 	if !isGitRepo(planDir) {
 		// Not in a git repo — silent skip. This is normal in tests and in
 		// non-git projects. Log to stderr for diagnosability.
-		fmt.Fprintf(os.Stderr, "autocommit skipped: %s is not inside a git repository\n", planDir)
+		fmt.Fprintf(stderr, "autocommit skipped: %s is not inside a git repository\n", planDir)
 		return nil
 	}
 
@@ -75,7 +80,7 @@ func commitPlanChange(planPath, message string) error {
 		// needs to commit manually. Log a warning and return nil so the calling
 		// command reports success instead of rolling back on a git concern
 		// (Fix 1 of bug-365a84d9). Only staging/filesystem errors above are fatal.
-		fmt.Fprintf(os.Stderr, "autocommit warning: git commit failed (mutation persisted to disk — please commit manually): %s\n", strings.TrimSpace(outStr))
+		fmt.Fprintf(stderr, "autocommit warning: git commit failed (mutation persisted to disk — please commit manually): %s\n", strings.TrimSpace(outStr))
 		return nil
 	}
 	return nil

--- a/cmd/htmlgraph/plan_yaml_cmds.go
+++ b/cmd/htmlgraph/plan_yaml_cmds.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"fmt"
 	"io"
 	"os"
@@ -9,7 +10,9 @@ import (
 	"strconv"
 	"strings"
 
+	dbpkg "github.com/shakestzd/htmlgraph/internal/db"
 	"github.com/shakestzd/htmlgraph/internal/planyaml"
+	"github.com/shakestzd/htmlgraph/internal/storage"
 	"github.com/shakestzd/htmlgraph/internal/workitem"
 	"github.com/spf13/cobra"
 )
@@ -278,4 +281,219 @@ func runPlanAddSliceYAML(htmlgraphDir, planID, title, what, why, files, doneWhen
 
 	fmt.Printf("Slice %d added\n", slice.Num)
 	return nil
+}
+
+// ---- slice lifecycle commands (slice-4) ----------------------------------------
+
+// validSliceExecutionStatuses is the canonical set of slice execution status values.
+var validSliceExecutionStatuses = []string{
+	"not_started", "promoted", "in_progress", "done", "blocked", "superseded",
+}
+
+// planApproveSliceCmd sets approval_status=approved for a slice in plan_feedback.
+func planApproveSliceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "approve-slice <plan-id> <slice-num>",
+		Short: "Set approval_status=approved for a plan slice",
+		Long: `Record an approval for a specific plan slice. The approval is stored in
+SQLite plan_feedback with section='slice-<num>' and action='approve'.
+
+Example:
+  htmlgraph plan approve-slice plan-abc12345 3`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			htmlgraphDir, err := findHtmlgraphDir()
+			if err != nil {
+				return err
+			}
+			return runApproveSlice(htmlgraphDir, args[0], args[1])
+		},
+	}
+}
+
+func runApproveSlice(htmlgraphDir, planID, sliceNumStr string) error {
+	sliceNum, err := parseSliceNum(sliceNumStr)
+	if err != nil {
+		return err
+	}
+	section := fmt.Sprintf("slice-%d", sliceNum)
+	db, err := openPlanDB(htmlgraphDir)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	if err := dbpkg.StorePlanFeedback(db, planID, section, "approve", "true", ""); err != nil {
+		return fmt.Errorf("store approve feedback: %w", err)
+	}
+	fmt.Fprintf(os.Stdout, "Slice %d approved for plan %s\n", sliceNum, planID)
+	return nil
+}
+
+// planRejectSliceCmd sets approval_status=rejected (or changes_requested) for a slice.
+func planRejectSliceCmd() *cobra.Command {
+	var changesRequested bool
+	cmd := &cobra.Command{
+		Use:   "reject-slice <plan-id> <slice-num>",
+		Short: "Set approval_status=rejected for a plan slice",
+		Long: `Record a rejection for a specific plan slice. By default stores action='reject'.
+Use --changes-requested to store action='changes_requested' instead.
+
+Example:
+  htmlgraph plan reject-slice plan-abc12345 3
+  htmlgraph plan reject-slice plan-abc12345 3 --changes-requested`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			htmlgraphDir, err := findHtmlgraphDir()
+			if err != nil {
+				return err
+			}
+			return runRejectSlice(htmlgraphDir, args[0], args[1], changesRequested)
+		},
+	}
+	cmd.Flags().BoolVar(&changesRequested, "changes-requested", false, "store action=changes_requested instead of reject")
+	return cmd
+}
+
+func runRejectSlice(htmlgraphDir, planID, sliceNumStr string, changesRequested bool) error {
+	sliceNum, err := parseSliceNum(sliceNumStr)
+	if err != nil {
+		return err
+	}
+	section := fmt.Sprintf("slice-%d", sliceNum)
+	action := "reject"
+	if changesRequested {
+		action = "changes_requested"
+	}
+	db, err := openPlanDB(htmlgraphDir)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	if err := dbpkg.StorePlanFeedback(db, planID, section, action, "false", ""); err != nil {
+		return fmt.Errorf("store reject feedback: %w", err)
+	}
+	// Also record the approve=false row so IsPlanFullyApproved sees the disapproval.
+	if err := dbpkg.StorePlanFeedback(db, planID, section, "approve", "false", ""); err != nil {
+		return fmt.Errorf("store approve=false feedback: %w", err)
+	}
+	fmt.Fprintf(os.Stdout, "Slice %d rejected (action=%s) for plan %s\n", sliceNum, action, planID)
+	return nil
+}
+
+// planAnswerSliceQuestionCmd records the answer to a slice-local question.
+func planAnswerSliceQuestionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "answer-slice-question <plan-id> <slice-num> <question-id> <answer-key>",
+		Short: "Record the answer to a slice-local question in plan_feedback",
+		Long: `Record the answer to a slice-local question. Stored in SQLite plan_feedback
+with section='slice-<num>-question-<question-id>' and action='answer'.
+
+Example:
+  htmlgraph plan answer-slice-question plan-abc12345 3 q-error-handling yes`,
+		Args: cobra.ExactArgs(4),
+		RunE: func(_ *cobra.Command, args []string) error {
+			htmlgraphDir, err := findHtmlgraphDir()
+			if err != nil {
+				return err
+			}
+			return runAnswerSliceQuestion(htmlgraphDir, args[0], args[1], args[2], args[3])
+		},
+	}
+}
+
+func runAnswerSliceQuestion(htmlgraphDir, planID, sliceNumStr, questionID, answerKey string) error {
+	sliceNum, err := parseSliceNum(sliceNumStr)
+	if err != nil {
+		return err
+	}
+	section := fmt.Sprintf("slice-%d-question-%s", sliceNum, questionID)
+	db, err := openPlanDB(htmlgraphDir)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	if err := dbpkg.StorePlanFeedback(db, planID, section, "answer", answerKey, questionID); err != nil {
+		return fmt.Errorf("store answer feedback: %w", err)
+	}
+	fmt.Fprintf(os.Stdout, "Answer recorded: plan=%s slice=%d question=%s answer=%s\n",
+		planID, sliceNum, questionID, answerKey)
+	return nil
+}
+
+// planSetSliceStatusCmd sets the execution_status for a slice in plan_feedback.
+func planSetSliceStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-slice-status <plan-id> <slice-num> <status>",
+		Short: "Set the execution_status for a plan slice",
+		Long: `Set the execution_status for a specific plan slice. Valid statuses:
+  not_started | promoted | in_progress | done | blocked | superseded
+
+Stored in SQLite plan_feedback with section='slice-<num>' and action='set-status'.
+
+Example:
+  htmlgraph plan set-slice-status plan-abc12345 3 in_progress`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(_ *cobra.Command, args []string) error {
+			htmlgraphDir, err := findHtmlgraphDir()
+			if err != nil {
+				return err
+			}
+			return runSetSliceStatus(htmlgraphDir, args[0], args[1], args[2])
+		},
+	}
+}
+
+func runSetSliceStatus(htmlgraphDir, planID, sliceNumStr, status string) error {
+	if err := validateSliceExecutionStatus(status); err != nil {
+		return err
+	}
+	sliceNum, err := parseSliceNum(sliceNumStr)
+	if err != nil {
+		return err
+	}
+	section := fmt.Sprintf("slice-%d", sliceNum)
+	db, err := openPlanDB(htmlgraphDir)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	if err := dbpkg.StorePlanFeedback(db, planID, section, "set-status", status, ""); err != nil {
+		return fmt.Errorf("store set-status feedback: %w", err)
+	}
+	fmt.Fprintf(os.Stdout, "Slice %d execution_status → %s for plan %s\n", sliceNum, status, planID)
+	return nil
+}
+
+// validateSliceExecutionStatus returns an error if status is not a valid slice execution status.
+func validateSliceExecutionStatus(status string) error {
+	for _, v := range validSliceExecutionStatuses {
+		if v == status {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid slice execution status %q — valid values: %s",
+		status, strings.Join(validSliceExecutionStatuses, ", "))
+}
+
+// parseSliceNum parses a slice number string and returns the int or an error.
+func parseSliceNum(s string) (int, error) {
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 1 {
+		return 0, fmt.Errorf("slice-num must be a positive integer (got %q)", s)
+	}
+	return n, nil
+}
+
+// openPlanDB resolves the DB path from htmlgraphDir and opens it.
+// The parent of htmlgraphDir is used as the project root for CanonicalDBPath.
+func openPlanDB(htmlgraphDir string) (*sql.DB, error) {
+	dbPath, err := storage.CanonicalDBPath(filepath.Dir(htmlgraphDir))
+	if err != nil {
+		return nil, fmt.Errorf("resolve db path: %w", err)
+	}
+	db, err := dbpkg.Open(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+	return db, nil
 }

--- a/cmd/htmlgraph/plan_yaml_cmds.go
+++ b/cmd/htmlgraph/plan_yaml_cmds.go
@@ -325,7 +325,30 @@ func runApproveSlice(htmlgraphDir, planID, sliceNumStr string) error {
 	if err := dbpkg.StorePlanFeedback(db, planID, section, "approve", "true", ""); err != nil {
 		return fmt.Errorf("store approve feedback: %w", err)
 	}
+	if err := updateSliceYAMLApproval(htmlgraphDir, planID, sliceNum, "approved"); err != nil {
+		fmt.Fprintf(stderr, "approve-slice: YAML sync warning: %v\n", err)
+	}
 	fmt.Fprintf(os.Stdout, "Slice %d approved for plan %s\n", sliceNum, planID)
+	return nil
+}
+
+// updateSliceYAMLApproval mirrors the plan_feedback approval state into the
+// YAML plan document so the dashboard checkbox and promote/finalize see the
+// same source of truth. Caller treats failures as non-fatal warnings.
+func updateSliceYAMLApproval(htmlgraphDir, planID string, sliceNum int, approval string) error {
+	planPath := filepath.Join(htmlgraphDir, "plans", planID+".yaml")
+	plan, err := planyaml.Load(planPath)
+	if err != nil {
+		return fmt.Errorf("load plan: %w", err)
+	}
+	idx, _, err := findPlanSlice(plan, sliceNum)
+	if err != nil {
+		return err
+	}
+	plan.Slices[idx].ApprovalStatus = approval
+	if err := planyaml.Save(planPath, plan); err != nil {
+		return fmt.Errorf("save plan: %w", err)
+	}
 	return nil
 }
 
@@ -375,6 +398,13 @@ func runRejectSlice(htmlgraphDir, planID, sliceNumStr string, changesRequested b
 	// Also record the approve=false row so IsPlanFullyApproved sees the disapproval.
 	if err := dbpkg.StorePlanFeedback(db, planID, section, "approve", "false", ""); err != nil {
 		return fmt.Errorf("store approve=false feedback: %w", err)
+	}
+	yamlState := "rejected"
+	if changesRequested {
+		yamlState = "changes_requested"
+	}
+	if err := updateSliceYAMLApproval(htmlgraphDir, planID, sliceNum, yamlState); err != nil {
+		fmt.Fprintf(stderr, "reject-slice: YAML sync warning: %v\n", err)
 	}
 	fmt.Fprintf(os.Stdout, "Slice %d rejected (action=%s) for plan %s\n", sliceNum, action, planID)
 	return nil
@@ -457,8 +487,8 @@ func runSetSliceStatus(htmlgraphDir, planID, sliceNumStr, status string) error {
 		return err
 	}
 	defer db.Close()
-	if err := dbpkg.StorePlanFeedback(db, planID, section, "set-status", status, ""); err != nil {
-		return fmt.Errorf("store set-status feedback: %w", err)
+	if err := dbpkg.StorePlanFeedback(db, planID, section, "set_execution_status", status, ""); err != nil {
+		return fmt.Errorf("store set_execution_status feedback: %w", err)
 	}
 	fmt.Fprintf(os.Stdout, "Slice %d execution_status → %s for plan %s\n", sliceNum, status, planID)
 	return nil

--- a/cmd/htmlgraph/plan_yaml_cmds_test.go
+++ b/cmd/htmlgraph/plan_yaml_cmds_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -274,24 +275,15 @@ func TestAutocommitPlan_CommitHookFailureIsNonFatal(t *testing.T) {
 		t.Fatalf("write pre-commit hook: %v", err)
 	}
 
-	// Capture stderr to verify the warning is printed.
-	origStderr := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	os.Stderr = w
+	// Capture stderr via the package-level seam — no pipe, no race.
+	var buf bytes.Buffer
+	origStderr := stderr
+	stderr = &buf
+	t.Cleanup(func() { stderr = origStderr })
 
 	commitErr := commitPlanChange(planPath, "plan(plan-hook1234): should be non-fatal")
 
-	// Restore stderr before reading — w must be closed first so Read doesn't block.
-	w.Close()
-	os.Stderr = origStderr
-
-	buf := make([]byte, 4096)
-	n, _ := r.Read(buf)
-	r.Close()
-	stderrOutput := string(buf[:n])
+	stderrOutput := buf.String()
 
 	// Assert non-fatal: commitPlanChange must return nil.
 	if commitErr != nil {

--- a/cmd/htmlgraph/worktree_helpers_test.go
+++ b/cmd/htmlgraph/worktree_helpers_test.go
@@ -8,7 +8,17 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/shakestzd/htmlgraph/internal/worktree"
 )
+
+// TestMain disables the reindex subprocess fork (`htmlgraph reindex`) for the
+// whole package so worktree-helper tests don't hang in environments where the
+// fork blocks on missing canonical state. Tracked as bug-bb5b26f6.
+func TestMain(m *testing.M) {
+	worktree.SetReindexFnForTest(func(string, io.Writer) {})
+	os.Exit(m.Run())
+}
 
 // setupWorktreeGitRepo creates a temp git repo with an initial commit and returns its path.
 func setupWorktreeGitRepo(t *testing.T) string {

--- a/docs/blog/posts/plan-mode-crispi.md
+++ b/docs/blog/posts/plan-mode-crispi.md
@@ -35,36 +35,46 @@ This is useful for tactical work. But it has key limitations:
 
 ## CRISPI: a structured alternative
 
-HtmlGraph's plan system produces a YAML document with a strict schema:
+HtmlGraph's plan system produces a YAML document where each slice is a self-contained executable spec card:
 
 ```yaml
 meta:
   id: plan-3a88d8a9
   title: "Session Ingestion Pipeline"
-  track: trk-97f85b3b
-  status: draft
+  track_id: trk-97f85b3b
+  status: active
 
 design:
   problem: "Agent sessions generate tool calls but no persistent record..."
-  goals: [...]
-  constraints: [...]
-  questions:
-    - question: "Should ingestion be real-time or batch?"
-      options: ["Real-time via hooks", "Batch via CLI command"]
-      recommended: 0
-      rationale: "Hooks already capture events..."
+  goals:
+    - "**Durability** — sessions survive process restarts"
+  constraints:
+    - "No new runtime dependencies"
 
 slices:
   - id: slice-1
+    num: 1
     title: "Hook Hierarchy Fix"
     effort: S
-    risk: low
-    what: "Restructure hook registration..."
-    done_when: ["All hooks fire in correct order", "Tests pass"]
-    depends_on: []
+    risk: Low
+    what: |
+      Restructure hook registration in internal/hooks/registry.go so
+      UserPromptSubmit fires before PreToolUse on every invocation.
+    why: |
+      The ingestion pipeline depends on prompt context being available
+      when the first tool call fires. The current ordering drops it.
+    done_when:
+      - "UserPromptSubmit fires before PreToolUse in all observed traces"
+      - "Existing hook tests pass unmodified"
+    tests: |
+      Unit: TestHookOrder — assert prompt hook index < tool hook index
+      Regression: go test ./internal/hooks/... -count=1
+    approval_status: pending
+    execution_status: not_started
+    deps: []
 ```
 
-Every plan has vertical slices with effort estimates, risk levels, dependencies, and concrete acceptance criteria. Design questions present options with recommended choices. Constraints are explicit. The schema is machine-readable, so agents can execute against it and report progress.
+Every slice card has effort estimates, risk levels, dependencies, and concrete acceptance criteria. Questions live inside the slice that needs the answer. Critic revisions are embedded per slice so reviewers see the feedback exactly where it applies. The schema is machine-readable, so agents can implement against it and track progress per slice.
 
 ## Dual-agent critique
 
@@ -108,13 +118,20 @@ Whether you use the Marimo notebook or the embedded dashboard, the review experi
 
 ## From plan to execution
 
-The finalize step is where CRISPI connects to the rest of HtmlGraph. When you finalize a plan:
+The connection between plan and execution is incremental. As slices are approved during review, they are promoted one at a time:
 
-1. The YAML is updated with all feedback, accepted amendments, and approval state
-2. A static HTML archive is generated for the permanent record
-3. The `execute` skill reads the approved slices, resolves their dependency graph, and dispatches all unblocked tasks simultaneously, each in its own git worktree
+```bash
+# Review a slice, then promote it to a feature:
+htmlgraph plan approve-slice plan-3a88d8a9 1
+htmlgraph plan promote-slice plan-3a88d8a9 1
+# → prints feat-7a3c1f0b
+```
 
-The plan becomes a dispatch queue. Each slice maps to a feature work item. Dependencies determine dispatch order. Quality gates run after each merge. The guardrails themselves are static thresholds (file count limits, test requirements, diff review), not plan-aware. But combining structured plans with tracked work items means there's always a clear record of what was intended vs. what was done.
+`promote-slice` creates a `feat-XXX` work item, wires it to the track and plan via typed edges, and checks dependency readiness. The feature immediately enters the execute skill's dependency-driven dispatch loop — no manual sequencing required. Dep-blocked slices wait in the `blocked` bucket until their dependencies complete.
+
+This incremental model means you can start executing approved slices while the rest of the plan is still under review. The plan doesn't need to be fully finalized to make progress. When all slices are done, rejected, or superseded, you close the plan with `htmlgraph plan set-status <id> completed`.
+
+The guardrails are static (file count limits, test requirements, diff review), not plan-aware. But combining structured slice cards with tracked features and linked sessions means there's always a clear record of what was intended, what was approved, and what was actually built.
 
 ## The key distinction
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -52,12 +52,27 @@ Commands for creating, reviewing, and executing structured CRISPI plans.
 | Command | Usage | Description |
 |---------|-------|-------------|
 | `plan create` | `htmlgraph plan create "Title" --track <trk-id>` | Create a new plan |
+| `plan create-yaml` | `htmlgraph plan create-yaml "Title" --track <trk-id>` | Create a v2 YAML plan file |
 | `plan show` | `htmlgraph plan show <id>` | Display plan details |
 | `plan start` | `htmlgraph plan start <id>` | Mark plan as in-progress |
 | `plan complete` | `htmlgraph plan complete <id>` | Mark plan as done |
 | `plan list` | `htmlgraph plan list` | List all plans |
+| `plan list-yaml` | `htmlgraph plan list-yaml` | List all YAML plans sorted by created_at |
 | `plan generate` | `htmlgraph plan generate <trk-id>` | Generate a CRISPI YAML plan for a track |
-| `plan rewrite-yaml` | `htmlgraph plan rewrite-yaml <id>` | Validated update of plan YAML |
+| `plan rewrite-yaml` | `htmlgraph plan rewrite-yaml <id> --file <path>` | Validated atomic update of plan YAML |
+| `plan validate-yaml` | `htmlgraph plan validate-yaml <id>` | Validate a YAML plan's schema |
+
+### v2 Slice Lifecycle
+
+Commands for per-slice review and incremental promotion (v2 plans only).
+
+| Command | Usage | Description |
+|---------|-------|-------------|
+| `plan approve-slice` | `htmlgraph plan approve-slice <plan-id> <num>` | Set `approval_status=approved` for a slice |
+| `plan reject-slice` | `htmlgraph plan reject-slice <plan-id> <num> [--changes-requested]` | Set `approval_status=rejected` (or `changes_requested`) |
+| `plan answer-slice-question` | `htmlgraph plan answer-slice-question <plan-id> <num> <question-id> <answer-key>` | Record answer to a slice-local question |
+| `plan set-slice-status` | `htmlgraph plan set-slice-status <plan-id> <num> <status>` | Set execution status (`not_started\|promoted\|in_progress\|done\|blocked\|superseded`) |
+| `plan promote-slice` | `htmlgraph plan promote-slice <plan-id> <num> [--waive-deps]` | Promote an approved slice to a feature work item |
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -18,14 +18,18 @@ require (
 
 require (
 	github.com/andybalholm/cascadia v1.3.3 // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/yuin/goldmark v1.8.2 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/PuerkitoBio/goquery v1.10.3 h1:pFYcNSqHxBD06Fpj/KsbStFRsgRATgnf3LeXiU
 github.com/PuerkitoBio/goquery v1.10.3/go.mod h1:tMUX0zDMHXYlAQk6p35XxQMqMweEKB7iK7iLNd4RH4Y=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
+github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
+github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
@@ -12,10 +14,14 @@ github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17k
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
+github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
+github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pelletier/go-toml/v2 v2.3.0 h1:k59bC/lIZREW0/iVaQR8nDHxVq8OVlIzYCOJf421CaM=
@@ -34,6 +40,8 @@ github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/db/plan_feedback.go
+++ b/internal/db/plan_feedback.go
@@ -117,6 +117,38 @@ func FinalizePlan(db *sql.DB, planID string) error {
 	return nil
 }
 
+// GetSliceApprovals returns a map of section key → approval status string
+// ("approved" or "rejected") for all slice-N keyed feedback rows for the plan.
+// Only sections matching the slice-<num> pattern are returned; legacy design/
+// outline/questions sections are excluded.
+// This is a read-only helper introduced in slice-4 for the approve-slice /
+// reject-slice lifecycle commands.
+func GetSliceApprovals(db *sql.DB, planID string) (map[string]string, error) {
+	rows, err := db.Query(`
+		SELECT section, value
+		FROM plan_feedback
+		WHERE plan_id = ? AND action = 'approve' AND section LIKE 'slice-%'
+		ORDER BY section ASC`, planID)
+	if err != nil {
+		return nil, fmt.Errorf("get slice approvals (plan=%s): %w", planID, err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]string)
+	for rows.Next() {
+		var section, value string
+		if err := rows.Scan(&section, &value); err != nil {
+			return nil, fmt.Errorf("scan slice approval row: %w", err)
+		}
+		if value == "true" {
+			result[section] = "approved"
+		} else {
+			result[section] = "rejected"
+		}
+	}
+	return result, rows.Err()
+}
+
 // DeletePlanFeedback deletes all feedback entries for a plan.
 func DeletePlanFeedback(db *sql.DB, planID string) error {
 	_, err := db.Exec(`DELETE FROM plan_feedback WHERE plan_id = ?`, planID)

--- a/internal/db/plan_feedback_test.go
+++ b/internal/db/plan_feedback_test.go
@@ -260,3 +260,103 @@ func TestFinalizePlanWrongType(t *testing.T) {
 		t.Errorf("feature status changed unexpectedly: got %q, want in-progress", status)
 	}
 }
+
+// ---- IsPlanFullyApproved regression tests (slice-4) ----------------------------
+
+// TestIsPlanFullyApproved_LegacyOnly_StillPasses verifies that writing feedback rows
+// ONLY for legacy sections (design, questions) and calling IsPlanFullyApproved
+// continues to return true when all legacy sections are approved.
+func TestIsPlanFullyApproved_LegacyOnly_StillPasses(t *testing.T) {
+	database, planID := setupPlanDB(t)
+	defer database.Close()
+
+	// Write legacy section approvals only.
+	legacySections := []string{"design", "outline"}
+	for _, s := range legacySections {
+		if err := db.StorePlanFeedback(database, planID, s, "approve", "true", ""); err != nil {
+			t.Fatalf("StorePlanFeedback %s: %v", s, err)
+		}
+	}
+
+	approved, err := db.IsPlanFullyApproved(database, planID)
+	if err != nil {
+		t.Fatalf("IsPlanFullyApproved: %v", err)
+	}
+	if !approved {
+		t.Error("expected true when all legacy sections approved — legacy behavior must be preserved")
+	}
+}
+
+// TestIsPlanFullyApproved_MixedLegacyAndV2_StableBehavior writes a V2 slice-local
+// section row (section='slice-1') alongside legacy sections and asserts that
+// IsPlanFullyApproved treats it uniformly — if all sections (legacy + V2) have
+// approve=true, the function returns true.
+func TestIsPlanFullyApproved_MixedLegacyAndV2_StableBehavior(t *testing.T) {
+	database, planID := setupPlanDB(t)
+	defer database.Close()
+
+	// Write legacy + V2 sections, all approved.
+	sections := []string{"design", "outline", "slice-1"}
+	for _, s := range sections {
+		if err := db.StorePlanFeedback(database, planID, s, "approve", "true", ""); err != nil {
+			t.Fatalf("StorePlanFeedback %s: %v", s, err)
+		}
+	}
+
+	approved, err := db.IsPlanFullyApproved(database, planID)
+	if err != nil {
+		t.Fatalf("IsPlanFullyApproved: %v", err)
+	}
+	if !approved {
+		t.Error("expected true when all legacy + V2 sections approved")
+	}
+
+	// Now add a V2 section with approve=false — should return false.
+	if err := db.StorePlanFeedback(database, planID, "slice-2", "approve", "false", ""); err != nil {
+		t.Fatalf("StorePlanFeedback slice-2: %v", err)
+	}
+
+	approved, err = db.IsPlanFullyApproved(database, planID)
+	if err != nil {
+		t.Fatalf("IsPlanFullyApproved after slice-2 disapprove: %v", err)
+	}
+	if approved {
+		t.Error("expected false when a V2 section (slice-2) is disapproved")
+	}
+}
+
+// ---- GetSliceApprovals tests (slice-4) -----------------------------------------
+
+// TestGetSliceApprovals_ReturnsPerSliceStatus verifies that GetSliceApprovals
+// returns only slice-N keyed rows and maps them to approval status correctly.
+func TestGetSliceApprovals_ReturnsPerSliceStatus(t *testing.T) {
+	database, planID := setupPlanDB(t)
+	defer database.Close()
+
+	// Store mixed sections: design (legacy) and two slices.
+	if err := db.StorePlanFeedback(database, planID, "design", "approve", "true", ""); err != nil {
+		t.Fatalf("store design: %v", err)
+	}
+	if err := db.StorePlanFeedback(database, planID, "slice-1", "approve", "true", ""); err != nil {
+		t.Fatalf("store slice-1: %v", err)
+	}
+	if err := db.StorePlanFeedback(database, planID, "slice-2", "approve", "false", ""); err != nil {
+		t.Fatalf("store slice-2: %v", err)
+	}
+
+	approvals, err := db.GetSliceApprovals(database, planID)
+	if err != nil {
+		t.Fatalf("GetSliceApprovals: %v", err)
+	}
+
+	// Should only contain slice sections, not "design".
+	if _, hasDesign := approvals["design"]; hasDesign {
+		t.Error("GetSliceApprovals should not include legacy 'design' section")
+	}
+	if v, ok := approvals["slice-1"]; !ok || v != "approved" {
+		t.Errorf("slice-1: got %q ok=%v, want approved=true", v, ok)
+	}
+	if v, ok := approvals["slice-2"]; !ok || v != "rejected" {
+		t.Errorf("slice-2: got %q ok=%v, want rejected", v, ok)
+	}
+}

--- a/internal/hooks/posttooluse.go
+++ b/internal/hooks/posttooluse.go
@@ -17,7 +17,10 @@ import (
 // It finds the most recent "started" event for this session/tool and marks it completed.
 // Note: env vars don't persist between hook processes, so we query the DB instead.
 func PostToolUse(event *CloudEvent, database *sql.DB) (*HookResult, error) {
-	ctx := resolveToolUseContext(event, database)
+	// PostToolUse trusts HTMLGRAPH_PARENT_PROMPT_EVENT set by the paired PreToolUse
+	// (trustParentEnvVar=true) to avoid the race where a new UserQuery arrives while
+	// the tool was executing and the LatestEventByTool fallback would return the wrong parent.
+	ctx := resolveToolUseContext(event, database, true)
 	if ctx == nil {
 		return &HookResult{Continue: true}, nil
 	}

--- a/internal/hooks/tooluse_shared.go
+++ b/internal/hooks/tooluse_shared.go
@@ -59,11 +59,17 @@ type toolUseContext struct {
 // Returns nil when no active session is found, indicating the caller should
 // skip all DB operations.
 //
+// trustParentEnvVar should be true only in PostToolUse, where
+// HTMLGRAPH_PARENT_PROMPT_EVENT was set by the paired PreToolUse for this
+// specific tool call. PreToolUse passes false so it always re-resolves the
+// parent from the DB, preventing stale env-var values from a prior tool call
+// from leaking into the next prompt's tool calls.
+//
 // Item 1 (feat-8b6fdf86): replaces 3 separate queries (GetSession,
 // GetActiveFeatureID, HasActiveClaimByAgent) with a single SQL join via
 // db.GetToolUseContext. The YOLO conditional queries remain separate since
 // they only run in YOLO mode.
-func resolveToolUseContext(event *CloudEvent, database *sql.DB) *toolUseContext {
+func resolveToolUseContext(event *CloudEvent, database *sql.DB, trustParentEnvVar bool) *toolUseContext {
 	start := time.Now()
 
 	sessionID := resolveSessionIDWithHarness(event)
@@ -105,7 +111,7 @@ func resolveToolUseContext(event *CloudEvent, database *sql.DB) *toolUseContext 
 	projectDir := ResolveProjectDir(event.CWD, event.SessionID)
 	hgDir := filepath.Join(projectDir, ".htmlgraph")
 	yolo := isYoloFromEvent(event, hgDir)
-	parentEventID := resolveParentEventID(database, sessionID, agentID, isSubagent)
+	parentEventID := resolveParentEventID(database, sessionID, agentID, isSubagent, trustParentEnvVar)
 
 	LogTimed(projectDir, "pretooluse", map[string]string{
 		"phase":   "resolve-context",
@@ -179,27 +185,38 @@ func resolveEventAgentType(event *CloudEvent) string {
 
 // resolveParentEventID finds the parent event using a multi-step fallback that
 // mirrors the Python event_tracker.py logic:
-//  1. Env var HTMLGRAPH_PARENT_PROMPT_EVENT (written by PreToolUse at tool-call time)
+//  1. Env var HTMLGRAPH_PARENT_PROMPT_EVENT (only when trustEnvVar=true, i.e. PostToolUse)
 //  2. Env var HTMLGRAPH_PARENT_EVENT (written by SubagentStart when CLAUDE_ENV_FILE set)
 //  3. Per-subagent hint file parent_event_id (written when CLAUDE_ENV_FILE unset)
 //  4. For subagents: task_delegation row matching our agent_id (Method 0.5)
 //  5. Most recent UserQuery in this session (orchestrator default)
-func resolveParentEventID(database *sql.DB, sessionID, agentID string, isSubagent bool) string {
+//
+// trustEnvVar must be true only in PostToolUse, where the env var was set by the
+// paired PreToolUse for this specific tool call. PreToolUse must pass false so it
+// always re-resolves from the DB — this prevents stale values from a prior tool
+// call being parented to the wrong prompt (the value persists in the process
+// environment across tool calls until the next UserPromptSubmit).
+func resolveParentEventID(database *sql.DB, sessionID, agentID string, isSubagent bool, trustEnvVar bool) string {
 	// HTMLGRAPH_PARENT_PROMPT_EVENT is written to CLAUDE_ENV_FILE by PreToolUse at
-	// the moment the tool starts (before the tool executes). Reading it here — in
-	// both PreToolUse and PostToolUse — eliminates the race where a new UserQuery
-	// arrives while a long-running tool is executing. Without this, the
-	// LatestEventByTool("UserQuery") fallback at the bottom of this chain would
-	// return the *newer* UserQuery (wrong parent) when PostToolUse fires.
+	// the moment the tool starts (before the tool executes). PostToolUse trusts it
+	// to avoid the race where a new UserQuery arrives while a long-running tool is
+	// executing (the LatestEventByTool fallback would return the wrong UserQuery).
+	//
+	// PreToolUse does NOT trust this env var — it is the authority and always
+	// re-resolves from the DB. This prevents the env var set by tool call N from
+	// leaking into tool call N+1 (it persists in the process environment until the
+	// next UserPromptSubmit hook resets it).
 	//
 	// Validate that the env-var event ID actually exists in the current DB before
 	// returning it. In tests, multiple hook invocations share a process and an
 	// earlier PreToolUse may have set this env var for a different DB instance —
 	// using a stale ID that doesn't exist in the current DB causes FK violations
 	// and silent InsertEvent failures.
-	if v := os.Getenv("HTMLGRAPH_PARENT_PROMPT_EVENT"); v != "" {
-		if db.EventExists(database, v) {
-			return v
+	if trustEnvVar {
+		if v := os.Getenv("HTMLGRAPH_PARENT_PROMPT_EVENT"); v != "" {
+			if db.EventExists(database, v) {
+				return v
+			}
 		}
 	}
 

--- a/internal/plantmpl/plantmpl.go
+++ b/internal/plantmpl/plantmpl.go
@@ -15,7 +15,49 @@ import (
 	"io"
 	"strings"
 	texttemplate "text/template"
+
+	"github.com/microcosm-cc/bluemonday"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/renderer/html"
 )
+
+// mdParser is a shared goldmark instance with GFM extensions enabled.
+// It allows unsafe HTML so that goldmark renders raw HTML — bluemonday then
+// strips the dangerous bits. This ensures we get proper fenced-code blocks,
+// tables, and strikethrough while still sanitizing XSS vectors.
+var mdParser = goldmark.New(
+	goldmark.WithExtensions(extension.GFM),
+	goldmark.WithRendererOptions(html.WithUnsafe()),
+)
+
+// mdPolicy is the bluemonday policy used to sanitize goldmark output.
+// It permits standard Markdown output elements (headings, lists, code, etc.)
+// while stripping <script>, event handlers, and other XSS vectors.
+var mdPolicy = func() *bluemonday.Policy {
+	p := bluemonday.UGCPolicy()
+	// Allow class attributes on <code> and <pre> (e.g. language-go) for
+	// client-side syntax highlighting if desired.
+	p.AllowAttrs("class").OnElements("code", "pre")
+	return p
+}()
+
+// RenderMd converts a Markdown string to sanitized HTML. It uses goldmark
+// for parsing and bluemonday for sanitization so that headings, lists, code
+// fences, and inline code all render correctly while XSS vectors are removed.
+// Plain-text input is wrapped in a <p> tag by goldmark.
+func RenderMd(src string) template.HTML {
+	if strings.TrimSpace(src) == "" {
+		return ""
+	}
+	var buf bytes.Buffer
+	if err := mdParser.Convert([]byte(src), &buf); err != nil {
+		// On parse error, return the source HTML-escaped as a fallback.
+		return template.HTML(template.HTMLEscapeString(src))
+	}
+	safe := mdPolicy.SanitizeBytes(buf.Bytes())
+	return template.HTML(safe)
+}
 
 //go:embed templates/*
 var templateFS embed.FS

--- a/internal/plantmpl/plantmpl.go
+++ b/internal/plantmpl/plantmpl.go
@@ -156,6 +156,11 @@ type PlanPage struct {
 	Version     int    // monotonic version counter from plan.meta.version; 0 if unset
 	Status      string // "draft", "in-progress", "finalized", etc.
 
+	// IsV2 marks a plan as using the v2 slice-card format where each slice
+	// carries its own questions and critic_revisions. When true, the global
+	// Questions and Critique sections are suppressed in favour of the per-slice UI.
+	IsV2 bool
+
 	// Zone components
 	Graph     *DependencyGraph
 	Design    *DesignSection

--- a/internal/plantmpl/plantmpl_test.go
+++ b/internal/plantmpl/plantmpl_test.go
@@ -278,3 +278,65 @@ func TestProgressBarRender(t *testing.T) {
 		t.Error("expected progress-bar placeholder")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Slice-3: PlanPage v2 vs legacy section visibility
+// ---------------------------------------------------------------------------
+
+func TestPlanPage_V2_HidesGlobalQuestionsAndCritique(t *testing.T) {
+	// A v2 plan: has slices with Questions — global sections should be suppressed.
+	page := &plantmpl.PlanPage{
+		PlanID: "plan-v2-test",
+		Title:  "V2 Plan",
+		IsV2:   true,
+		Slices: []plantmpl.SliceCard{
+			{
+				Num:   1,
+				ID:    "feat-s1",
+				Title: "Slice 1",
+			},
+		},
+		// Provide a Questions zone — should be hidden for v2
+		Questions: &plantmpl.QuestionsSection{
+			Cards: []plantmpl.DecisionCard{
+				{ID: "q1", Text: "Which approach?"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := page.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	html := buf.String()
+	// For v2, global questions section should not be rendered as the main review flow
+	if strings.Contains(html, `id="questions"`) {
+		t.Error("v2 plan: global questions section should be hidden")
+	}
+}
+
+func TestPlanPage_Legacy_StillRendersGlobalSections(t *testing.T) {
+	// A legacy plan: IsV2 is false — global Questions and Critique should still render.
+	page := &plantmpl.PlanPage{
+		PlanID: "plan-legacy-test",
+		Title:  "Legacy Plan",
+		IsV2:   false,
+		Questions: &plantmpl.QuestionsSection{
+			Cards: []plantmpl.DecisionCard{
+				{ID: "q1", Text: "Which approach?"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := page.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	html := buf.String()
+	// Legacy plan must still render global questions
+	if !strings.Contains(html, `id="questions"`) {
+		t.Error("legacy plan: global questions section should still be rendered")
+	}
+}

--- a/internal/plantmpl/slice_card.go
+++ b/internal/plantmpl/slice_card.go
@@ -17,10 +17,10 @@ type SliceCard struct {
 	FeatureID   string // generated feature ID like "feat-abc123" (for Related Features lookup)
 	Title       string
 	Description string   // Legacy: flat description text (used when What is empty)
-	What        string   // Structured: what to implement
-	Why         string   // Structured: rationale / motivation
-	DoneWhen    []string // Structured: acceptance criteria bullets
-	Tests       string   // Test strategy text
+	What        string   // Structured: what to implement (Markdown source)
+	Why         string   // Structured: rationale / motivation (Markdown source)
+	DoneWhen    []string // Structured: acceptance criteria bullets (literal, no Markdown)
+	Tests       string   // Test strategy text (Markdown source)
 	Effort      string   // "S", "M", "L"
 	Risk        string   // "Low", "Med", "High"
 	Deps        string   // comma-separated slice numbers
@@ -33,6 +33,18 @@ type SliceCard struct {
 func (sc *SliceCard) HasStructuredContent() bool {
 	return sc.What != "" || sc.Why != ""
 }
+
+// WhatHTML returns the What field rendered as sanitized HTML.
+func (sc *SliceCard) WhatHTML() template.HTML { return RenderMd(sc.What) }
+
+// WhyHTML returns the Why field rendered as sanitized HTML.
+func (sc *SliceCard) WhyHTML() template.HTML { return RenderMd(sc.Why) }
+
+// DescriptionHTML returns the Description field rendered as sanitized HTML.
+func (sc *SliceCard) DescriptionHTML() template.HTML { return RenderMd(sc.Description) }
+
+// TestsHTML returns the Tests field rendered as sanitized HTML.
+func (sc *SliceCard) TestsHTML() template.HTML { return RenderMd(sc.Tests) }
 
 // Render writes the slice card HTML.
 func (sc *SliceCard) Render(w io.Writer) error {

--- a/internal/plantmpl/slice_card.go
+++ b/internal/plantmpl/slice_card.go
@@ -1,8 +1,12 @@
 package plantmpl
 
 import (
+	"fmt"
 	"html/template"
 	"io"
+	"strings"
+
+	"github.com/shakestzd/htmlgraph/internal/planyaml"
 )
 
 var sliceCardTmpl = template.Must(
@@ -26,6 +30,14 @@ type SliceCard struct {
 	Deps        string   // comma-separated slice numbers
 	Files       string   // comma-separated file paths
 	Status      string
+
+	// V2 lifecycle fields (additive — legacy plans omit these and remain valid).
+	ApprovalStatus  string // pending | approved | rejected | changes_requested
+	ExecutionStatus string // not_started | promoted | in_progress | done | blocked | superseded
+
+	// V2 slice-local spec fields.
+	Questions       []planyaml.SliceQuestion  // slice-local open questions
+	CriticRevisions []planyaml.CriticRevision // critic feedback specific to this slice
 }
 
 // HasStructuredContent returns true when the slice has What/Why fields
@@ -83,4 +95,118 @@ func (sc *SliceCard) DepsLabel() string {
 		return "none"
 	}
 	return "slices " + sc.Deps
+}
+
+// ApprovalStatusClass returns the CSS badge class for the approval status.
+func (sc *SliceCard) ApprovalStatusClass() string {
+	switch sc.ApprovalStatus {
+	case "approved":
+		return "badge-approved"
+	case "rejected":
+		return "badge-blocked"
+	case "changes_requested":
+		return "badge-revision"
+	default:
+		return "badge-pending"
+	}
+}
+
+// ApprovalStatusLabel returns the display label for the approval status.
+func (sc *SliceCard) ApprovalStatusLabel() string {
+	switch sc.ApprovalStatus {
+	case "approved":
+		return "Approved"
+	case "rejected":
+		return "Rejected"
+	case "changes_requested":
+		return "Changes Requested"
+	default:
+		return "Pending"
+	}
+}
+
+// ExecutionStatusLabel returns a display label for the execution status.
+func (sc *SliceCard) ExecutionStatusLabel() string {
+	switch sc.ExecutionStatus {
+	case "not_started":
+		return "Not Started"
+	case "promoted":
+		return "Promoted"
+	case "in_progress":
+		return "In Progress"
+	case "done":
+		return "Done"
+	case "blocked":
+		return "Blocked"
+	case "superseded":
+		return "Superseded"
+	default:
+		return sc.ExecutionStatus
+	}
+}
+
+// ExecutionStatusClass returns the CSS badge class for the execution status.
+func (sc *SliceCard) ExecutionStatusClass() string {
+	switch sc.ExecutionStatus {
+	case "done":
+		return "badge-approved"
+	case "in_progress", "promoted":
+		return "badge-revision"
+	case "blocked", "superseded":
+		return "badge-blocked"
+	default:
+		return "badge-pending"
+	}
+}
+
+// CriticSeverityClass returns the CSS badge class for a critic revision severity.
+func (sc *SliceCard) CriticSeverityClass(severity string) string {
+	upper := strings.ToUpper(severity)
+	switch {
+	case upper == "HIGH" || upper == "DANGER":
+		return "badge-blocked"
+	case upper == "MED" || upper == "MEDIUM":
+		return "badge-revision"
+	default:
+		return "badge-pending"
+	}
+}
+
+// SliceQuestionSectionKey returns the plan_feedback section key for a
+// slice-local question, following the contract: slice-<num>-question-<id>.
+func (sc *SliceCard) SliceQuestionSectionKey(questionID string) string {
+	return fmt.Sprintf("slice-%d-question-%s", sc.Num, questionID)
+}
+
+// SliceCardFromPlanSlice maps a planyaml.PlanSlice to a SliceCard.
+// This is the canonical mapping used by enrichPageFromYAML and tests.
+func SliceCardFromPlanSlice(s planyaml.PlanSlice) SliceCard {
+	depsStr := ""
+	for i, d := range s.Deps {
+		if i > 0 {
+			depsStr += ","
+		}
+		depsStr += fmt.Sprintf("%d", d)
+	}
+	filesStr := strings.Join(s.Files, ", ")
+
+	return SliceCard{
+		Num:             s.Num,
+		ID:              s.ID,
+		FeatureID:       s.FeatureID,
+		Title:           s.Title,
+		What:            s.What,
+		Why:             s.Why,
+		DoneWhen:        s.DoneWhen,
+		Tests:           s.Tests,
+		Effort:          s.Effort,
+		Risk:            s.Risk,
+		Deps:            depsStr,
+		Files:           filesStr,
+		Status:          "pending",
+		ApprovalStatus:  s.ApprovalStatus,
+		ExecutionStatus: s.ExecutionStatus,
+		Questions:       s.Questions,
+		CriticRevisions: s.CriticRevisions,
+	}
 }

--- a/internal/plantmpl/slice_card_test.go
+++ b/internal/plantmpl/slice_card_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/shakestzd/htmlgraph/internal/plantmpl"
+	"github.com/shakestzd/htmlgraph/internal/planyaml"
 )
 
 // ---------------------------------------------------------------------------
@@ -583,5 +584,323 @@ func TestMultipleSliceCardsRenderIndependently(t *testing.T) {
 		if !strings.Contains(html, c.ID) {
 			t.Errorf("card %d: missing ID %q", c.Num, c.ID)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Slice-3: v2 fields — approval status, execution status, questions, revisions
+// ---------------------------------------------------------------------------
+
+func TestSliceCard_RendersApprovalStatus_Pending(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num:            1,
+		ID:             "feat-test",
+		ApprovalStatus: "pending",
+	}
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, "Pending") {
+		t.Errorf("ApprovalStatus=pending should show 'Pending' text, got:\n%s", html)
+	}
+}
+
+func TestSliceCard_RendersApprovalStatus_Approved(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num:            2,
+		ID:             "feat-test",
+		ApprovalStatus: "approved",
+	}
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, "Approved") {
+		t.Errorf("ApprovalStatus=approved should show 'Approved' text, got:\n%s", html)
+	}
+	if !strings.Contains(html, "badge-approved") {
+		t.Errorf("ApprovalStatus=approved should use badge-approved class, got:\n%s", html)
+	}
+}
+
+func TestSliceCard_RendersApprovalStatus_Rejected(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num:            3,
+		ID:             "feat-test",
+		ApprovalStatus: "rejected",
+	}
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, "Rejected") {
+		t.Errorf("ApprovalStatus=rejected should show 'Rejected' text, got:\n%s", html)
+	}
+	if !strings.Contains(html, "badge-blocked") {
+		t.Errorf("ApprovalStatus=rejected should use badge-blocked class, got:\n%s", html)
+	}
+}
+
+func TestSliceCard_RendersExecutionStatus(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num:             4,
+		ID:              "feat-test",
+		ExecutionStatus: "in_progress",
+	}
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, "in_progress") && !strings.Contains(html, "In Progress") && !strings.Contains(html, "in-progress") {
+		t.Errorf("ExecutionStatus=in_progress should appear in output, got:\n%s", html)
+	}
+}
+
+func TestSliceCard_RendersSliceLocalQuestions(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num: 5,
+		ID:  "feat-test",
+		Questions: []planyaml.SliceQuestion{
+			{ID: "q-1", Text: "Should we use gRPC or REST?"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, "Should we use gRPC or REST?") {
+		t.Errorf("Question text missing from output:\n%s", html)
+	}
+	// The section key for the question must follow the contract: slice-N-question-<id>
+	if !strings.Contains(html, `data-section="slice-5-question-q-1"`) {
+		t.Errorf("expected data-section=\"slice-5-question-q-1\" in output:\n%s", html)
+	}
+}
+
+func TestSliceCard_RendersCriticRevisionBadges(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num: 6,
+		ID:  "feat-test",
+		CriticRevisions: []planyaml.CriticRevision{
+			{Source: "feasibility", Severity: "High", Summary: "Consider rate limiting"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, "Consider rate limiting") {
+		t.Errorf("CriticRevision summary missing from output:\n%s", html)
+	}
+	if !strings.Contains(html, "feasibility") {
+		t.Errorf("CriticRevision source missing from output:\n%s", html)
+	}
+	// High severity should get a blocked/danger style
+	if !strings.Contains(html, "badge-blocked") && !strings.Contains(html, "severity-high") {
+		t.Errorf("High severity badge should use blocked/danger class, got:\n%s", html)
+	}
+}
+
+func TestSliceCard_ReconcilesExistingApprovalCheckbox(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num:            7,
+		ID:             "feat-test",
+		ApprovalStatus: "approved",
+	}
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	html := buf.String()
+	// There must be exactly ONE approval checkbox (one mechanism, not duplicated).
+	checkboxCount := strings.Count(html, `data-action="approve"`)
+	if checkboxCount != 1 {
+		t.Errorf("expected exactly 1 approve checkbox, got %d in:\n%s", checkboxCount, html)
+	}
+	// The visual status badge must reference the same slice key (data-badge-for=slice-7).
+	if !strings.Contains(html, `data-badge-for="slice-7"`) {
+		t.Errorf("expected badge with data-badge-for=\"slice-7\" in output:\n%s", html)
+	}
+	// When approved, the checkbox should be pre-checked.
+	if !strings.Contains(html, `checked`) {
+		t.Errorf("approved slice should have checked checkbox:\n%s", html)
+	}
+}
+
+func TestSliceCard_LegacyV1NoNewFields(t *testing.T) {
+	// A slice without any v2 fields should render as it did before slice-3.
+	sc := &plantmpl.SliceCard{
+		Num:         1,
+		ID:          "feat-legacy",
+		Title:       "Legacy slice",
+		Description: "Old-style description.",
+	}
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	html := buf.String()
+	// Must contain the slice card
+	if !strings.Contains(html, `class="slice-card"`) {
+		t.Error("legacy slice should still render slice-card class")
+	}
+	// Must contain description
+	if !strings.Contains(html, "Old-style description.") {
+		t.Error("legacy slice should still render description")
+	}
+	// Should not have any critic revision or question UI (no data)
+	if strings.Contains(html, "class=\"critic-revision\"") {
+		t.Error("no CriticRevisions set, should not render critic revision UI")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SliceCard.SliceQuestionSectionKey helper
+// ---------------------------------------------------------------------------
+
+func TestSliceCard_SliceQuestionSectionKey(t *testing.T) {
+	sc := &plantmpl.SliceCard{Num: 3}
+	got := sc.SliceQuestionSectionKey("q-abc")
+	want := "slice-3-question-q-abc"
+	if got != want {
+		t.Errorf("SliceQuestionSectionKey: got %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SliceCard.ApprovalStatusClass helper
+// ---------------------------------------------------------------------------
+
+func TestSliceCard_ApprovalStatusClass_Approved(t *testing.T) {
+	sc := &plantmpl.SliceCard{ApprovalStatus: "approved"}
+	if got := sc.ApprovalStatusClass(); got != "badge-approved" {
+		t.Errorf("ApprovalStatusClass approved: got %q, want badge-approved", got)
+	}
+}
+
+func TestSliceCard_ApprovalStatusClass_Rejected(t *testing.T) {
+	sc := &plantmpl.SliceCard{ApprovalStatus: "rejected"}
+	if got := sc.ApprovalStatusClass(); got != "badge-blocked" {
+		t.Errorf("ApprovalStatusClass rejected: got %q, want badge-blocked", got)
+	}
+}
+
+func TestSliceCard_ApprovalStatusClass_ChangesRequested(t *testing.T) {
+	sc := &plantmpl.SliceCard{ApprovalStatus: "changes_requested"}
+	if got := sc.ApprovalStatusClass(); got != "badge-revision" {
+		t.Errorf("ApprovalStatusClass changes_requested: got %q, want badge-revision", got)
+	}
+}
+
+func TestSliceCard_ApprovalStatusClass_Pending(t *testing.T) {
+	sc := &plantmpl.SliceCard{ApprovalStatus: "pending"}
+	if got := sc.ApprovalStatusClass(); got != "badge-pending" {
+		t.Errorf("ApprovalStatusClass pending: got %q, want badge-pending", got)
+	}
+}
+
+func TestSliceCard_ApprovalStatusClass_Empty(t *testing.T) {
+	sc := &plantmpl.SliceCard{ApprovalStatus: ""}
+	if got := sc.ApprovalStatusClass(); got != "badge-pending" {
+		t.Errorf("ApprovalStatusClass empty: got %q, want badge-pending", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SliceCard.CriticSeverityClass helper
+// ---------------------------------------------------------------------------
+
+func TestSliceCard_CriticSeverityClass(t *testing.T) {
+	sc := &plantmpl.SliceCard{}
+	tests := []struct {
+		severity string
+		want     string
+	}{
+		{"High", "badge-blocked"},
+		{"HIGH", "badge-blocked"},
+		{"DANGER", "badge-blocked"},
+		{"Med", "badge-revision"},
+		{"Medium", "badge-revision"},
+		{"Low", "badge-pending"},
+		{"low", "badge-pending"},
+		{"", "badge-pending"},
+	}
+	for _, tt := range tests {
+		got := sc.CriticSeverityClass(tt.severity)
+		if got != tt.want {
+			t.Errorf("CriticSeverityClass(%q): got %q, want %q", tt.severity, got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SliceCardFromPlanSlice mapper
+// ---------------------------------------------------------------------------
+
+func TestSliceCardFromPlanSlice_BasicFields(t *testing.T) {
+	ps := planyaml.PlanSlice{
+		Num:    2,
+		ID:     "feat-xyz",
+		Title:  "Auth slice",
+		What:   "Implement JWT",
+		Why:    "Security",
+		Effort: "M",
+		Risk:   "Low",
+		Deps:   []int{1},
+		Files:  []string{"internal/auth/auth.go"},
+	}
+	sc := plantmpl.SliceCardFromPlanSlice(ps)
+	if sc.Num != 2 {
+		t.Errorf("Num: got %d, want 2", sc.Num)
+	}
+	if sc.ID != "feat-xyz" {
+		t.Errorf("ID: got %q, want feat-xyz", sc.ID)
+	}
+	if sc.What != "Implement JWT" {
+		t.Errorf("What: got %q, want 'Implement JWT'", sc.What)
+	}
+	if sc.Effort != "M" {
+		t.Errorf("Effort: got %q, want M", sc.Effort)
+	}
+	if sc.Deps != "1" {
+		t.Errorf("Deps: got %q, want '1'", sc.Deps)
+	}
+	if sc.Files != "internal/auth/auth.go" {
+		t.Errorf("Files: got %q, want 'internal/auth/auth.go'", sc.Files)
+	}
+}
+
+func TestSliceCardFromPlanSlice_V2Fields(t *testing.T) {
+	ps := planyaml.PlanSlice{
+		Num:             3,
+		ID:              "feat-v2",
+		ApprovalStatus:  "approved",
+		ExecutionStatus: "in_progress",
+		Questions: []planyaml.SliceQuestion{
+			{ID: "q-1", Text: "What DB?"},
+		},
+		CriticRevisions: []planyaml.CriticRevision{
+			{Source: "arch", Severity: "High", Summary: "Add index"},
+		},
+	}
+	sc := plantmpl.SliceCardFromPlanSlice(ps)
+	if sc.ApprovalStatus != "approved" {
+		t.Errorf("ApprovalStatus: got %q, want approved", sc.ApprovalStatus)
+	}
+	if sc.ExecutionStatus != "in_progress" {
+		t.Errorf("ExecutionStatus: got %q, want in_progress", sc.ExecutionStatus)
+	}
+	if len(sc.Questions) != 1 || sc.Questions[0].ID != "q-1" {
+		t.Errorf("Questions not mapped correctly: %+v", sc.Questions)
+	}
+	if len(sc.CriticRevisions) != 1 || sc.CriticRevisions[0].Source != "arch" {
+		t.Errorf("CriticRevisions not mapped correctly: %+v", sc.CriticRevisions)
 	}
 }

--- a/internal/plantmpl/slice_card_test.go
+++ b/internal/plantmpl/slice_card_test.go
@@ -302,6 +302,175 @@ func TestSliceCardRenderEmptyFilesOmitted(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Markdown rendering tests (slice-2 / feat-33807582)
+// ---------------------------------------------------------------------------
+
+func TestSliceCard_RendersMarkdownHeadings(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num:  1,
+		ID:   "feat-md-h",
+		What: "### Heading\n\ntext",
+	}
+
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	html := buf.String()
+	if !strings.Contains(html, "<h3>") {
+		t.Errorf("expected <h3> from ### heading, got output:\n%s", html)
+	}
+}
+
+func TestSliceCard_RendersMarkdownLists(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num:  1,
+		ID:   "feat-md-list",
+		What: "- item one\n- item two\n- item three",
+	}
+
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	html := buf.String()
+	if !strings.Contains(html, "<ul>") {
+		t.Errorf("expected <ul> from bullet list, got output:\n%s", html)
+	}
+	if !strings.Contains(html, "<li>") {
+		t.Errorf("expected <li> from bullet list, got output:\n%s", html)
+	}
+}
+
+func TestSliceCard_RendersMarkdownCodeFence(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num:  1,
+		ID:   "feat-md-fence",
+		What: "```go\nfunc main() {}\n```",
+	}
+
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	html := buf.String()
+	if !strings.Contains(html, "<pre>") {
+		t.Errorf("expected <pre> from code fence, got output:\n%s", html)
+	}
+	if !strings.Contains(html, "<code") {
+		t.Errorf("expected <code> from code fence, got output:\n%s", html)
+	}
+}
+
+func TestSliceCard_RendersInlineCode(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num:  1,
+		ID:   "feat-md-inline",
+		What: "Use `myFunc()` to do it.",
+	}
+
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	html := buf.String()
+	if !strings.Contains(html, "<code>") {
+		t.Errorf("expected <code> from inline code, got output:\n%s", html)
+	}
+	if !strings.Contains(html, "myFunc()") {
+		t.Errorf("expected myFunc() in output, got:\n%s", html)
+	}
+}
+
+func TestSliceCard_StripsScriptTags(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num:  1,
+		ID:   "feat-md-xss",
+		What: `<script>alert(1)</script>`,
+	}
+
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	html := buf.String()
+	if strings.Contains(html, "<script>") {
+		t.Errorf("unescaped <script> tag must not appear in output:\n%s", html)
+	}
+}
+
+func TestSliceCard_StripsRawHTMLEventHandlers(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num:  1,
+		ID:   "feat-md-evil",
+		What: `<img src=x onerror="alert(1)">`,
+	}
+
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	html := buf.String()
+	if strings.Contains(html, "onerror=") {
+		t.Errorf("onerror event handler must be stripped from output:\n%s", html)
+	}
+	if strings.Contains(html, "alert(1)") {
+		t.Errorf("event handler payload must be stripped from output:\n%s", html)
+	}
+}
+
+func TestSliceCard_DoneWhenStaysStructuredList(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num:      1,
+		ID:       "feat-md-done",
+		What:     "Implement it",
+		DoneWhen: []string{"All tests pass", "Code reviewed"},
+	}
+
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	html := buf.String()
+	// done_when items must render as literal <li> text — no Markdown heading etc.
+	if !strings.Contains(html, "All tests pass") {
+		t.Errorf("DoneWhen item 'All tests pass' missing from output:\n%s", html)
+	}
+	if !strings.Contains(html, "Code reviewed") {
+		t.Errorf("DoneWhen item 'Code reviewed' missing from output:\n%s", html)
+	}
+	// The done_when section wraps items in <ul>
+	if !strings.Contains(html, `class="slice-done-list"`) {
+		t.Errorf("expected slice-done-list ul, got:\n%s", html)
+	}
+}
+
+func TestSliceCard_LegacyPlainTextStillRenders(t *testing.T) {
+	sc := &plantmpl.SliceCard{
+		Num:  1,
+		ID:   "feat-legacy",
+		What: "Just text.",
+	}
+
+	var buf bytes.Buffer
+	if err := sc.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	html := buf.String()
+	if !strings.Contains(html, "Just text.") {
+		t.Errorf("plain text 'Just text.' missing from output:\n%s", html)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // DepsLabel helper
 // ---------------------------------------------------------------------------
 

--- a/internal/plantmpl/templates/plan_page.gohtml
+++ b/internal/plantmpl/templates/plan_page.gohtml
@@ -370,8 +370,8 @@ textarea::placeholder{color:var(--text-muted)}
   </div>
 </details>
 
-<!-- Design Decisions -->
-{{if .Questions}}{{renderZone .Questions}}{{else}}<details id="questions" class="section-card" data-phase="questions" data-status="pending">
+<!-- Design Decisions (hidden for v2 plans — slice cards carry their own questions) -->
+{{if .IsV2}}{{else}}{{if .Questions}}{{renderZone .Questions}}{{else}}<details id="questions" class="section-card" data-phase="questions" data-status="pending">
   <summary><span>Design Decisions</span><span class="badge badge-pending" data-badge-for="questions">Pending</span></summary>
   <div class="section-body">
     <table class="q-table">
@@ -381,11 +381,11 @@ textarea::placeholder{color:var(--text-muted)}
       </tbody>
     </table>
   </div>
-</details>{{end}}
+</details>{{end}}{{end}}
 
-{{if .Critique}}
+{{if .IsV2}}{{else}}{{if .Critique}}
 {{renderZone .Critique}}
-{{end}}
+{{end}}{{end}}
 
 {{if .Preview}}
 {{renderZone .Preview}}

--- a/internal/plantmpl/templates/slice_card.gohtml
+++ b/internal/plantmpl/templates/slice_card.gohtml
@@ -4,7 +4,8 @@
     <span class="slice-name">{{.Title}}</span>
     {{if .Effort}}<span class="badge {{.EffortClass}}">{{.Effort}}</span>{{end}}
     {{if .Risk}}<span class="badge {{.RiskClass}}">{{.Risk}}</span>{{end}}
-    <span class="badge badge-pending" data-badge-for="slice-{{.Num}}">Pending</span>
+    {{if .ExecutionStatus}}<span class="badge {{.ExecutionStatusClass}} slice-exec-badge" title="Execution: {{.ExecutionStatus}}">{{.ExecutionStatusLabel}}</span>{{end}}
+    <span class="badge {{.ApprovalStatusClass}} slice-approval-badge" data-badge-for="slice-{{.Num}}">{{.ApprovalStatusLabel}}</span>
   </div>
   {{if .HasStructuredContent}}
   <div class="slice-field">{{if .What}}<div class="slice-field-label">What</div><div class="slice-field-value slice-md">{{.WhatHTML}}</div>{{end}}</div>
@@ -17,9 +18,39 @@
   {{if .Files}}<div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>{{.Files}}</code></div></div>{{end}}
   {{end}}
   {{if .Tests}}<div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-md slice-tests">{{.TestsHTML}}</div></div>{{end}}
+  {{if .CriticRevisions}}
+  <div class="slice-field slice-critic-revisions">
+    <div class="slice-field-label">Critic Revisions</div>
+    <div class="slice-field-value">
+      {{range .CriticRevisions}}
+      <div class="critic-revision">
+        <span class="badge {{$.CriticSeverityClass .Severity}} critic-revision-badge">{{.Severity}}</span>
+        <span class="critic-revision-source">{{.Source}}</span>
+        <span class="critic-revision-summary">{{.Summary}}</span>
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+  {{if .Questions}}
+  <div class="slice-field slice-questions">
+    <div class="slice-field-label">Open Questions</div>
+    <div class="slice-field-value">
+      {{range .Questions}}
+      <div class="question-block slice-question-block">
+        <p>{{.Text}}</p>
+        <textarea
+          data-section="{{$.SliceQuestionSectionKey .ID}}"
+          data-comment-for="{{$.SliceQuestionSectionKey .ID}}"
+          placeholder="Answer question {{.ID}}...">{{.Answer}}</textarea>
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
   <div class="slice-deps">Dependencies: {{.DepsLabel}}</div>
   <div class="approval-row">
-    <label><input type="checkbox" data-section="slice-{{.Num}}" data-action="approve"> Approve slice</label>
+    <label><input type="checkbox" data-section="slice-{{.Num}}" data-action="approve"{{if eq .ApprovalStatus "approved"}} checked{{end}}> Approve slice</label>
     <textarea data-section="slice-{{.Num}}" data-comment-for="slice-{{.Num}}" placeholder="Comments on slice {{.Num}}..."></textarea>
   </div>
 </div>

--- a/internal/plantmpl/templates/slice_card.gohtml
+++ b/internal/plantmpl/templates/slice_card.gohtml
@@ -7,16 +7,16 @@
     <span class="badge badge-pending" data-badge-for="slice-{{.Num}}">Pending</span>
   </div>
   {{if .HasStructuredContent}}
-  <div class="slice-field">{{if .What}}<div class="slice-field-label">What</div><div class="slice-field-value" data-markdown="">{{.What}}</div>{{end}}</div>
-  {{if .Why}}<div class="slice-field"><div class="slice-field-label">Why</div><div class="slice-field-value" data-markdown="">{{.Why}}</div></div>{{end}}
+  <div class="slice-field">{{if .What}}<div class="slice-field-label">What</div><div class="slice-field-value slice-md">{{.WhatHTML}}</div>{{end}}</div>
+  {{if .Why}}<div class="slice-field"><div class="slice-field-label">Why</div><div class="slice-field-value slice-md">{{.WhyHTML}}</div></div>{{end}}
   {{if .Files}}<div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>{{.Files}}</code></div></div>{{end}}
-  {{if .DoneWhen}}<div class="slice-field"><div class="slice-field-label">Done when</div><ul class="slice-done-list">{{range .DoneWhen}}<li data-markdown="">{{.}}</li>{{end}}</ul></div>{{end}}
+  {{if .DoneWhen}}<div class="slice-field"><div class="slice-field-label">Done when</div><ul class="slice-done-list">{{range .DoneWhen}}<li>{{.}}</li>{{end}}</ul></div>{{end}}
   {{else}}
   {{if .ID}}<div class="slice-meta"><span>{{.ID}}</span></div>{{end}}
-  {{if .Description}}<div class="slice-field"><div class="slice-field-value" data-markdown="">{{.Description}}</div></div>{{end}}
+  {{if .Description}}<div class="slice-field"><div class="slice-field-value slice-md">{{.DescriptionHTML}}</div></div>{{end}}
   {{if .Files}}<div class="slice-field"><div class="slice-field-label">Files</div><div class="slice-field-value"><code>{{.Files}}</code></div></div>{{end}}
   {{end}}
-  {{if .Tests}}<div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-tests" data-markdown="">{{.Tests}}</div></div>{{end}}
+  {{if .Tests}}<div class="slice-field"><div class="slice-field-label">Test Strategy</div><div class="slice-field-value slice-md slice-tests">{{.TestsHTML}}</div></div>{{end}}
   <div class="slice-deps">Dependencies: {{.DepsLabel}}</div>
   <div class="approval-row">
     <label><input type="checkbox" data-section="slice-{{.Num}}" data-action="approve"> Approve slice</label>

--- a/internal/planyaml/schema.go
+++ b/internal/planyaml/schema.go
@@ -19,7 +19,7 @@ type PlanMeta struct {
 	Title       string `yaml:"title"`
 	Description string `yaml:"description"`
 	CreatedAt   string `yaml:"created_at"`
-	Status      string `yaml:"status"` // draft | review | finalized
+	Status      string `yaml:"status"` // draft | review | finalized | active | completed
 	CreatedBy   string `yaml:"created_by,omitempty"`
 	Version     int    `yaml:"version"`
 }
@@ -35,7 +35,23 @@ type PlanDesign struct {
 }
 
 // PlanSlice is a vertical delivery slice with metadata for effort,
-// risk, dependencies, and human approval.
+// risk, dependencies, and human approval. V2 adds slice-local lifecycle
+// states, questions, and critic revisions so each slice is an independently
+// reviewable executable spec card.
+//
+// Section-naming contract for plan_feedback (load-bearing — slice-4 extends
+// validSectionRe to accept the new pattern):
+//
+//	slice-<num>                        — slice-level approval/state
+//	slice-<num>-question-<question-id> — slice-local question answer
+//
+// Global sections ("design", "questions", existing keys) are unchanged.
+// The UNIQUE(plan_id, section, action, question_id) constraint in
+// internal/db/plan_feedback.go already accommodates these formats; slice-4
+// extends cmd/htmlgraph/api_plans.go validSectionRe to accept the new pattern.
+//
+// Agents should write multiline what/why/tests fields using YAML literal
+// blocks (|) for Markdown-capable content — see the planning skill for examples.
 type PlanSlice struct {
 	ID        string   `yaml:"id"`
 	FeatureID string   `yaml:"feature_id,omitempty"` // populated after plan finalize
@@ -51,6 +67,37 @@ type PlanSlice struct {
 	Tests     string   `yaml:"tests"`
 	Approved  bool     `yaml:"approved"`
 	Comment   string   `yaml:"comment"`
+
+	// V2 lifecycle fields (additive — legacy plans omit these and remain valid).
+	ApprovalStatus  string `yaml:"approval_status,omitempty"`  // pending | approved | rejected | changes_requested
+	ExecutionStatus string `yaml:"execution_status,omitempty"` // not_started | promoted | in_progress | done | blocked | superseded
+
+	// V2 slice-local spec fields.
+	Questions       []SliceQuestion  `yaml:"questions,omitempty"`        // slice-local open questions
+	CriticRevisions []CriticRevision `yaml:"critic_revisions,omitempty"` // critic feedback specific to this slice
+}
+
+// SliceQuestion is an open question scoped to a single slice. Unlike plan-level
+// PlanQuestion, it is lightweight (no options list) — it captures the question
+// text and an optional freeform answer.
+//
+// The section key for plan_feedback responses is:
+//
+//	slice-<num>-question-<id>
+type SliceQuestion struct {
+	ID     string `yaml:"id"`
+	Text   string `yaml:"text"`
+	Answer string `yaml:"answer,omitempty"` // freeform answer; empty = unanswered
+}
+
+// CriticRevision records a critic's feedback item scoped to a specific slice.
+// Source identifies the reviewer (e.g. "haiku", "opus"), Severity is a
+// free-form label (e.g. "HIGH", "LOW", "DANGER"), and Summary is a
+// one-line description of the finding.
+type CriticRevision struct {
+	Source   string `yaml:"source"`
+	Severity string `yaml:"severity"`
+	Summary  string `yaml:"summary"`
 }
 
 // PlanQuestion is an open design question with options and an optional answer.

--- a/internal/planyaml/schema_test.go
+++ b/internal/planyaml/schema_test.go
@@ -506,3 +506,206 @@ func TestEmptySlicesAndQuestions_Marshal(t *testing.T) {
 		t.Errorf("Expected 'questions: []' in output, got:\n%s", content)
 	}
 }
+
+// ---- v2 slice-card schema tests ----
+
+// v2PlanYAML is a YAML string that exercises all v2 slice-card fields:
+// slice-local questions, critic_revisions, approval_status, execution_status,
+// and plan status='active'.
+const v2PlanYAML = `
+meta:
+  id: plan-v2yaml01
+  title: V2 Schema Parse Test
+  status: active
+  created_at: "2026-04-28"
+  version: 1
+design:
+  problem: Testing v2 schema parsing.
+  goals:
+    - Parse slice-local fields
+  constraints:
+    - Additive only
+  approved: false
+  comment: ""
+slices:
+  - num: 1
+    title: First slice
+    what: |
+      Build the slice-card schema with Markdown support.
+    why: |
+      The v2 model needs independently reviewable slice specs.
+    files:
+      - internal/planyaml/schema.go
+    deps: []
+    done_when:
+      - Tests pass
+    effort: S
+    risk: Low
+    tests: |
+      Unit: struct fields round-trip through YAML
+    approved: false
+    comment: ""
+    approval_status: approved
+    execution_status: done
+    questions:
+      - id: sq-1
+        text: Should we use interface{}?
+        answer: "no"
+    critic_revisions:
+      - source: haiku
+        severity: LOW
+        summary: Minor style nit about variable naming.
+  - num: 2
+    title: Second slice
+    what: Integrate the schema into the validator.
+    why: Validation needs the new fields.
+    files:
+      - internal/planyaml/validate.go
+    deps:
+      - 1
+    done_when:
+      - Validation tests pass
+    effort: M
+    risk: Med
+    tests: Integration test for validator
+    approved: false
+    comment: ""
+    approval_status: pending
+    execution_status: not_started
+    questions: []
+    critic_revisions: []
+questions: []
+`
+
+func TestV2Schema_ParseSliceLocalFields(t *testing.T) {
+	var plan PlanYAML
+	if err := yaml.Unmarshal([]byte(v2PlanYAML), &plan); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	// Meta
+	if plan.Meta.Status != "active" {
+		t.Errorf("Meta.Status = %q, want %q", plan.Meta.Status, "active")
+	}
+
+	// Slice count
+	if len(plan.Slices) != 2 {
+		t.Fatalf("Slices len = %d, want 2", len(plan.Slices))
+	}
+
+	s0 := plan.Slices[0]
+
+	// Lifecycle states
+	if s0.ApprovalStatus != "approved" {
+		t.Errorf("Slices[0].ApprovalStatus = %q, want %q", s0.ApprovalStatus, "approved")
+	}
+	if s0.ExecutionStatus != "done" {
+		t.Errorf("Slices[0].ExecutionStatus = %q, want %q", s0.ExecutionStatus, "done")
+	}
+
+	// Slice-local questions
+	if len(s0.Questions) != 1 {
+		t.Fatalf("Slices[0].Questions len = %d, want 1", len(s0.Questions))
+	}
+	if s0.Questions[0].ID != "sq-1" {
+		t.Errorf("Slices[0].Questions[0].ID = %q, want %q", s0.Questions[0].ID, "sq-1")
+	}
+	if s0.Questions[0].Text != "Should we use interface{}?" {
+		t.Errorf("Slices[0].Questions[0].Text mismatch")
+	}
+
+	// Critic revisions
+	if len(s0.CriticRevisions) != 1 {
+		t.Fatalf("Slices[0].CriticRevisions len = %d, want 1", len(s0.CriticRevisions))
+	}
+	cr := s0.CriticRevisions[0]
+	if cr.Source != "haiku" {
+		t.Errorf("CriticRevisions[0].Source = %q, want %q", cr.Source, "haiku")
+	}
+	if cr.Severity != "LOW" {
+		t.Errorf("CriticRevisions[0].Severity = %q, want %q", cr.Severity, "LOW")
+	}
+	if cr.Summary != "Minor style nit about variable naming." {
+		t.Errorf("CriticRevisions[0].Summary mismatch")
+	}
+
+	s1 := plan.Slices[1]
+	if s1.ApprovalStatus != "pending" {
+		t.Errorf("Slices[1].ApprovalStatus = %q, want %q", s1.ApprovalStatus, "pending")
+	}
+	if s1.ExecutionStatus != "not_started" {
+		t.Errorf("Slices[1].ExecutionStatus = %q, want %q", s1.ExecutionStatus, "not_started")
+	}
+	if len(s1.Questions) != 0 {
+		t.Errorf("Slices[1].Questions len = %d, want 0", len(s1.Questions))
+	}
+	if len(s1.CriticRevisions) != 0 {
+		t.Errorf("Slices[1].CriticRevisions len = %d, want 0", len(s1.CriticRevisions))
+	}
+}
+
+func TestV2Schema_RoundTrip(t *testing.T) {
+	// Verify that v2 fields survive a marshal/unmarshal round-trip.
+	original := &PlanYAML{
+		Meta: PlanMeta{
+			ID:     "plan-v2rt001",
+			Title:  "Round Trip",
+			Status: "active",
+		},
+		Design: PlanDesign{
+			Problem:     "Round trip test.",
+			Goals:       []string{"Goal"},
+			Constraints: []string{"Constraint"},
+		},
+		Slices: []PlanSlice{
+			{
+				Num:             1,
+				Title:           "Slice one",
+				What:            "What",
+				Why:             "Why",
+				Files:           []string{"main.go"},
+				DoneWhen:        []string{"done"},
+				Tests:           "test",
+				Effort:          "S",
+				Risk:            "Low",
+				Deps:            []int{},
+				ApprovalStatus:  "changes_requested",
+				ExecutionStatus: "in_progress",
+				Questions: []SliceQuestion{
+					{ID: "sq-rt", Text: "Round trip question?"},
+				},
+				CriticRevisions: []CriticRevision{
+					{Source: "opus", Severity: "HIGH", Summary: "Critical issue found."},
+				},
+			},
+		},
+		Questions: []PlanQuestion{},
+	}
+
+	data, err := yaml.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var loaded PlanYAML
+	if err := yaml.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if len(loaded.Slices) != 1 {
+		t.Fatalf("Slices len = %d, want 1", len(loaded.Slices))
+	}
+	s := loaded.Slices[0]
+	if s.ApprovalStatus != "changes_requested" {
+		t.Errorf("ApprovalStatus = %q, want %q", s.ApprovalStatus, "changes_requested")
+	}
+	if s.ExecutionStatus != "in_progress" {
+		t.Errorf("ExecutionStatus = %q, want %q", s.ExecutionStatus, "in_progress")
+	}
+	if len(s.Questions) != 1 || s.Questions[0].ID != "sq-rt" {
+		t.Errorf("Questions not round-tripped correctly: %+v", s.Questions)
+	}
+	if len(s.CriticRevisions) != 1 || s.CriticRevisions[0].Source != "opus" {
+		t.Errorf("CriticRevisions not round-tripped correctly: %+v", s.CriticRevisions)
+	}
+}

--- a/internal/planyaml/validate.go
+++ b/internal/planyaml/validate.go
@@ -4,6 +4,10 @@ import "fmt"
 
 // Validate checks a PlanYAML for schema errors. Returns a list of error
 // strings. Empty list means the plan is valid.
+//
+// V2 slice-card fields (ApprovalStatus, ExecutionStatus, Questions,
+// CriticRevisions) are additive — legacy plans that omit them validate
+// without errors.
 func Validate(plan *PlanYAML) []string {
 	var errs []string
 	if plan.Meta.ID == "" {
@@ -13,9 +17,9 @@ func Validate(plan *PlanYAML) []string {
 		errs = append(errs, "meta.title is required")
 	}
 	switch plan.Meta.Status {
-	case "draft", "review", "finalized":
+	case "draft", "review", "finalized", "active", "completed":
 	default:
-		errs = append(errs, fmt.Sprintf("meta.status %q must be draft|review|finalized", plan.Meta.Status))
+		errs = append(errs, fmt.Sprintf("meta.status %q must be draft|review|finalized|active|completed", plan.Meta.Status))
 	}
 	if plan.Design.Problem == "" {
 		errs = append(errs, "design.problem is required")
@@ -26,7 +30,11 @@ func Validate(plan *PlanYAML) []string {
 	if len(plan.Design.Constraints) == 0 {
 		errs = append(errs, "design.constraints must have at least 1 entry")
 	}
+
+	// Collect slice nums and IDs for duplicate/dep checks.
 	nums := map[int]bool{}
+	ids := map[string]bool{}
+
 	for i, s := range plan.Slices {
 		prefix := fmt.Sprintf("slices[%d]", i)
 		if s.What == "" {
@@ -63,7 +71,55 @@ func Validate(plan *PlanYAML) []string {
 				errs = append(errs, fmt.Sprintf("%s.deps: self-reference %d", prefix, d))
 			}
 		}
+
+		// Duplicate slice IDs (non-empty IDs only).
+		if s.ID != "" {
+			if ids[s.ID] {
+				errs = append(errs, fmt.Sprintf("%s.id %q is duplicate", prefix, s.ID))
+			}
+			ids[s.ID] = true
+		}
+
+		// V2: approval_status enum (empty = unset, valid for legacy plans).
+		switch s.ApprovalStatus {
+		case "", "pending", "approved", "rejected", "changes_requested":
+		default:
+			errs = append(errs, fmt.Sprintf("%s.approval_status %q must be pending|approved|rejected|changes_requested", prefix, s.ApprovalStatus))
+		}
+
+		// V2: execution_status enum (empty = unset, valid for legacy plans).
+		switch s.ExecutionStatus {
+		case "", "not_started", "promoted", "in_progress", "done", "blocked", "superseded":
+		default:
+			errs = append(errs, fmt.Sprintf("%s.execution_status %q must be not_started|promoted|in_progress|done|blocked|superseded", prefix, s.ExecutionStatus))
+		}
+
+		// V2: slice-local questions — reject duplicate IDs within the same slice.
+		qIDs := map[string]bool{}
+		for j, q := range s.Questions {
+			if q.ID != "" {
+				if qIDs[q.ID] {
+					errs = append(errs, fmt.Sprintf("%s.questions[%d].id %q is duplicate within slice", prefix, j, q.ID))
+				}
+				qIDs[q.ID] = true
+			}
+		}
+
+		// V2: critic_revisions — require source, severity, summary.
+		for j, cr := range s.CriticRevisions {
+			crPrefix := fmt.Sprintf("%s.critic_revisions[%d]", prefix, j)
+			if cr.Source == "" {
+				errs = append(errs, crPrefix+".source is required")
+			}
+			if cr.Severity == "" {
+				errs = append(errs, crPrefix+".severity is required")
+			}
+			if cr.Summary == "" {
+				errs = append(errs, crPrefix+".summary is required")
+			}
+		}
 	}
+
 	// Check dep references after collecting all nums.
 	for i, s := range plan.Slices {
 		for _, d := range s.Deps {
@@ -72,6 +128,7 @@ func Validate(plan *PlanYAML) []string {
 			}
 		}
 	}
+
 	for i, q := range plan.Questions {
 		prefix := fmt.Sprintf("questions[%d]", i)
 		if q.Text == "" {

--- a/internal/planyaml/validate_test.go
+++ b/internal/planyaml/validate_test.go
@@ -295,3 +295,238 @@ func assertContainsError(t *testing.T, errs []string, substr string) {
 	}
 	t.Errorf("expected an error containing %q, got: %v", substr, errs)
 }
+
+// ---- v2 slice-card tests ----
+
+// validV2Plan returns a fully-populated valid v2 plan with slice-local
+// questions, critic_revisions, and lifecycle states.
+func validV2Plan() *PlanYAML {
+	return &PlanYAML{
+		Meta: PlanMeta{
+			ID:     "plan-v2test01",
+			Title:  "V2 Slice-Card Test Plan",
+			Status: "active",
+		},
+		Design: PlanDesign{
+			Problem:     "A real problem to solve.",
+			Goals:       []string{"Goal 1"},
+			Constraints: []string{"Constraint 1"},
+		},
+		Slices: []PlanSlice{
+			{
+				Num:             1,
+				What:            "Build the thing.",
+				Why:             "Because it matters.",
+				Files:           []string{"internal/foo/bar.go"},
+				DoneWhen:        []string{"Tests pass"},
+				Tests:           "Unit: it works",
+				Effort:          "S",
+				Risk:            "Low",
+				Deps:            []int{},
+				ApprovalStatus:  "approved",
+				ExecutionStatus: "done",
+				Questions: []SliceQuestion{
+					{
+						ID:   "sq-1",
+						Text: "Should we use interface{}?",
+					},
+				},
+				CriticRevisions: []CriticRevision{
+					{
+						Source:   "haiku",
+						Severity: "LOW",
+						Summary:  "Minor style nit.",
+					},
+				},
+			},
+			{
+				Num:             2,
+				What:            "Integrate the thing.",
+				Why:             "Because end-to-end matters.",
+				Files:           []string{"internal/foo/baz.go"},
+				DoneWhen:        []string{"Integration test passes"},
+				Tests:           "Integration: full flow works",
+				Effort:          "M",
+				Risk:            "Med",
+				Deps:            []int{1},
+				ApprovalStatus:  "pending",
+				ExecutionStatus: "not_started",
+				Questions:       []SliceQuestion{},
+				CriticRevisions: []CriticRevision{},
+			},
+		},
+		Questions: []PlanQuestion{
+			{
+				Text:        "Which approach?",
+				Description: "We need to decide between A and B.",
+				Recommended: "opt-a",
+				Options: []QuestionOption{
+					{Key: "opt-a", Label: "Option A"},
+					{Key: "opt-b", Label: "Option B"},
+				},
+			},
+		},
+	}
+}
+
+func TestValidate_V2Plan_Valid(t *testing.T) {
+	plan := validV2Plan()
+	errs := Validate(plan)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for valid v2 plan, got: %v", errs)
+	}
+}
+
+func TestValidate_MetaStatusActive(t *testing.T) {
+	plan := validPlan()
+	plan.Meta.Status = "active"
+	errs := Validate(plan)
+	for _, e := range errs {
+		if strings.Contains(e, "meta.status") {
+			t.Errorf("status 'active' should be valid, got error: %s", e)
+		}
+	}
+}
+
+func TestValidate_MetaStatusCompleted(t *testing.T) {
+	plan := validPlan()
+	plan.Meta.Status = "completed"
+	errs := Validate(plan)
+	for _, e := range errs {
+		if strings.Contains(e, "meta.status") {
+			t.Errorf("status 'completed' should be valid, got error: %s", e)
+		}
+	}
+}
+
+func TestValidate_AllMetaStatuses(t *testing.T) {
+	for _, status := range []string{"draft", "review", "finalized", "active", "completed"} {
+		plan := validPlan()
+		plan.Meta.Status = status
+		errs := Validate(plan)
+		for _, e := range errs {
+			if strings.Contains(e, "meta.status") {
+				t.Errorf("status %q should be valid, got error: %s", status, e)
+			}
+		}
+	}
+}
+
+func TestValidate_DuplicateSliceIDs(t *testing.T) {
+	plan := validPlan()
+	plan.Slices[0].ID = "feat-duplicate"
+	plan.Slices[1].ID = "feat-duplicate"
+	errs := Validate(plan)
+	assertContainsError(t, errs, "duplicate")
+}
+
+func TestValidate_DuplicateQuestionIDsWithinSlice(t *testing.T) {
+	plan := validV2Plan()
+	plan.Slices[0].Questions = []SliceQuestion{
+		{ID: "sq-dup", Text: "First question"},
+		{ID: "sq-dup", Text: "Second question"},
+	}
+	errs := Validate(plan)
+	assertContainsError(t, errs, "duplicate")
+}
+
+func TestValidate_CriticRevisionMissingSource(t *testing.T) {
+	plan := validV2Plan()
+	plan.Slices[0].CriticRevisions = []CriticRevision{
+		{Source: "", Severity: "HIGH", Summary: "A summary"},
+	}
+	errs := Validate(plan)
+	assertContainsError(t, errs, "source")
+}
+
+func TestValidate_CriticRevisionMissingSeverity(t *testing.T) {
+	plan := validV2Plan()
+	plan.Slices[0].CriticRevisions = []CriticRevision{
+		{Source: "haiku", Severity: "", Summary: "A summary"},
+	}
+	errs := Validate(plan)
+	assertContainsError(t, errs, "severity")
+}
+
+func TestValidate_CriticRevisionMissingSummary(t *testing.T) {
+	plan := validV2Plan()
+	plan.Slices[0].CriticRevisions = []CriticRevision{
+		{Source: "haiku", Severity: "HIGH", Summary: ""},
+	}
+	errs := Validate(plan)
+	assertContainsError(t, errs, "summary")
+}
+
+func TestValidate_InvalidApprovalStatus(t *testing.T) {
+	plan := validV2Plan()
+	plan.Slices[0].ApprovalStatus = "unknown-status"
+	errs := Validate(plan)
+	assertContainsError(t, errs, "approval_status")
+}
+
+func TestValidate_ValidApprovalStatuses(t *testing.T) {
+	for _, status := range []string{"", "pending", "approved", "rejected", "changes_requested"} {
+		plan := validV2Plan()
+		plan.Slices[0].ApprovalStatus = status
+		errs := Validate(plan)
+		for _, e := range errs {
+			if strings.Contains(e, "approval_status") {
+				t.Errorf("approval_status %q should be valid, got error: %s", status, e)
+			}
+		}
+	}
+}
+
+func TestValidate_InvalidExecutionStatus(t *testing.T) {
+	plan := validV2Plan()
+	plan.Slices[0].ExecutionStatus = "running"
+	errs := Validate(plan)
+	assertContainsError(t, errs, "execution_status")
+}
+
+func TestValidate_ValidExecutionStatuses(t *testing.T) {
+	for _, status := range []string{"", "not_started", "promoted", "in_progress", "done", "blocked", "superseded"} {
+		plan := validV2Plan()
+		plan.Slices[0].ExecutionStatus = status
+		errs := Validate(plan)
+		for _, e := range errs {
+			if strings.Contains(e, "execution_status") {
+				t.Errorf("execution_status %q should be valid, got error: %s", status, e)
+			}
+		}
+	}
+}
+
+func TestValidate_LegacyPlanRegression(t *testing.T) {
+	// A legacy plan (no v2 fields) should still validate without errors.
+	plan := &PlanYAML{
+		Meta: PlanMeta{
+			ID:     "plan-legacy01",
+			Title:  "Legacy Plan",
+			Status: "draft",
+		},
+		Design: PlanDesign{
+			Problem:     "An old problem.",
+			Goals:       []string{"Legacy goal"},
+			Constraints: []string{"Legacy constraint"},
+		},
+		Slices: []PlanSlice{
+			{
+				Num:      1,
+				What:     "Do the legacy thing.",
+				Why:      "Because legacy.",
+				Files:    []string{"internal/legacy/foo.go"},
+				DoneWhen: []string{"It works"},
+				Tests:    "Manual: smoke test",
+				Effort:   "M",
+				Risk:     "High",
+				Deps:     []int{},
+			},
+		},
+		Questions: []PlanQuestion{},
+	}
+	errs := Validate(plan)
+	if len(errs) != 0 {
+		t.Errorf("legacy plan should validate without errors, got: %v", errs)
+	}
+}

--- a/internal/storage/dbpath.go
+++ b/internal/storage/dbpath.go
@@ -71,25 +71,58 @@ func EnsureDBDir(dbPath string) error {
 	return os.MkdirAll(filepath.Dir(dbPath), 0o755)
 }
 
-// WarnIfLegacyDBPresent checks whether any legacy project-local SQLite
-// files are still present and writes a human-readable warning to w for
-// each one found. It never deletes files or blocks startup.
+// CleanLegacyDBIfSafe checks for legacy project-local SQLite files and
+// handles them based on whether the canonical cache DB exists and is non-empty:
+//
+//   - If the canonical DB exists and has Size() > 0 (migration is complete):
+//     silently os.Remove each legacy file found. Also removes the empty
+//     .htmlgraph/.db/ directory if present and empty (using os.Remove, which
+//     will not remove a non-empty directory). Removal errors are silently
+//     swallowed — if a file cannot be removed, the warn branch fires instead
+//     for that specific file.
+//
+//   - Otherwise (canonical DB missing or empty): writes a human-readable
+//     warning to w for each legacy file found, so the user doesn't
+//     inadvertently delete their only copy. The size is formatted as %.1f MB
+//     so a 430 KB file shows as "0.4 MB" rather than "0 MB".
 //
 // Wire from one place that runs early in every binary path — the root
 // cobra command's PersistentPreRun is the right location.
-func WarnIfLegacyDBPresent(projectDir string, w io.Writer) {
+func CleanLegacyDBIfSafe(projectDir string, w io.Writer) {
+	canonicalPath, err := CanonicalDBPath(projectDir)
+	canonicalReady := false
+	if err == nil {
+		if ci, statErr := os.Stat(canonicalPath); statErr == nil && ci.Size() > 0 {
+			canonicalReady = true
+		}
+	}
+
+	dbDir := filepath.Join(projectDir, ".htmlgraph", ".db")
+
 	for _, p := range LegacyProjectDBPaths(projectDir) {
-		info, err := os.Stat(p)
-		if err != nil {
+		info, statErr := os.Stat(p)
+		if statErr != nil {
 			continue
 		}
-		rel, err := filepath.Rel(projectDir, p)
-		if err != nil {
+		if canonicalReady {
+			if removeErr := os.Remove(p); removeErr == nil {
+				continue
+			}
+			// Fall through to warn if removal fails.
+		}
+		rel, relErr := filepath.Rel(projectDir, p)
+		if relErr != nil {
 			rel = p
 		}
 		mb := float64(info.Size()) / (1024 * 1024)
 		fmt.Fprintf(w,
-			"[htmlgraph] WARNING: legacy SQLite file at %s (%.0f MB) is unused — DB now lives in the user cache dir. You can delete: %s\n",
+			"[htmlgraph] WARNING: legacy SQLite file at %s (%.1f MB) is unused — DB now lives in the user cache dir. You can delete: %s\n",
 			rel, mb, p)
+	}
+
+	// Remove the empty .db/ subdirectory if the canonical DB is ready.
+	if canonicalReady {
+		// os.Remove succeeds only on empty directories; non-empty ones are left alone.
+		_ = os.Remove(dbDir)
 	}
 }

--- a/internal/storage/dbpath.go
+++ b/internal/storage/dbpath.go
@@ -39,6 +39,14 @@ func CanonicalDBPath(projectDir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve project dir: %w", err)
 	}
+	// Resolve symlinks so the same checkout reached via different paths
+	// (e.g. macOS /var → /private/var, or a symlinked workspace) hashes
+	// to one cache key. Falling back to the abs path when EvalSymlinks
+	// fails (broken link, permission error) keeps the helper usable on
+	// non-existent dirs that callers will create later (init flow).
+	if resolved, evalErr := filepath.EvalSymlinks(abs); evalErr == nil {
+		abs = resolved
+	}
 	cache, err := os.UserCacheDir()
 	if err != nil {
 		return "", fmt.Errorf("locate user cache dir: %w", err)

--- a/internal/storage/dbpath_test.go
+++ b/internal/storage/dbpath_test.go
@@ -228,3 +228,207 @@ func TestLegacyProjectDBPaths(t *testing.T) {
 		t.Errorf("path[1]: got %s, want %s", paths[1], want1)
 	}
 }
+
+// TestCleanLegacyDBIfSafe_DeletesWhenCanonicalReady verifies that when the
+// canonical DB exists and is non-empty, the legacy file is silently deleted
+// and no output is written.
+func TestCleanLegacyDBIfSafe_DeletesWhenCanonicalReady(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Set up canonical DB (non-empty).
+	canonicalPath := filepath.Join(projectDir, "canonical.db")
+	if err := os.WriteFile(canonicalPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write canonical db: %v", err)
+	}
+	t.Setenv("HTMLGRAPH_DB_PATH", canonicalPath)
+
+	// Set up legacy file.
+	legacyDir := filepath.Join(projectDir, ".htmlgraph")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatalf("mkdir .htmlgraph: %v", err)
+	}
+	legacyFile := filepath.Join(legacyDir, "htmlgraph.db")
+	if err := os.WriteFile(legacyFile, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write legacy db: %v", err)
+	}
+
+	var buf strings.Builder
+	storage.CleanLegacyDBIfSafe(projectDir, &buf)
+
+	// No output expected.
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got: %q", buf.String())
+	}
+
+	// Legacy file must be gone.
+	if _, err := os.Stat(legacyFile); !os.IsNotExist(err) {
+		t.Errorf("expected legacy file to be removed, but it still exists")
+	}
+}
+
+// TestCleanLegacyDBIfSafe_WarnsWhenCanonicalMissing verifies that when the
+// canonical DB does not exist, the legacy file is NOT deleted and a warning
+// with %.1f MB formatting is written.
+func TestCleanLegacyDBIfSafe_WarnsWhenCanonicalMissing(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Point canonical DB to a path that does not exist.
+	canonicalPath := filepath.Join(projectDir, "nonexistent-canonical.db")
+	t.Setenv("HTMLGRAPH_DB_PATH", canonicalPath)
+
+	// Set up legacy file (~430 KB so it shows as 0.4 MB, not 0 MB).
+	legacyDir := filepath.Join(projectDir, ".htmlgraph")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatalf("mkdir .htmlgraph: %v", err)
+	}
+	legacyFile := filepath.Join(legacyDir, "htmlgraph.db")
+	content := make([]byte, 440*1024) // 440 KB
+	if err := os.WriteFile(legacyFile, content, 0o600); err != nil {
+		t.Fatalf("write legacy db: %v", err)
+	}
+
+	var buf strings.Builder
+	storage.CleanLegacyDBIfSafe(projectDir, &buf)
+
+	output := buf.String()
+	if output == "" {
+		t.Error("expected warning output, got nothing")
+	}
+	// Must contain the decimal MB format — "0.4" not "0 MB".
+	if !strings.Contains(output, "0.4") {
+		t.Errorf("expected '0.4' in MB display, got: %q", output)
+	}
+	if strings.Contains(output, "0 MB") {
+		t.Errorf("must not display '0 MB' for a non-zero file; got: %q", output)
+	}
+
+	// Legacy file must still be present.
+	if _, err := os.Stat(legacyFile); err != nil {
+		t.Errorf("expected legacy file to remain, but got: %v", err)
+	}
+}
+
+// TestCleanLegacyDBIfSafe_WarnsWhenCanonicalEmpty verifies that when the
+// canonical DB file exists but is empty (Size() == 0), the legacy file is
+// NOT deleted and a warning is written.
+func TestCleanLegacyDBIfSafe_WarnsWhenCanonicalEmpty(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Set up canonical DB that is empty (size 0).
+	canonicalPath := filepath.Join(projectDir, "canonical.db")
+	if err := os.WriteFile(canonicalPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("write empty canonical db: %v", err)
+	}
+	t.Setenv("HTMLGRAPH_DB_PATH", canonicalPath)
+
+	// Set up legacy file.
+	legacyDir := filepath.Join(projectDir, ".htmlgraph")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatalf("mkdir .htmlgraph: %v", err)
+	}
+	legacyFile := filepath.Join(legacyDir, "htmlgraph.db")
+	if err := os.WriteFile(legacyFile, []byte("stale data"), 0o600); err != nil {
+		t.Fatalf("write legacy db: %v", err)
+	}
+
+	var buf strings.Builder
+	storage.CleanLegacyDBIfSafe(projectDir, &buf)
+
+	output := buf.String()
+	if output == "" {
+		t.Error("expected warning output when canonical DB is empty, got nothing")
+	}
+
+	// Legacy file must still be present.
+	if _, err := os.Stat(legacyFile); err != nil {
+		t.Errorf("expected legacy file to remain, but got: %v", err)
+	}
+}
+
+// TestCleanLegacyDBIfSafe_RemovesEmptyDBDir verifies that the empty
+// .htmlgraph/.db/ directory is removed when the canonical DB is non-empty.
+func TestCleanLegacyDBIfSafe_RemovesEmptyDBDir(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Set up canonical DB (non-empty).
+	canonicalPath := filepath.Join(projectDir, "canonical.db")
+	if err := os.WriteFile(canonicalPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write canonical db: %v", err)
+	}
+	t.Setenv("HTMLGRAPH_DB_PATH", canonicalPath)
+
+	// Create empty .htmlgraph/.db/ directory (no legacy DB file inside).
+	dbDir := filepath.Join(projectDir, ".htmlgraph", ".db")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatalf("mkdir .htmlgraph/.db: %v", err)
+	}
+
+	var buf strings.Builder
+	storage.CleanLegacyDBIfSafe(projectDir, &buf)
+
+	// No output expected.
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got: %q", buf.String())
+	}
+
+	// Empty .db/ directory must be removed.
+	if _, err := os.Stat(dbDir); !os.IsNotExist(err) {
+		t.Errorf("expected empty .db/ dir to be removed, but it still exists")
+	}
+}
+
+// TestCleanLegacyDBIfSafe_LeavesNonEmptyDBDir verifies that a non-empty
+// .htmlgraph/.db/ directory (containing unrelated files) is NOT removed.
+func TestCleanLegacyDBIfSafe_LeavesNonEmptyDBDir(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Set up canonical DB (non-empty).
+	canonicalPath := filepath.Join(projectDir, "canonical.db")
+	if err := os.WriteFile(canonicalPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write canonical db: %v", err)
+	}
+	t.Setenv("HTMLGRAPH_DB_PATH", canonicalPath)
+
+	// Create .htmlgraph/.db/ with an unrelated file inside.
+	dbDir := filepath.Join(projectDir, ".htmlgraph", ".db")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatalf("mkdir .htmlgraph/.db: %v", err)
+	}
+	unrelated := filepath.Join(dbDir, "unrelated.txt")
+	if err := os.WriteFile(unrelated, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("write unrelated file: %v", err)
+	}
+
+	var buf strings.Builder
+	storage.CleanLegacyDBIfSafe(projectDir, &buf)
+
+	// Non-empty .db/ directory must still be present.
+	if _, err := os.Stat(dbDir); err != nil {
+		t.Errorf("expected non-empty .db/ dir to remain, but got: %v", err)
+	}
+	if _, err := os.Stat(unrelated); err != nil {
+		t.Errorf("expected unrelated file to remain, but got: %v", err)
+	}
+}
+
+// TestCleanLegacyDBIfSafe_NoLegacyFiles verifies that no-op behavior
+// (no output, no errors) when no legacy files are present.
+func TestCleanLegacyDBIfSafe_NoLegacyFiles(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Set up canonical DB (non-empty).
+	canonicalPath := filepath.Join(projectDir, "canonical.db")
+	if err := os.WriteFile(canonicalPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write canonical db: %v", err)
+	}
+	t.Setenv("HTMLGRAPH_DB_PATH", canonicalPath)
+
+	// No .htmlgraph/ directory or legacy files created.
+
+	var buf strings.Builder
+	storage.CleanLegacyDBIfSafe(projectDir, &buf)
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output when no legacy files exist, got: %q", buf.String())
+	}
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -318,6 +318,15 @@ func excludeHtmlgraphFromWorktree(worktreePath string, w io.Writer) {
 // no-op in tests to skip the subprocess fork. Defaults to the real impl.
 var reindexWorktreeFn = runReindexSubprocess
 
+// SetReindexFnForTest replaces reindexWorktreeFn for the duration of a test.
+// The previous function is returned so callers can restore it via defer.
+// Test-only helper; do not call from production code.
+func SetReindexFnForTest(fn func(worktreeDir string, w io.Writer)) func(string, io.Writer) {
+	prev := reindexWorktreeFn
+	reindexWorktreeFn = fn
+	return prev
+}
+
 // reindexWorktree runs `htmlgraph reindex` in the given worktree directory so
 // the worktree's SQLite cache is current before Claude launches. Best-effort:
 // failures are written to w but do not abort.

--- a/packages/codex-marketplace/.agents/plugins/htmlgraph/commands/git-commit.md
+++ b/packages/codex-marketplace/.agents/plugins/htmlgraph/commands/git-commit.md
@@ -29,8 +29,7 @@ Commit changes using Bash-copilot first, haiku-coder as fallback.
 ### Step 1: Analyze what to commit
 
 ```bash
-git diff --stat HEAD
-git status --short
+git diff --stat HEAD; git status --short
 ```
 
 Select source files to stage. Exclude `.htmlgraph/` directory unless explicitly requested.

--- a/packages/codex-marketplace/.agents/plugins/htmlgraph/skills/execute/SKILL.md
+++ b/packages/codex-marketplace/.agents/plugins/htmlgraph/skills/execute/SKILL.md
@@ -19,6 +19,17 @@ When running in a worktree, `HTMLGRAPH_PROJECT_DIR` is set automatically. All `h
 
 ---
 
+## Efficiency Rules (read before dispatching)
+
+Every tool call spends a turn. The goal is to dispatch the first subagent within **≤5 tool calls**. To hit that budget:
+
+1. **One call, not ten.** Use `htmlgraph execute-preview <trk-id> --format json` to get the track, linked features/bugs/plans, and current git state in a single invocation. Do not call `htmlgraph track show`, `htmlgraph feature show`, `htmlgraph plan show`, and `git status` separately before the first dispatch.
+2. **Batch git-state probes.** If execute-preview doesn't cover a probe you need, chain with `&&` in one Bash call — never one tool call per git subcommand.
+3. **Don't feature-show more than twice in a row.** If you find yourself calling `htmlgraph feature show` for every linked feature, stop and re-read the preview JSON — the status you need is already there.
+4. **Don't retry flag variants.** If a flag fails, check the skill for the real flag name before trying a second guess. This skill is validated by a build-time smoke test — prescribed flags are real.
+
+---
+
 ## Work Item Attribution (MANDATORY)
 
 Before dispatching any agents, verify attribution is set:
@@ -51,6 +62,12 @@ LOOP:
 
 This maximizes parallelism automatically. If 10 of 13 tasks are independent, all 10 run in the first dispatch — no artificial wave boundaries.
 
+Slices promoted via `htmlgraph plan promote-slice` from a still-active plan are dispatched through the same dependency-readiness loop — they appear as features linked to the track via `part_of` edges and are ready to dispatch as soon as their `blocked_by` deps are complete.
+
+### Incremental slice promotion
+
+When a track is executing a v2 plan, slices may be promoted one at a time rather than all at once. Each call to `htmlgraph plan promote-slice <plan-id> <num>` creates a `feat-XXX` linked to the track and marks the slice `execution_status=promoted`. That feature immediately appears in `htmlgraph execute-preview <trk-id>` and enters the dispatch loop. Dep-blocked slices stay in the `blocked` bucket until their dependencies complete, exactly like manually created features. No special handling is required — promoted slices are regular features from the executor's perspective.
+
 ---
 
 ## Step 1: Query Unblocked Tasks
@@ -72,14 +89,11 @@ If no tasks exist yet, create them from the plan (see `/htmlgraph:plan`).
 
 When executing features that originated from a plan, you must first resolve the track title, then create tasks with readable subject fields.
 
-**Resolve track title before dispatching:**
+**Resolve the track title in the same call that fetched everything else:**
 
-Before creating any tasks, resolve the track's human title by running:
-```
-Bash("htmlgraph track show <trk-id> --format json")
-```
+You already called `htmlgraph execute-preview <trk-id> --format json` in the first discovery step. The track's human title is `.track.title` in that payload — reuse it. Do not issue a second `htmlgraph track show` call just for the title.
 
-Extract the `.title` field. Use it (not the raw track ID) as the outer `Agent()` description when spawning the top-level coordinator:
+Use the title (not the raw track ID) as the outer `Agent()` description when spawning the top-level coordinator:
 
 ```
 Agent(description="Multi-Project MVP: execute plan", ...)  # ✓ GOOD
@@ -442,17 +456,13 @@ Status categories: **ready** (pending, no blockedBy) | **in_progress** | **block
 ## Cleanup After Completion
 
 ```bash
-# Prune all merged worktrees
-git worktree prune
+# Prune merged worktrees and confirm clean state in one call
+git worktree prune && git worktree list
 
-# Remove a specific worktree
-git worktree remove <path>
+# Remove a specific worktree and its branch (chain to avoid leaving orphans)
+git worktree remove <path> && git branch -D worktree-agent-XXXX
 
-# Remove stale branches
-git branch -D worktree-agent-XXXX
-
-# Confirm clean state + run quality gates
-git worktree list
+# Final quality gates
 go build ./... && go vet ./... && go test ./...
 ```
 

--- a/packages/codex-marketplace/.agents/plugins/htmlgraph/skills/plan/SKILL.md
+++ b/packages/codex-marketplace/.agents/plugins/htmlgraph/skills/plan/SKILL.md
@@ -1,25 +1,28 @@
 ---
 name: htmlgraph:plan
-description: Plan development work with interactive dashboard review before any code is written. Generates a YAML plan, populates slices and questions, runs dual-agent critique, opens dashboard for human review (approvals persist to SQLite), then reads finalized decisions to dispatch tasks. Use when asked to plan, create a development plan, or build a feature with design clarity first.
+description: Plan development work using v2 slice-card YAML. Generates a plan with slice cards as executable specs, runs critique, pauses for human review, then promotes approved slices to features. Use when asked to plan, create a development plan, or build a feature with design clarity first.
 ---
 
 # HtmlGraph Plan
 
-Use this skill when asked to plan development work, create a parallel execution plan, organize tasks for multi-agent execution, or build a feature with human review before implementation.
+Use this skill when asked to plan development work, organize tasks for multi-agent execution, or design a feature with human review before implementation.
 
-**Trigger keywords:** create plan, development plan, parallel plan, plan tasks, parallelize work, organize work, task breakdown, crispi, interactive plan, plan with review, design and build, plan this feature, review before building, generate plan, scaffold plan
+**Trigger keywords:** create plan, development plan, parallel plan, plan tasks, plan this feature, review before building, generate plan, scaffold plan, slice plan, crispi
 
 ---
 
-## What This Skill Does
+## Overview
 
-Generates a structured YAML plan, populates it with vertical slices, design questions with recommendations, and dual-agent critique. Opens the dashboard for interactive human review — approvals persist to SQLite on every click. After finalization, reads approved slices and design decisions to dispatch tasks via `/htmlgraph:execute`.
+A v2 plan is a YAML document containing slice cards. Each slice card is an executable spec — it defines what to build, why it matters, acceptance criteria, and tests. The human reviews and approves slices individually. Approved slices are promoted to feature work items incrementally via `htmlgraph plan promote-slice`.
 
-**Architecture:**
-- **YAML** = plan content (agent-written, read by dashboard)
-- **SQLite `plan_feedback`** = human approvals (persisted on every interaction)
-- **Dashboard** = interactive review UI (reads both, writes approvals to SQLite)
-- **Static HTML** = archival export (on finalize)
+**Spec-driven mapping:**
+
+| Artifact | Role |
+|----------|------|
+| `.htmlgraph/plans/<plan-id>.yaml` | Plan = context document (problem, goals, constraints, slices) |
+| Each slice card (`what/why/done_when/tests`) | Executable spec — what an agent implements |
+| `feat-XXX` work item | Promoted feature = implementation tracker |
+| Sessions and commits | Evidence linked via `implemented_in` edges |
 
 ---
 
@@ -27,388 +30,154 @@ Generates a structured YAML plan, populates it with vertical slices, design ques
 
 Before anything else:
 
-1. Check: `htmlgraph status` — is there an active feature/track for this work?
+1. `htmlgraph status` — is there an active feature/track?
 2. If yes: `htmlgraph feature start <id>`
 3. If no: `htmlgraph feature create "<title>" --track <trk-id>` then `htmlgraph feature start <id>`
 
-Plans without attribution produce untracked work.
-
 ---
 
-## Step 0.5: Check for Already-Finalized Plan
+## Step 1: Research
 
-If the user's request mentions a specific plan ID (e.g. "dispatch plan-a1b2c3d4" or "run step 7 for plan-xxxx"), check its status first:
-
-```bash
-htmlgraph plan show <plan-id> | grep -i status
-```
-
-**If status is `finalized`:** skip Steps 1-6 entirely and go straight to Step 7. The approvals and question answers are already persisted in `plan_feedback`. The plan has already been locked (read-only) — no further revisions are possible without reopening. Hand off directly to `/htmlgraph:execute <plan-id>` or the `htmlgraph yolo` command from the plan details view.
-
-**Do NOT re-run research, critique, or human review on a finalized plan.** If the plan needs revision, ask the user explicitly before reopening.
-
-If the plan status is `draft` or `review`, proceed to Step 1.
-
----
-
-## Step 1b: Check for Existing Plan from Plan Mode
-
-If the user just exited Claude Code's plan mode, the `ExitPlanMode` hook may have already created a skeleton YAML:
-
-```bash
-# Check for recently-created plan YAMLs (within last 5 minutes)
-find .htmlgraph/plans/ -name "plan-*.yaml" -mmin -5 2>/dev/null
-```
-
-If a recent YAML exists:
-1. Read the skeleton YAML — it will have slices with `what` partially populated but `why`, `done_when`, `tests`, `files` mostly empty. The slices may not map to proper delivery slices.
-2. **Do NOT create a new plan** — use this plan ID as the base
-3. Also locate the original `.md` plan file (same directory, most recent `.md` file)
-4. Proceed to Step 1 (research) as normal — the research output will inform the enrichment
-5. In Step 2, **launch enrichment agents instead of writing YAML from scratch** (see Step 2 below)
-
-If no recent YAML exists, proceed to Step 1 (research) and Step 2 as normal.
-
----
-
-## Step 1: Research (Parallel Agents)
-
-Spawn research agents in a single message — do not proceed until both complete:
-
-```
-Agent(description="Understand current codebase state", subagent_type="htmlgraph:researcher",
-      prompt="Investigate [area]. Answer: current state, key files, existing patterns, constraints.")
-
-Agent(description="Check for prior work", subagent_type="Explore",
-      prompt="Search .htmlgraph/ for any features or spikes related to [area]. Report feature IDs and status.")
-```
-
-Research must answer:
-- Current state of the codebase in this area
-- Desired end state (from the request)
-- Open design questions (choices that affect the architecture)
+Research the area before writing any YAML. Answer:
+- Current state of the codebase
+- Desired end state
+- Open design questions (architecture choices)
 - Candidate vertical slices (end-to-end, not horizontal layers)
 - Real dependencies between slices
-- Prior art or existing patterns to leverage
+- Prior art and existing patterns
 
-**Skip research only for:** trivial changes (<10 lines), bug fixes with known root cause, documentation-only changes.
+**Skip only for:** trivial changes, bug fixes with known root cause, documentation-only work.
 
 ---
 
-## Step 2: Generate Plan YAML
+## Step 2: Create the Plan YAML
 
-### Path A: Enriching a skeleton from plan mode (Step 1b found a YAML)
-
-The hook-generated skeleton has structural issues: headings may not map to delivery slices, mandatory fields are empty, and the design section is sparse. **This requires agent reasoning, not just a CLI command.**
-
-Launch parallel enrichment agents — each reads the skeleton YAML + original `.md` + research output, and produces one section of the complete CRISPI YAML:
-
-```
-Agent(description="Enrich design section", subagent_type="htmlgraph:sonnet-coder",
-      prompt="Read the skeleton YAML at .htmlgraph/plans/<plan-id>.yaml and the original
-      plan at .htmlgraph/plans/<name>.md. Also use these research findings: [paste findings].
-      
-      Populate the design section:
-      - design.problem: evidence-based description from the markdown's context/background
-      - design.goals: measurable outcomes extracted from the plan's objectives
-      - design.constraints: real limitations from research findings
-      
-      Write ONLY the design section as YAML to /tmp/design-section.yaml")
-
-Agent(description="Restructure slices", subagent_type="htmlgraph:sonnet-coder",
-      prompt="Read the skeleton YAML at .htmlgraph/plans/<plan-id>.yaml and the original
-      plan at .htmlgraph/plans/<name>.md. Also use these research findings: [paste findings].
-      
-      The skeleton slices may be document sections (Context, Testing, Files Changed),
-      not delivery slices. Restructure them into proper vertical slices:
-      - Each slice = one end-to-end deliverable, not a horizontal layer
-      - Populate ALL mandatory fields: what, why, files, done_when, tests, effort, risk
-      - Set real dependency order in deps
-      - Use slice-N IDs (e.g. slice-1, slice-2) — real feat- IDs are issued at finalize (Step 7b)
-      - Collapse structural sections into slice metadata (testing → done_when, files → files)
-      
-      Write ONLY the slices section as YAML to /tmp/slices-section.yaml")
-
-Agent(description="Generate design questions", subagent_type="htmlgraph:haiku-coder",
-      prompt="Read the skeleton YAML at .htmlgraph/plans/<plan-id>.yaml and the original
-      plan at .htmlgraph/plans/<name>.md. Also use these research findings: [paste findings].
-      
-      Identify 2-5 open design questions where the plan has implicit choices.
-      Each question needs: text, description (context + tradeoffs), recommended option,
-      and 2+ options with descriptive labels.
-      
-      Write ONLY the questions section as YAML to /tmp/questions-section.yaml")
-```
-
-After all agents return, the orchestrator assembles the complete YAML from the three sections, preserving the existing `meta` from the skeleton. Write the assembled plan via:
 ```bash
-htmlgraph plan rewrite-yaml <plan-id> --file /tmp/assembled-plan.yaml
+htmlgraph plan create-yaml "<title>" --description "<description>" --track <trk-id>
 ```
 
-### Path B: Creating a new plan from scratch (no skeleton)
+Note the returned plan ID. Then write the YAML to `.htmlgraph/plans/<plan-id>.yaml` using `htmlgraph plan rewrite-yaml <plan-id> --file /tmp/plan.yaml`.
 
-Generate the plan ID:
-```bash
-htmlgraph plan create "<title>" --description "<description>"
-```
-Note the returned plan ID. Then create the YAML file at `.htmlgraph/plans/<plan-id>.yaml`.
-
-The orchestrator constructs the full YAML structure and writes it directly, or launches the same parallel agents as Path A but without a skeleton to start from (agents use research findings only).
-
-### YAML Schema
-
-Every plan YAML MUST follow this exact structure:
+### v2 YAML Schema
 
 ```yaml
 meta:
-  id: plan-<hex8>          # from plan create
-  track_id: <trk-id>       # if retroactive, empty if plan-first
+  id: plan-<hex8>
+  track_id: <trk-id>
   title: "<plan title>"
   description: >
-    One paragraph describing what this plan designs and why.
+    One paragraph: what this plan designs and why.
   created_at: "YYYY-MM-DD"
-  status: draft             # draft | review | finalized
-  created_by: claude-opus   # agent that generated it
+  status: active              # active | completed
+  created_by: claude-opus
 
 design:
   problem: >
-    What is the current state? What's wrong? Why does this matter?
-    Include measurements, evidence, or user impact.
+    Current state, what is broken, and why it matters.
   goals:
     - "**Goal 1** — measurable outcome"
     - "**Goal 2** — measurable outcome"
   constraints:
-    - "Constraint 1 — why it exists"
-    - "Constraint 2 — why it exists"
+    - "Constraint — why it exists"
   approved: false
   comment: ""
 
 slices:
-  - id: slice-1             # slice-N until finalize; real feat- IDs issued at Step 7b
+  - id: slice-1
     num: 1
     title: "<slice title>"
-    what: >
-      What exactly will be implemented. Be specific — name functions,
-      files, APIs. An agent reading this should know what to build.
-    why: >
-      Why this slice exists. What problem does it solve? What breaks
-      without it? Link to the design goals.
+    what: |
+      What exactly will be implemented. Name functions, files, APIs.
+      An agent reading this should know what to build without asking.
+    why: |
+      Why this slice exists. What problem does it solve? Which goal does
+      it serve? What breaks without it?
     files:
       - path/to/file1.go
       - path/to/file2.go
-    deps: []                 # slice numbers this depends on, e.g. [1, 3]
+    deps: []                  # slice numbers this depends on, e.g. [1, 3]
     done_when:
-      - "Acceptance criterion 1 — testable, concrete"
-      - "Acceptance criterion 2 — testable, concrete"
-    effort: S                # S | M | L
-    risk: Low                # Low | Med | High
+      - "Acceptance criterion 1 — testable and concrete"
+      - "Acceptance criterion 2 — testable and concrete"
+    effort: S                 # S | M | L
+    risk: Low                 # Low | Med | High
     tests: |
-      Unit: specific test description with expected input/output
-      Integration: specific integration test
-      Regression: what existing tests must still pass
+      Unit: specific test with expected input/output
+      Integration: specific integration scenario
+      Regression: which existing tests must still pass
     approved: false
     comment: ""
 
+    # V2 slice-local lifecycle (omit from legacy plans — they remain valid)
+    approval_status: pending  # pending | approved | rejected | changes_requested
+    execution_status: not_started  # not_started | promoted | in_progress | done | blocked | superseded
+    questions:                # slice-local open questions (optional)
+      - id: q-approach
+        text: "Should we use X or Y approach here?"
+        answer: ""            # empty = unanswered
+    critic_revisions:         # critic feedback scoped to this slice (optional)
+      - source: sonnet
+        severity: HIGH
+        summary: "Missing error handling for network timeout path"
+
+  - id: slice-2
+    num: 2
+    # ... (same fields as slice-1)
+
+# Plan-level design questions (optional — prefer slice-local questions for v2)
 questions:
   - id: q-<kebab-name>
-    text: "The design question in plain English?"
+    text: "Design question?"
     description: >
-      Context paragraph explaining WHY this question matters, what
-      tradeoffs are involved, and what evidence exists for each option.
-      The reviewer needs this to make an informed decision.
-    recommended: <option-key>  # agent's best judgment
+      Context: why this question matters and what the tradeoffs are.
+    recommended: option-a
     options:
       - key: option-a
-        label: "A: Short name — Full description of what this option means and its implications"
+        label: "A: Short name — full description"
       - key: option-b
-        label: "B: Short name — Full description of what this option means and its implications"
-    answer: null               # null = unanswered, set by human
+        label: "B: Short name — full description"
+    answer: null              # null = unanswered
 
-critique: null                 # null = not yet run, populated by Step 4
+critique: null                # null = not yet run; populated in Step 4
 ```
 
-### Quality Requirements for Each Section
+### Mandatory slice fields
 
-**Slices — ALL fields are MANDATORY:**
-- `what`: Specific enough that an agent can implement it without asking questions
-- `why`: Links to a design goal or explains the business need
-- `files`: At least one file path (check codebase if unsure)
-- `done_when`: At least two concrete, testable acceptance criteria
-- `tests`: At least one unit test and one integration/regression test
-- `effort`: S (<50 lines), M (50-200 lines), L (>200 lines)
-- `risk`: Low (pure addition), Med (modifies existing), High (changes hot path or shared interfaces)
+All of these must be present and non-empty on every slice:
 
-**Questions — ALL fields are MANDATORY:**
-- `description`: At least 2 sentences explaining context and tradeoffs
-- `recommended`: Agent MUST pick a default — the human overrides only where they disagree
-- `options`: At least 2 options, each with a descriptive label (not just a key)
+| Field | Requirement |
+|-------|-------------|
+| `what` | Specific enough for an agent to implement without further questions |
+| `why` | Links to a design goal or explains the business need |
+| `files` | At least one file path |
+| `done_when` | At least two testable acceptance criteria |
+| `tests` | At least one unit test and one integration/regression test |
+| `effort` | `S` (<50 lines), `M` (50–200 lines), `L` (>200 lines) |
+| `risk` | `Low` (pure addition), `Med` (modifies existing), `High` (changes hot path or shared interface) |
 
-**Design — ALL subsections are MANDATORY:**
-- `problem`: Evidence-based description of current state
-- `goals`: Measurable outcomes (not vague aspirations)
-- `constraints`: Real limitations that affect design choices
+Use `what: |`, `why: |`, and `tests: |` (YAML literal blocks) so Markdown renders correctly in the dashboard.
 
 ---
 
-## Step 3: Validate Plan Structure
-
-Before proceeding, validate the YAML:
-
-1. All required fields present on every slice
-2. All questions have description + recommended
-3. Design has problem + goals + constraints
-4. Slice deps reference valid slice numbers
-5. Effort and risk values are valid (S/M/L, Low/Med/High)
-6. No duplicate slice numbers or question IDs
+## Step 3: Validate
 
 ```bash
 htmlgraph plan validate-yaml <plan-id>
-
 ```
+
+Fix any schema errors before proceeding.
 
 ---
 
-## Step 4: Critique (Parallel Agents)
+## Step 4: Critique (for plans with 3+ slices)
 
-**Trigger:** Always run critique for plans with >= 3 slices. Skip for trivial plans.
+Run two critique agents in parallel. Each reads the plan YAML and produces findings.
 
-Dispatch two critique agents in parallel. Each reads the plan YAML and produces structured findings.
-
-```
-Agent(description="Design critique", subagent_type="htmlgraph:haiku-coder",
-      prompt="Read [plan.yaml]. Produce structured critique. [See prompt template below]")
-
-Agent(description="Feasibility critique", subagent_type="htmlgraph:sonnet-coder",
-      prompt="Read [plan.yaml]. Verify feasibility. [See prompt template below]")
-```
-
-### What Critique Agents Must Do
-
-**For ALL plan types:**
-- **Identify gaps** — what does the plan not address? What's missing?
-- **Challenge assumptions** — what might be wrong? What is the plan taking for granted?
-- **Suggest prior art** — what existing solutions, patterns, libraries, or examples are relevant?
-- **Assess risks** — what could go wrong? What's the worst case? What's the blast radius?
-- **Propose alternatives** — is there a simpler or different approach the plan missed?
-
-**For plans involving existing code, also:**
-- Verify claims against actual code (cite file:line numbers)
-- Check if proposed changes conflict with existing patterns
-- Identify functions/utilities that already exist and can be leveraged
-
-**For greenfield or new ideas, also:**
-- Question user/market assumptions — is there evidence of demand?
-- Identify MVP scope vs full scope — what can be cut?
-- Find real-world examples of similar systems — what can we learn from them?
-- Flag "unknown unknowns" — what will we only discover by building?
-
-### Critique Output Format
-
-Each critique agent produces text in this format:
-
-```
-ASSUMPTIONS:
-A1: [VERIFIED|PLAUSIBLE|UNVERIFIED|QUESTIONABLE|FALSIFIED] text | evidence
-
-SLICE_ASSESSMENTS:
-S1: [assessment with specific concerns]
-
-RISKS:
-R1: risk description | severity: Low/Medium/High | mitigation
-
-GAPS:
-- What the plan doesn't address
-
-ALTERNATIVES:
-- Different approaches worth considering
-
-PRIOR_ART:
-- Relevant existing solutions or patterns
-```
-
-### Writing Critique to YAML
-
-The orchestrator parses both agents' output and writes the `critique` section:
-
-```yaml
-critique:
-  reviewed_at: "YYYY-MM-DD"
-  reviewers:
-    - "Haiku (design review)"
-    - "Sonnet (feasibility)"
-  assumptions:
-    - id: A1
-      status: verified       # verified|plausible|unverified|questionable|falsified
-      text: "The assumption being tested"
-      evidence: "file:line or reasoning"
-  critics:
-    - title: "DESIGN CRITIC"
-      sections:
-        - heading: "Slice Assessment"
-          items:
-            - badge: "S1"
-              kind: success   # success|warn|danger|info
-              text: "Assessment text"
-        - heading: "Gaps & Missing Considerations"
-          items:
-            - badge: "Gap"
-              kind: warn
-              text: "What the plan doesn't address"
-        - heading: "Alternative Approaches"
-          items:
-            - badge: "Alt"
-              kind: info
-              text: "A different approach worth considering"
-    - title: "FEASIBILITY CRITIC"
-      sections:
-        - heading: "What Exists to Leverage"
-          items: [...]
-        - heading: "What the Plan Gets Wrong"
-          items: [...]
-        - heading: "Prior Art & Examples"
-          items: [...]
-  risks:
-    - risk: "Risk description"
-      severity: High          # High|Medium|Low
-      mitigation: "How to mitigate"
-  synthesis: >
-    Summary of key findings. What must change before the plan is approved?
-    Numbered action items.
-```
+After critique, integrate HIGH/DANGER findings directly into the affected slice cards as `critic_revisions` entries. Rewrite the YAML via `htmlgraph plan rewrite-yaml`.
 
 ---
 
-## Step 4b: Address Critique Findings (MANDATORY before review)
-
-After critique agents return, the orchestrator MUST update the plan to address findings before launching review. The human should review the critique-informed version, not the stale original.
-
-**For each FALSIFIED assumption:**
-- Update the affected slice's `what` and `done_when` to address the falsification
-- Add the corrected understanding to `design.constraints` if it affects the whole plan
-
-**For each HIGH severity risk:**
-- Add the mitigation as a `done_when` criterion on the affected slice
-- If no slice owns the risk, add it to design constraints
-
-**For each missing consideration identified by critics:**
-- Add as a new question (if it's a design choice) or a new constraint (if it's a fact)
-
-**Process:**
-1. Parse both critique outputs for FALSIFIED/HIGH items
-2. Read the current plan YAML
-3. Modify the affected sections in memory
-4. Write to temp file
-5. Run: `htmlgraph plan rewrite-yaml <plan-id> --file /tmp/revised.yaml`
-6. Git auto-commits the revision with message: `plan(<id>): address critique findings`
-7. Proceed to Step 5 (review) with the updated plan
-
-**Skip Step 4b only if:** all assumptions are verified/plausible AND no HIGH severity risks exist.
-
----
-
-## Step 5: Open for Human Review (PAUSE HERE)
-
-Direct the human to review the plan in the dashboard:
+## Step 5: Open for Human Review (PAUSE)
 
 ```bash
 htmlgraph serve
@@ -417,160 +186,199 @@ htmlgraph serve
 Tell the human:
 
 ```
-Plan ready for review in the dashboard:
+Plan ready for review in the dashboard at http://localhost:8088/#plans
 
-  htmlgraph serve
-  Open http://localhost:8080/#plans and click the plan.
+Per-slice review:
+  1. Read each slice card — what/why/done_when/tests
+  2. Approve or reject each slice individually
+  3. Answer any slice-local questions
+  4. Read the critique revisions embedded in each card
 
-Please:
-1. Read the Design Discussion — Problem, Goals, Constraints
-2. Review each Slice — approve or leave unchecked
-3. Answer the Open Questions — defaults are recommended, override where you disagree
-4. Read the AI Critique — note any risks or gaps
-5. Check the Feedback Summary — progress bar shows completion
-6. Click Finalize when all sections are approved
+CLI shortcuts (if reviewing outside the dashboard):
+  htmlgraph plan approve-slice <plan-id> <num>
+  htmlgraph plan reject-slice <plan-id> <num> [--changes-requested]
+  htmlgraph plan answer-slice-question <plan-id> <num> <question-id> <answer-key>
 
-Your approvals persist automatically — you can close and reopen without losing progress.
-
-I will wait until you finalize the plan before writing any code.
+I will wait until you signal readiness before promoting any slices.
 ```
 
-**STOP. Do not proceed until the human finalizes the plan.**
+**STOP. Do not promote slices until the human has reviewed.**
 
-### Monitoring Review Progress
+---
 
-Poll SQLite to check if the human has finalized:
+## Step 6: Read Decisions and Integrate Feedback
 
 ```bash
-# Check approval progress
-sqlite3 .htmlgraph/htmlgraph.db \
-  "SELECT section, value FROM plan_feedback WHERE plan_id='<plan-id>' AND action='approve'"
+htmlgraph plan read-feedback-yaml <plan-id>
+```
 
-# Check if all slices approved
-sqlite3 .htmlgraph/htmlgraph.db \
-  "SELECT COUNT(*) as approved FROM plan_feedback WHERE plan_id='<plan-id>' AND action='approve' AND value='True'"
+For rejected slices: update the YAML to address the rejection, then re-run Step 5.
+For slices with `changes_requested`: revise the slice card and re-present.
+For answered questions: bake the decision into the affected slice's `what` field.
 
-# Check question answers
-sqlite3 .htmlgraph/htmlgraph.db \
-  "SELECT question_id, value FROM plan_feedback WHERE plan_id='<plan-id>' AND action='answer'"
+---
+
+## Step 7: Promote Approved Slices
+
+Promote slices incrementally as they are approved — no need to wait for full-plan finalization.
+
+```bash
+# Promote a single approved slice (creates feat-XXX, wires edges):
+htmlgraph plan promote-slice <plan-id> <slice-num>
+
+# If a slice's deps are already done externally (e.g. already in-flight):
+htmlgraph plan promote-slice <plan-id> <slice-num> --waive-deps
+```
+
+Rules:
+- The slice must have `approval_status=approved` (set via `approve-slice`).
+- All dependency slices must have `execution_status=done` or `superseded`, unless `--waive-deps`.
+- `promote-slice` is idempotent: if `feature_id` is already set, it reuses the existing feature.
+- After promotion, `execution_status` is set to `promoted` in both YAML and `plan_feedback`.
+
+The command prints the promoted `feat-XXX` ID. That feature is now part of the track and participates in the dependency-driven dispatch loop (see `/htmlgraph:execute`).
+
+### Promotion workflow for a multi-slice plan
+
+```
+for each slice (in dependency order):
+  1. Review → htmlgraph plan approve-slice <plan-id> <num>
+  2. Promote → htmlgraph plan promote-slice <plan-id> <num>
+  3. Track execution → htmlgraph plan set-slice-status <plan-id> <num> in_progress
+  4. When done → htmlgraph plan set-slice-status <plan-id> <num> done
 ```
 
 ---
 
-## Step 6: Read Finalized Decisions
+## Step 8: Close the Plan
 
-After the human clicks Finalize in the dashboard, read all feedback:
+When all slices are done, rejected, or superseded:
 
 ```bash
-# Read all feedback — approvals, answers, amendments, chat
-htmlgraph plan feedback <plan-id>
+htmlgraph plan set-status <plan-id> completed
 ```
-
-This outputs JSON with the complete review context:
-
-```json
-{
-  "plan_id": "plan-abc123",
-  "approvals": {"slice-1": {"approved": true}, "slice-2": {"approved": false, "comment": "too risky"}},
-  "answers": {"q-caching": "lazy", "q-error-handling": "metric-counter"},
-  "amendments": [{"field": "what", "slice": 1, "op": "set", "value": "updated description"}],
-  "chat_messages": [{"role": "user", "content": "...", "timestamp": "..."}]
-}
-```
-
-Parse the results:
-- If any slice has `approved: false`: summarize what was rejected. Ask the human — revise or proceed without?
-- If revising: update the YAML, loop to Step 5.
-- If proceeding: note excluded slices.
 
 ---
 
-## Step 7: Revise Plan, Create Features, and Dispatch
+## CLI Reference for Slice Lifecycle
 
-Finalization is an **agentic process**. You synthesize all review feedback into a revised plan, then create properly structured features.
-
-### 7a. Revise the Plan
-
-Read the plan YAML and the feedback from Step 6. Produce a **revised version** of the plan that incorporates:
-
-- **Amendments**: Apply accepted amendment changes to slice descriptions, titles, deps
-- **Chat discussion**: If the chat contains decisions, clarifications, or scope changes, reflect them in the affected slices
-- **Design decisions**: Bake answered questions into relevant slice descriptions under "Accepted Design Decisions"
-- **Rejected slices**: Remove or mark as excluded
-- **Critique insights**: If critique raised risks or assumptions that were discussed, note mitigations in affected slices
-
-The revised YAML's `slice.what` field becomes the feature description at finalize time (via `buildSliceFeatureContent`). If you need richer per-feature content — e.g., incorporating chat discussion specific to that slice — write it into `slice.what` during revision. Do not rely on finalize to synthesize it.
-
-Update the YAML via:
-
-```bash
-htmlgraph plan rewrite-yaml <plan-id> --file /tmp/revised.yaml
-```
-
-This validates the revised structure and auto-commits with version history.
-
-### 7b. Finalize via the Canonical Command
-
-Call the single, atomic finalize command:
-
-```bash
-htmlgraph plan finalize <plan-id>
-```
-
-This command:
-1. Reads approvals and answers from SQLite `plan_feedback` table
-2. Loops over approved slices and creates features using the slice's Title and What (or Why fallback) as content
-3. Writes each created `FeatureID` back into the slice YAML
-4. Emits edges: `planned_in` (feature→plan), `part_of`/`contains` (feature↔track), `implemented_in` (plan→track)
-5. Sets plan status to `finalized` and locks it (subsequent calls error with "plan is locked … use 'plan reopen'")
-
-If finalize errors with "plan is locked", the plan was previously finalized. Run `htmlgraph plan reopen <plan-id>` first, revise Step 7a, then re-finalize. The finalize command is idempotent: slices whose `feature_id` is already set and whose feature exists will be reused rather than duplicated; only new or orphaned slices create new features.
-
-If finalize errors on missing track, description, or slices, the error message is actionable — fix the YAML and re-run.
-
-### 7c. Announce the Finalized Plan
-
-```
-Plan finalized. Track: <track-id>
-
-Approved slices (N of M):
-  feat-XXXX  Slice 1 title       -> implement
-  feat-XXXX  Slice 2 title       -> implement
-
-Rejected slices:
-  Slice 3 title                  -> excluded (not approved)
-
-Design decisions:
-  Q1: Migration caching: schema-version (recommended, accepted)
-  Q2: Error handling: metric-counter (overrode recommendation: structured-log)
-  Q3: SessionStart scope: git-only (recommended, accepted)
-```
-
-Then hand off to `/htmlgraph:execute`.
+| Command | Usage | Effect |
+|---------|-------|--------|
+| `approve-slice` | `htmlgraph plan approve-slice <plan-id> <num>` | Sets `approval_status=approved` in `plan_feedback` |
+| `reject-slice` | `htmlgraph plan reject-slice <plan-id> <num> [--changes-requested]` | Sets `approval_status=rejected` or `changes_requested` |
+| `answer-slice-question` | `htmlgraph plan answer-slice-question <plan-id> <num> <question-id> <answer-key>` | Records answer to a slice-local question |
+| `set-slice-status` | `htmlgraph plan set-slice-status <plan-id> <num> <status>` | Sets `execution_status` (`not_started\|promoted\|in_progress\|done\|blocked\|superseded`) |
+| `promote-slice` | `htmlgraph plan promote-slice <plan-id> <num> [--waive-deps]` | Creates `feat-XXX`, wires edges, sets `execution_status=promoted` |
 
 ---
 
-## Agent Type Selection
+## Section-Naming Contract
 
-| Agent | When to Use |
-|-------|------------|
-| `htmlgraph:haiku-coder` | Critique (design review), single-file tasks, <50 lines |
-| `htmlgraph:sonnet-coder` | Critique (feasibility), multi-file tasks, moderate complexity |
-| `htmlgraph:opus-coder` | Architecture decisions, complex algorithms, novel design |
+State stored in `plan_feedback` uses these section keys:
 
-Default to sonnet unless the task is trivially simple (haiku) or requires deep reasoning (opus).
+| Key pattern | What it stores |
+|-------------|----------------|
+| `slice-<num>` | Slice-level approval (`action=approve`) and execution status (`action=set_execution_status`) |
+| `slice-<num>-question-<id>` | Answer to a slice-local question (`action=answer`) |
+| `design` | Design section approval |
+| `questions` | Plan-level question answers |
+
+The `answer-slice-question` command maps `<slice-num>` and `<question-id>` to the section key automatically.
+
+---
+
+## Minimal Example (2-slice plan)
+
+```yaml
+meta:
+  id: plan-a1b2c3d4
+  track_id: trk-xyz
+  title: "Add rate limiting to API"
+  status: active
+  created_at: "2026-04-28"
+
+design:
+  problem: >
+    The /api/ingest endpoint accepts unbounded request volume. Under load,
+    the SQLite writer becomes a bottleneck and drops events silently.
+  goals:
+    - "**Throughput cap** — reject requests above 100 req/s per client with 429"
+    - "**Visibility** — expose a counter metric for throttled requests"
+  constraints:
+    - "No new runtime dependencies — use stdlib only"
+  approved: false
+  comment: ""
+
+slices:
+  - id: slice-1
+    num: 1
+    title: "In-memory rate limiter middleware"
+    what: |
+      Add `internal/ratelimit/limiter.go`: a token-bucket limiter keyed by
+      client IP. Wire it as HTTP middleware in `cmd/htmlgraph/serve.go`.
+      Return HTTP 429 with a JSON error body when the bucket is empty.
+    why: |
+      Protects the SQLite writer from burst overload. Addresses the throughput
+      cap goal.
+    files:
+      - internal/ratelimit/limiter.go
+      - cmd/htmlgraph/serve.go
+    deps: []
+    done_when:
+      - "Requests above the configured limit receive HTTP 429"
+      - "Requests within the limit pass through unchanged"
+    effort: S
+    risk: Low
+    tests: |
+      Unit: TestLimiter_Allow — burst of 10 req/s, expect first 5 allowed, next rejected
+      Integration: TestServeRateLimit — spin up server, hammer /api/ingest, assert 429s
+    approval_status: pending
+    execution_status: not_started
+
+  - id: slice-2
+    num: 2
+    title: "Throttle counter metric"
+    what: |
+      Increment a `htmlgraph_throttled_total` counter in the limiter middleware.
+      Expose it on the existing `/metrics` endpoint via the Prometheus-compatible
+      text format already used by `cmd/htmlgraph/metrics.go`.
+    why: |
+      Addresses the visibility goal. Without this, operators cannot tell whether
+      rate limiting is firing or calibrated correctly.
+    files:
+      - internal/ratelimit/limiter.go
+      - cmd/htmlgraph/metrics.go
+    deps: [1]
+    done_when:
+      - "`htmlgraph_throttled_total` increments on each 429 response"
+      - "Counter is present in /metrics output"
+    effort: S
+    risk: Low
+    tests: |
+      Unit: TestLimiterMetric — after N rejections, counter equals N
+      Regression: existing /metrics tests still pass
+    approval_status: pending
+    execution_status: not_started
+
+questions: []
+critique: null
+```
+
+---
+
+## Legacy Compatibility
+
+Plans created before v2 (without `approval_status`, `execution_status`, `questions`, or `critic_revisions` on slices) remain valid. The schema treats these fields as optional (`omitempty`). The dashboard renders them via a global Questions/Critique fallback when the v2 slice-card fields are absent.
+
+Legacy plans can be migrated incrementally: add v2 fields to individual slices as they come up for review, without touching the rest of the YAML.
 
 ---
 
 ## Key Rules
 
-- **Plans are YAML files** — agents write structured data, not HTML strings
-- **All slice fields are mandatory** — What, Why, Files, DoneWhen, Tests, Effort, Risk
-- **All questions need context** — description + recommended option
-- **Design has three subsections** — Problem, Goals, Constraints (not a single blob)
-- **Critique challenges assumptions** — not just verifies code
-- **Approvals persist to SQLite** — human can close and reopen without losing state
-- **Finalize is explicit** — human clicks the button, not the agent
-- **TDD is mandatory** — every dispatched task includes tests before implementation
-- **Only approved slices** become features on dispatch
-- **Finalize is atomic** — `htmlgraph plan finalize` handles feature creation, edge wiring, and status transition in one command. Agents do not call `feature create` or `plan wire` directly during finalization.
+- **v2 slices are slice cards** — each card contains its own questions, critic revisions, approval status, and execution status
+- **Use literal blocks** (`|`) for `what`, `why`, `tests` so Markdown renders in the dashboard
+- **Promote incrementally** — `promote-slice` does not require full-plan finalization
+- **Critique is embedded per-slice** — use `critic_revisions` instead of a global critique section for v2 plans
+- **All slice fields are mandatory** — missing fields will fail `validate-yaml`
+- **Finalize is for legacy plans** — v2 plans use `promote-slice` per slice; `htmlgraph plan finalize` is the legacy all-at-once path

--- a/packages/codex-marketplace/.agents/plugins/htmlgraph/static/components.js
+++ b/packages/codex-marketplace/.agents/plugins/htmlgraph/static/components.js
@@ -65,21 +65,58 @@ class HgActivityFeed extends HTMLElement {
 
   async refresh() {
     try {
-      const resp = await fetch('/api/events/recent?limit=20');
+      const resp = await fetch('/api/events/feed?limit=20');
       if (!resp.ok) return;
-      const events = await resp.json();
+      const data = await resp.json();
+      const events = data.events || [];
       const feed = this.querySelector('.hg-feed');
+      // Build DOM nodes via textContent/dataset rather than innerHTML so
+      // OTel-sourced summaries — which now include raw user prompts and
+      // tool content — cannot inject HTML or script into the dashboard.
+      feed.replaceChildren();
       if (!events.length) {
-        feed.innerHTML = '<p class="hg-feed-empty">No recent activity</p>';
+        const empty = document.createElement('p');
+        empty.className = 'hg-feed-empty';
+        empty.textContent = 'No recent activity';
+        feed.appendChild(empty);
         return;
       }
-      feed.innerHTML = events.map(e => `
-        <div class="hg-feed-item" data-event-type="${e.event_type || ''}">
-          <span class="hg-feed-time">${new Date(e.timestamp).toLocaleTimeString()}</span>
-          <span class="hg-feed-tool">${e.tool_name || e.event_type || 'event'}</span>
-          <span class="hg-feed-summary">${e.output_summary || e.input_summary || ''}</span>
-        </div>
-      `).join('');
+      for (const e of events) {
+        const item = document.createElement('div');
+        item.className = 'hg-feed-item';
+        item.dataset.eventType = e.type || '';
+        item.dataset.source = e.source || '';
+
+        const time = document.createElement('span');
+        time.className = 'hg-feed-time';
+        time.textContent = new Date(e.timestamp).toLocaleTimeString();
+        item.appendChild(time);
+
+        const tool = document.createElement('span');
+        tool.className = 'hg-feed-tool';
+        tool.textContent = e.tool_name || e.type || 'event';
+        item.appendChild(tool);
+
+        if (e.duration_ms > 0) {
+          const dur = document.createElement('span');
+          dur.className = 'hg-feed-badge hg-feed-badge-dur';
+          dur.textContent = `${e.duration_ms}ms`;
+          item.appendChild(dur);
+        }
+        if (e.cost_usd > 0) {
+          const cost = document.createElement('span');
+          cost.className = 'hg-feed-badge hg-feed-badge-cost';
+          cost.textContent = `$${e.cost_usd.toFixed(3)}`;
+          item.appendChild(cost);
+        }
+
+        const summary = document.createElement('span');
+        summary.className = 'hg-feed-summary';
+        summary.textContent = e.summary || '';
+        item.appendChild(summary);
+
+        feed.appendChild(item);
+      }
     } catch (_) { /* server not available */ }
   }
 }

--- a/packages/gemini-extension/commands/htmlgraph/git-commit.toml
+++ b/packages/gemini-extension/commands/htmlgraph/git-commit.toml
@@ -30,8 +30,7 @@ Commit changes using Bash-copilot first, haiku-coder as fallback.
 ### Step 1: Analyze what to commit
 
 ```bash
-git diff --stat HEAD
-git status --short
+git diff --stat HEAD; git status --short
 ```
 
 Select source files to stage. Exclude `.htmlgraph/` directory unless explicitly requested.

--- a/packages/gemini-extension/skills/execute/SKILL.md
+++ b/packages/gemini-extension/skills/execute/SKILL.md
@@ -19,6 +19,17 @@ When running in a worktree, `HTMLGRAPH_PROJECT_DIR` is set automatically. All `h
 
 ---
 
+## Efficiency Rules (read before dispatching)
+
+Every tool call spends a turn. The goal is to dispatch the first subagent within **≤5 tool calls**. To hit that budget:
+
+1. **One call, not ten.** Use `htmlgraph execute-preview <trk-id> --format json` to get the track, linked features/bugs/plans, and current git state in a single invocation. Do not call `htmlgraph track show`, `htmlgraph feature show`, `htmlgraph plan show`, and `git status` separately before the first dispatch.
+2. **Batch git-state probes.** If execute-preview doesn't cover a probe you need, chain with `&&` in one Bash call — never one tool call per git subcommand.
+3. **Don't feature-show more than twice in a row.** If you find yourself calling `htmlgraph feature show` for every linked feature, stop and re-read the preview JSON — the status you need is already there.
+4. **Don't retry flag variants.** If a flag fails, check the skill for the real flag name before trying a second guess. This skill is validated by a build-time smoke test — prescribed flags are real.
+
+---
+
 ## Work Item Attribution (MANDATORY)
 
 Before dispatching any agents, verify attribution is set:
@@ -51,6 +62,12 @@ LOOP:
 
 This maximizes parallelism automatically. If 10 of 13 tasks are independent, all 10 run in the first dispatch — no artificial wave boundaries.
 
+Slices promoted via `htmlgraph plan promote-slice` from a still-active plan are dispatched through the same dependency-readiness loop — they appear as features linked to the track via `part_of` edges and are ready to dispatch as soon as their `blocked_by` deps are complete.
+
+### Incremental slice promotion
+
+When a track is executing a v2 plan, slices may be promoted one at a time rather than all at once. Each call to `htmlgraph plan promote-slice <plan-id> <num>` creates a `feat-XXX` linked to the track and marks the slice `execution_status=promoted`. That feature immediately appears in `htmlgraph execute-preview <trk-id>` and enters the dispatch loop. Dep-blocked slices stay in the `blocked` bucket until their dependencies complete, exactly like manually created features. No special handling is required — promoted slices are regular features from the executor's perspective.
+
 ---
 
 ## Step 1: Query Unblocked Tasks
@@ -72,14 +89,11 @@ If no tasks exist yet, create them from the plan (see `/htmlgraph:plan`).
 
 When executing features that originated from a plan, you must first resolve the track title, then create tasks with readable subject fields.
 
-**Resolve track title before dispatching:**
+**Resolve the track title in the same call that fetched everything else:**
 
-Before creating any tasks, resolve the track's human title by running:
-```
-Bash("htmlgraph track show <trk-id> --format json")
-```
+You already called `htmlgraph execute-preview <trk-id> --format json` in the first discovery step. The track's human title is `.track.title` in that payload — reuse it. Do not issue a second `htmlgraph track show` call just for the title.
 
-Extract the `.title` field. Use it (not the raw track ID) as the outer `Agent()` description when spawning the top-level coordinator:
+Use the title (not the raw track ID) as the outer `Agent()` description when spawning the top-level coordinator:
 
 ```
 Agent(description="Multi-Project MVP: execute plan", ...)  # ✓ GOOD
@@ -442,17 +456,13 @@ Status categories: **ready** (pending, no blockedBy) | **in_progress** | **block
 ## Cleanup After Completion
 
 ```bash
-# Prune all merged worktrees
-git worktree prune
+# Prune merged worktrees and confirm clean state in one call
+git worktree prune && git worktree list
 
-# Remove a specific worktree
-git worktree remove <path>
+# Remove a specific worktree and its branch (chain to avoid leaving orphans)
+git worktree remove <path> && git branch -D worktree-agent-XXXX
 
-# Remove stale branches
-git branch -D worktree-agent-XXXX
-
-# Confirm clean state + run quality gates
-git worktree list
+# Final quality gates
 go build ./... && go vet ./... && go test ./...
 ```
 

--- a/packages/gemini-extension/skills/plan/SKILL.md
+++ b/packages/gemini-extension/skills/plan/SKILL.md
@@ -1,25 +1,28 @@
 ---
 name: htmlgraph:plan
-description: Plan development work with interactive dashboard review before any code is written. Generates a YAML plan, populates slices and questions, runs dual-agent critique, opens dashboard for human review (approvals persist to SQLite), then reads finalized decisions to dispatch tasks. Use when asked to plan, create a development plan, or build a feature with design clarity first.
+description: Plan development work using v2 slice-card YAML. Generates a plan with slice cards as executable specs, runs critique, pauses for human review, then promotes approved slices to features. Use when asked to plan, create a development plan, or build a feature with design clarity first.
 ---
 
 # HtmlGraph Plan
 
-Use this skill when asked to plan development work, create a parallel execution plan, organize tasks for multi-agent execution, or build a feature with human review before implementation.
+Use this skill when asked to plan development work, organize tasks for multi-agent execution, or design a feature with human review before implementation.
 
-**Trigger keywords:** create plan, development plan, parallel plan, plan tasks, parallelize work, organize work, task breakdown, crispi, interactive plan, plan with review, design and build, plan this feature, review before building, generate plan, scaffold plan
+**Trigger keywords:** create plan, development plan, parallel plan, plan tasks, plan this feature, review before building, generate plan, scaffold plan, slice plan, crispi
 
 ---
 
-## What This Skill Does
+## Overview
 
-Generates a structured YAML plan, populates it with vertical slices, design questions with recommendations, and dual-agent critique. Opens the dashboard for interactive human review — approvals persist to SQLite on every click. After finalization, reads approved slices and design decisions to dispatch tasks via `/htmlgraph:execute`.
+A v2 plan is a YAML document containing slice cards. Each slice card is an executable spec — it defines what to build, why it matters, acceptance criteria, and tests. The human reviews and approves slices individually. Approved slices are promoted to feature work items incrementally via `htmlgraph plan promote-slice`.
 
-**Architecture:**
-- **YAML** = plan content (agent-written, read by dashboard)
-- **SQLite `plan_feedback`** = human approvals (persisted on every interaction)
-- **Dashboard** = interactive review UI (reads both, writes approvals to SQLite)
-- **Static HTML** = archival export (on finalize)
+**Spec-driven mapping:**
+
+| Artifact | Role |
+|----------|------|
+| `.htmlgraph/plans/<plan-id>.yaml` | Plan = context document (problem, goals, constraints, slices) |
+| Each slice card (`what/why/done_when/tests`) | Executable spec — what an agent implements |
+| `feat-XXX` work item | Promoted feature = implementation tracker |
+| Sessions and commits | Evidence linked via `implemented_in` edges |
 
 ---
 
@@ -27,388 +30,154 @@ Generates a structured YAML plan, populates it with vertical slices, design ques
 
 Before anything else:
 
-1. Check: `htmlgraph status` — is there an active feature/track for this work?
+1. `htmlgraph status` — is there an active feature/track?
 2. If yes: `htmlgraph feature start <id>`
 3. If no: `htmlgraph feature create "<title>" --track <trk-id>` then `htmlgraph feature start <id>`
 
-Plans without attribution produce untracked work.
-
 ---
 
-## Step 0.5: Check for Already-Finalized Plan
+## Step 1: Research
 
-If the user's request mentions a specific plan ID (e.g. "dispatch plan-a1b2c3d4" or "run step 7 for plan-xxxx"), check its status first:
-
-```bash
-htmlgraph plan show <plan-id> | grep -i status
-```
-
-**If status is `finalized`:** skip Steps 1-6 entirely and go straight to Step 7. The approvals and question answers are already persisted in `plan_feedback`. The plan has already been locked (read-only) — no further revisions are possible without reopening. Hand off directly to `/htmlgraph:execute <plan-id>` or the `htmlgraph yolo` command from the plan details view.
-
-**Do NOT re-run research, critique, or human review on a finalized plan.** If the plan needs revision, ask the user explicitly before reopening.
-
-If the plan status is `draft` or `review`, proceed to Step 1.
-
----
-
-## Step 1b: Check for Existing Plan from Plan Mode
-
-If the user just exited Claude Code's plan mode, the `ExitPlanMode` hook may have already created a skeleton YAML:
-
-```bash
-# Check for recently-created plan YAMLs (within last 5 minutes)
-find .htmlgraph/plans/ -name "plan-*.yaml" -mmin -5 2>/dev/null
-```
-
-If a recent YAML exists:
-1. Read the skeleton YAML — it will have slices with `what` partially populated but `why`, `done_when`, `tests`, `files` mostly empty. The slices may not map to proper delivery slices.
-2. **Do NOT create a new plan** — use this plan ID as the base
-3. Also locate the original `.md` plan file (same directory, most recent `.md` file)
-4. Proceed to Step 1 (research) as normal — the research output will inform the enrichment
-5. In Step 2, **launch enrichment agents instead of writing YAML from scratch** (see Step 2 below)
-
-If no recent YAML exists, proceed to Step 1 (research) and Step 2 as normal.
-
----
-
-## Step 1: Research (Parallel Agents)
-
-Spawn research agents in a single message — do not proceed until both complete:
-
-```
-Agent(description="Understand current codebase state", subagent_type="htmlgraph:researcher",
-      prompt="Investigate [area]. Answer: current state, key files, existing patterns, constraints.")
-
-Agent(description="Check for prior work", subagent_type="Explore",
-      prompt="Search .htmlgraph/ for any features or spikes related to [area]. Report feature IDs and status.")
-```
-
-Research must answer:
-- Current state of the codebase in this area
-- Desired end state (from the request)
-- Open design questions (choices that affect the architecture)
+Research the area before writing any YAML. Answer:
+- Current state of the codebase
+- Desired end state
+- Open design questions (architecture choices)
 - Candidate vertical slices (end-to-end, not horizontal layers)
 - Real dependencies between slices
-- Prior art or existing patterns to leverage
+- Prior art and existing patterns
 
-**Skip research only for:** trivial changes (<10 lines), bug fixes with known root cause, documentation-only changes.
+**Skip only for:** trivial changes, bug fixes with known root cause, documentation-only work.
 
 ---
 
-## Step 2: Generate Plan YAML
+## Step 2: Create the Plan YAML
 
-### Path A: Enriching a skeleton from plan mode (Step 1b found a YAML)
-
-The hook-generated skeleton has structural issues: headings may not map to delivery slices, mandatory fields are empty, and the design section is sparse. **This requires agent reasoning, not just a CLI command.**
-
-Launch parallel enrichment agents — each reads the skeleton YAML + original `.md` + research output, and produces one section of the complete CRISPI YAML:
-
-```
-Agent(description="Enrich design section", subagent_type="htmlgraph:sonnet-coder",
-      prompt="Read the skeleton YAML at .htmlgraph/plans/<plan-id>.yaml and the original
-      plan at .htmlgraph/plans/<name>.md. Also use these research findings: [paste findings].
-      
-      Populate the design section:
-      - design.problem: evidence-based description from the markdown's context/background
-      - design.goals: measurable outcomes extracted from the plan's objectives
-      - design.constraints: real limitations from research findings
-      
-      Write ONLY the design section as YAML to /tmp/design-section.yaml")
-
-Agent(description="Restructure slices", subagent_type="htmlgraph:sonnet-coder",
-      prompt="Read the skeleton YAML at .htmlgraph/plans/<plan-id>.yaml and the original
-      plan at .htmlgraph/plans/<name>.md. Also use these research findings: [paste findings].
-      
-      The skeleton slices may be document sections (Context, Testing, Files Changed),
-      not delivery slices. Restructure them into proper vertical slices:
-      - Each slice = one end-to-end deliverable, not a horizontal layer
-      - Populate ALL mandatory fields: what, why, files, done_when, tests, effort, risk
-      - Set real dependency order in deps
-      - Use slice-N IDs (e.g. slice-1, slice-2) — real feat- IDs are issued at finalize (Step 7b)
-      - Collapse structural sections into slice metadata (testing → done_when, files → files)
-      
-      Write ONLY the slices section as YAML to /tmp/slices-section.yaml")
-
-Agent(description="Generate design questions", subagent_type="htmlgraph:haiku-coder",
-      prompt="Read the skeleton YAML at .htmlgraph/plans/<plan-id>.yaml and the original
-      plan at .htmlgraph/plans/<name>.md. Also use these research findings: [paste findings].
-      
-      Identify 2-5 open design questions where the plan has implicit choices.
-      Each question needs: text, description (context + tradeoffs), recommended option,
-      and 2+ options with descriptive labels.
-      
-      Write ONLY the questions section as YAML to /tmp/questions-section.yaml")
-```
-
-After all agents return, the orchestrator assembles the complete YAML from the three sections, preserving the existing `meta` from the skeleton. Write the assembled plan via:
 ```bash
-htmlgraph plan rewrite-yaml <plan-id> --file /tmp/assembled-plan.yaml
+htmlgraph plan create-yaml "<title>" --description "<description>" --track <trk-id>
 ```
 
-### Path B: Creating a new plan from scratch (no skeleton)
+Note the returned plan ID. Then write the YAML to `.htmlgraph/plans/<plan-id>.yaml` using `htmlgraph plan rewrite-yaml <plan-id> --file /tmp/plan.yaml`.
 
-Generate the plan ID:
-```bash
-htmlgraph plan create "<title>" --description "<description>"
-```
-Note the returned plan ID. Then create the YAML file at `.htmlgraph/plans/<plan-id>.yaml`.
-
-The orchestrator constructs the full YAML structure and writes it directly, or launches the same parallel agents as Path A but without a skeleton to start from (agents use research findings only).
-
-### YAML Schema
-
-Every plan YAML MUST follow this exact structure:
+### v2 YAML Schema
 
 ```yaml
 meta:
-  id: plan-<hex8>          # from plan create
-  track_id: <trk-id>       # if retroactive, empty if plan-first
+  id: plan-<hex8>
+  track_id: <trk-id>
   title: "<plan title>"
   description: >
-    One paragraph describing what this plan designs and why.
+    One paragraph: what this plan designs and why.
   created_at: "YYYY-MM-DD"
-  status: draft             # draft | review | finalized
-  created_by: claude-opus   # agent that generated it
+  status: active              # active | completed
+  created_by: claude-opus
 
 design:
   problem: >
-    What is the current state? What's wrong? Why does this matter?
-    Include measurements, evidence, or user impact.
+    Current state, what is broken, and why it matters.
   goals:
     - "**Goal 1** — measurable outcome"
     - "**Goal 2** — measurable outcome"
   constraints:
-    - "Constraint 1 — why it exists"
-    - "Constraint 2 — why it exists"
+    - "Constraint — why it exists"
   approved: false
   comment: ""
 
 slices:
-  - id: slice-1             # slice-N until finalize; real feat- IDs issued at Step 7b
+  - id: slice-1
     num: 1
     title: "<slice title>"
-    what: >
-      What exactly will be implemented. Be specific — name functions,
-      files, APIs. An agent reading this should know what to build.
-    why: >
-      Why this slice exists. What problem does it solve? What breaks
-      without it? Link to the design goals.
+    what: |
+      What exactly will be implemented. Name functions, files, APIs.
+      An agent reading this should know what to build without asking.
+    why: |
+      Why this slice exists. What problem does it solve? Which goal does
+      it serve? What breaks without it?
     files:
       - path/to/file1.go
       - path/to/file2.go
-    deps: []                 # slice numbers this depends on, e.g. [1, 3]
+    deps: []                  # slice numbers this depends on, e.g. [1, 3]
     done_when:
-      - "Acceptance criterion 1 — testable, concrete"
-      - "Acceptance criterion 2 — testable, concrete"
-    effort: S                # S | M | L
-    risk: Low                # Low | Med | High
+      - "Acceptance criterion 1 — testable and concrete"
+      - "Acceptance criterion 2 — testable and concrete"
+    effort: S                 # S | M | L
+    risk: Low                 # Low | Med | High
     tests: |
-      Unit: specific test description with expected input/output
-      Integration: specific integration test
-      Regression: what existing tests must still pass
+      Unit: specific test with expected input/output
+      Integration: specific integration scenario
+      Regression: which existing tests must still pass
     approved: false
     comment: ""
 
+    # V2 slice-local lifecycle (omit from legacy plans — they remain valid)
+    approval_status: pending  # pending | approved | rejected | changes_requested
+    execution_status: not_started  # not_started | promoted | in_progress | done | blocked | superseded
+    questions:                # slice-local open questions (optional)
+      - id: q-approach
+        text: "Should we use X or Y approach here?"
+        answer: ""            # empty = unanswered
+    critic_revisions:         # critic feedback scoped to this slice (optional)
+      - source: sonnet
+        severity: HIGH
+        summary: "Missing error handling for network timeout path"
+
+  - id: slice-2
+    num: 2
+    # ... (same fields as slice-1)
+
+# Plan-level design questions (optional — prefer slice-local questions for v2)
 questions:
   - id: q-<kebab-name>
-    text: "The design question in plain English?"
+    text: "Design question?"
     description: >
-      Context paragraph explaining WHY this question matters, what
-      tradeoffs are involved, and what evidence exists for each option.
-      The reviewer needs this to make an informed decision.
-    recommended: <option-key>  # agent's best judgment
+      Context: why this question matters and what the tradeoffs are.
+    recommended: option-a
     options:
       - key: option-a
-        label: "A: Short name — Full description of what this option means and its implications"
+        label: "A: Short name — full description"
       - key: option-b
-        label: "B: Short name — Full description of what this option means and its implications"
-    answer: null               # null = unanswered, set by human
+        label: "B: Short name — full description"
+    answer: null              # null = unanswered
 
-critique: null                 # null = not yet run, populated by Step 4
+critique: null                # null = not yet run; populated in Step 4
 ```
 
-### Quality Requirements for Each Section
+### Mandatory slice fields
 
-**Slices — ALL fields are MANDATORY:**
-- `what`: Specific enough that an agent can implement it without asking questions
-- `why`: Links to a design goal or explains the business need
-- `files`: At least one file path (check codebase if unsure)
-- `done_when`: At least two concrete, testable acceptance criteria
-- `tests`: At least one unit test and one integration/regression test
-- `effort`: S (<50 lines), M (50-200 lines), L (>200 lines)
-- `risk`: Low (pure addition), Med (modifies existing), High (changes hot path or shared interfaces)
+All of these must be present and non-empty on every slice:
 
-**Questions — ALL fields are MANDATORY:**
-- `description`: At least 2 sentences explaining context and tradeoffs
-- `recommended`: Agent MUST pick a default — the human overrides only where they disagree
-- `options`: At least 2 options, each with a descriptive label (not just a key)
+| Field | Requirement |
+|-------|-------------|
+| `what` | Specific enough for an agent to implement without further questions |
+| `why` | Links to a design goal or explains the business need |
+| `files` | At least one file path |
+| `done_when` | At least two testable acceptance criteria |
+| `tests` | At least one unit test and one integration/regression test |
+| `effort` | `S` (<50 lines), `M` (50–200 lines), `L` (>200 lines) |
+| `risk` | `Low` (pure addition), `Med` (modifies existing), `High` (changes hot path or shared interface) |
 
-**Design — ALL subsections are MANDATORY:**
-- `problem`: Evidence-based description of current state
-- `goals`: Measurable outcomes (not vague aspirations)
-- `constraints`: Real limitations that affect design choices
+Use `what: |`, `why: |`, and `tests: |` (YAML literal blocks) so Markdown renders correctly in the dashboard.
 
 ---
 
-## Step 3: Validate Plan Structure
-
-Before proceeding, validate the YAML:
-
-1. All required fields present on every slice
-2. All questions have description + recommended
-3. Design has problem + goals + constraints
-4. Slice deps reference valid slice numbers
-5. Effort and risk values are valid (S/M/L, Low/Med/High)
-6. No duplicate slice numbers or question IDs
+## Step 3: Validate
 
 ```bash
 htmlgraph plan validate-yaml <plan-id>
-
 ```
+
+Fix any schema errors before proceeding.
 
 ---
 
-## Step 4: Critique (Parallel Agents)
+## Step 4: Critique (for plans with 3+ slices)
 
-**Trigger:** Always run critique for plans with >= 3 slices. Skip for trivial plans.
+Run two critique agents in parallel. Each reads the plan YAML and produces findings.
 
-Dispatch two critique agents in parallel. Each reads the plan YAML and produces structured findings.
-
-```
-Agent(description="Design critique", subagent_type="htmlgraph:haiku-coder",
-      prompt="Read [plan.yaml]. Produce structured critique. [See prompt template below]")
-
-Agent(description="Feasibility critique", subagent_type="htmlgraph:sonnet-coder",
-      prompt="Read [plan.yaml]. Verify feasibility. [See prompt template below]")
-```
-
-### What Critique Agents Must Do
-
-**For ALL plan types:**
-- **Identify gaps** — what does the plan not address? What's missing?
-- **Challenge assumptions** — what might be wrong? What is the plan taking for granted?
-- **Suggest prior art** — what existing solutions, patterns, libraries, or examples are relevant?
-- **Assess risks** — what could go wrong? What's the worst case? What's the blast radius?
-- **Propose alternatives** — is there a simpler or different approach the plan missed?
-
-**For plans involving existing code, also:**
-- Verify claims against actual code (cite file:line numbers)
-- Check if proposed changes conflict with existing patterns
-- Identify functions/utilities that already exist and can be leveraged
-
-**For greenfield or new ideas, also:**
-- Question user/market assumptions — is there evidence of demand?
-- Identify MVP scope vs full scope — what can be cut?
-- Find real-world examples of similar systems — what can we learn from them?
-- Flag "unknown unknowns" — what will we only discover by building?
-
-### Critique Output Format
-
-Each critique agent produces text in this format:
-
-```
-ASSUMPTIONS:
-A1: [VERIFIED|PLAUSIBLE|UNVERIFIED|QUESTIONABLE|FALSIFIED] text | evidence
-
-SLICE_ASSESSMENTS:
-S1: [assessment with specific concerns]
-
-RISKS:
-R1: risk description | severity: Low/Medium/High | mitigation
-
-GAPS:
-- What the plan doesn't address
-
-ALTERNATIVES:
-- Different approaches worth considering
-
-PRIOR_ART:
-- Relevant existing solutions or patterns
-```
-
-### Writing Critique to YAML
-
-The orchestrator parses both agents' output and writes the `critique` section:
-
-```yaml
-critique:
-  reviewed_at: "YYYY-MM-DD"
-  reviewers:
-    - "Haiku (design review)"
-    - "Sonnet (feasibility)"
-  assumptions:
-    - id: A1
-      status: verified       # verified|plausible|unverified|questionable|falsified
-      text: "The assumption being tested"
-      evidence: "file:line or reasoning"
-  critics:
-    - title: "DESIGN CRITIC"
-      sections:
-        - heading: "Slice Assessment"
-          items:
-            - badge: "S1"
-              kind: success   # success|warn|danger|info
-              text: "Assessment text"
-        - heading: "Gaps & Missing Considerations"
-          items:
-            - badge: "Gap"
-              kind: warn
-              text: "What the plan doesn't address"
-        - heading: "Alternative Approaches"
-          items:
-            - badge: "Alt"
-              kind: info
-              text: "A different approach worth considering"
-    - title: "FEASIBILITY CRITIC"
-      sections:
-        - heading: "What Exists to Leverage"
-          items: [...]
-        - heading: "What the Plan Gets Wrong"
-          items: [...]
-        - heading: "Prior Art & Examples"
-          items: [...]
-  risks:
-    - risk: "Risk description"
-      severity: High          # High|Medium|Low
-      mitigation: "How to mitigate"
-  synthesis: >
-    Summary of key findings. What must change before the plan is approved?
-    Numbered action items.
-```
+After critique, integrate HIGH/DANGER findings directly into the affected slice cards as `critic_revisions` entries. Rewrite the YAML via `htmlgraph plan rewrite-yaml`.
 
 ---
 
-## Step 4b: Address Critique Findings (MANDATORY before review)
-
-After critique agents return, the orchestrator MUST update the plan to address findings before launching review. The human should review the critique-informed version, not the stale original.
-
-**For each FALSIFIED assumption:**
-- Update the affected slice's `what` and `done_when` to address the falsification
-- Add the corrected understanding to `design.constraints` if it affects the whole plan
-
-**For each HIGH severity risk:**
-- Add the mitigation as a `done_when` criterion on the affected slice
-- If no slice owns the risk, add it to design constraints
-
-**For each missing consideration identified by critics:**
-- Add as a new question (if it's a design choice) or a new constraint (if it's a fact)
-
-**Process:**
-1. Parse both critique outputs for FALSIFIED/HIGH items
-2. Read the current plan YAML
-3. Modify the affected sections in memory
-4. Write to temp file
-5. Run: `htmlgraph plan rewrite-yaml <plan-id> --file /tmp/revised.yaml`
-6. Git auto-commits the revision with message: `plan(<id>): address critique findings`
-7. Proceed to Step 5 (review) with the updated plan
-
-**Skip Step 4b only if:** all assumptions are verified/plausible AND no HIGH severity risks exist.
-
----
-
-## Step 5: Open for Human Review (PAUSE HERE)
-
-Direct the human to review the plan in the dashboard:
+## Step 5: Open for Human Review (PAUSE)
 
 ```bash
 htmlgraph serve
@@ -417,160 +186,199 @@ htmlgraph serve
 Tell the human:
 
 ```
-Plan ready for review in the dashboard:
+Plan ready for review in the dashboard at http://localhost:8088/#plans
 
-  htmlgraph serve
-  Open http://localhost:8080/#plans and click the plan.
+Per-slice review:
+  1. Read each slice card — what/why/done_when/tests
+  2. Approve or reject each slice individually
+  3. Answer any slice-local questions
+  4. Read the critique revisions embedded in each card
 
-Please:
-1. Read the Design Discussion — Problem, Goals, Constraints
-2. Review each Slice — approve or leave unchecked
-3. Answer the Open Questions — defaults are recommended, override where you disagree
-4. Read the AI Critique — note any risks or gaps
-5. Check the Feedback Summary — progress bar shows completion
-6. Click Finalize when all sections are approved
+CLI shortcuts (if reviewing outside the dashboard):
+  htmlgraph plan approve-slice <plan-id> <num>
+  htmlgraph plan reject-slice <plan-id> <num> [--changes-requested]
+  htmlgraph plan answer-slice-question <plan-id> <num> <question-id> <answer-key>
 
-Your approvals persist automatically — you can close and reopen without losing progress.
-
-I will wait until you finalize the plan before writing any code.
+I will wait until you signal readiness before promoting any slices.
 ```
 
-**STOP. Do not proceed until the human finalizes the plan.**
+**STOP. Do not promote slices until the human has reviewed.**
 
-### Monitoring Review Progress
+---
 
-Poll SQLite to check if the human has finalized:
+## Step 6: Read Decisions and Integrate Feedback
 
 ```bash
-# Check approval progress
-sqlite3 .htmlgraph/htmlgraph.db \
-  "SELECT section, value FROM plan_feedback WHERE plan_id='<plan-id>' AND action='approve'"
+htmlgraph plan read-feedback-yaml <plan-id>
+```
 
-# Check if all slices approved
-sqlite3 .htmlgraph/htmlgraph.db \
-  "SELECT COUNT(*) as approved FROM plan_feedback WHERE plan_id='<plan-id>' AND action='approve' AND value='True'"
+For rejected slices: update the YAML to address the rejection, then re-run Step 5.
+For slices with `changes_requested`: revise the slice card and re-present.
+For answered questions: bake the decision into the affected slice's `what` field.
 
-# Check question answers
-sqlite3 .htmlgraph/htmlgraph.db \
-  "SELECT question_id, value FROM plan_feedback WHERE plan_id='<plan-id>' AND action='answer'"
+---
+
+## Step 7: Promote Approved Slices
+
+Promote slices incrementally as they are approved — no need to wait for full-plan finalization.
+
+```bash
+# Promote a single approved slice (creates feat-XXX, wires edges):
+htmlgraph plan promote-slice <plan-id> <slice-num>
+
+# If a slice's deps are already done externally (e.g. already in-flight):
+htmlgraph plan promote-slice <plan-id> <slice-num> --waive-deps
+```
+
+Rules:
+- The slice must have `approval_status=approved` (set via `approve-slice`).
+- All dependency slices must have `execution_status=done` or `superseded`, unless `--waive-deps`.
+- `promote-slice` is idempotent: if `feature_id` is already set, it reuses the existing feature.
+- After promotion, `execution_status` is set to `promoted` in both YAML and `plan_feedback`.
+
+The command prints the promoted `feat-XXX` ID. That feature is now part of the track and participates in the dependency-driven dispatch loop (see `/htmlgraph:execute`).
+
+### Promotion workflow for a multi-slice plan
+
+```
+for each slice (in dependency order):
+  1. Review → htmlgraph plan approve-slice <plan-id> <num>
+  2. Promote → htmlgraph plan promote-slice <plan-id> <num>
+  3. Track execution → htmlgraph plan set-slice-status <plan-id> <num> in_progress
+  4. When done → htmlgraph plan set-slice-status <plan-id> <num> done
 ```
 
 ---
 
-## Step 6: Read Finalized Decisions
+## Step 8: Close the Plan
 
-After the human clicks Finalize in the dashboard, read all feedback:
+When all slices are done, rejected, or superseded:
 
 ```bash
-# Read all feedback — approvals, answers, amendments, chat
-htmlgraph plan feedback <plan-id>
+htmlgraph plan set-status <plan-id> completed
 ```
-
-This outputs JSON with the complete review context:
-
-```json
-{
-  "plan_id": "plan-abc123",
-  "approvals": {"slice-1": {"approved": true}, "slice-2": {"approved": false, "comment": "too risky"}},
-  "answers": {"q-caching": "lazy", "q-error-handling": "metric-counter"},
-  "amendments": [{"field": "what", "slice": 1, "op": "set", "value": "updated description"}],
-  "chat_messages": [{"role": "user", "content": "...", "timestamp": "..."}]
-}
-```
-
-Parse the results:
-- If any slice has `approved: false`: summarize what was rejected. Ask the human — revise or proceed without?
-- If revising: update the YAML, loop to Step 5.
-- If proceeding: note excluded slices.
 
 ---
 
-## Step 7: Revise Plan, Create Features, and Dispatch
+## CLI Reference for Slice Lifecycle
 
-Finalization is an **agentic process**. You synthesize all review feedback into a revised plan, then create properly structured features.
-
-### 7a. Revise the Plan
-
-Read the plan YAML and the feedback from Step 6. Produce a **revised version** of the plan that incorporates:
-
-- **Amendments**: Apply accepted amendment changes to slice descriptions, titles, deps
-- **Chat discussion**: If the chat contains decisions, clarifications, or scope changes, reflect them in the affected slices
-- **Design decisions**: Bake answered questions into relevant slice descriptions under "Accepted Design Decisions"
-- **Rejected slices**: Remove or mark as excluded
-- **Critique insights**: If critique raised risks or assumptions that were discussed, note mitigations in affected slices
-
-The revised YAML's `slice.what` field becomes the feature description at finalize time (via `buildSliceFeatureContent`). If you need richer per-feature content — e.g., incorporating chat discussion specific to that slice — write it into `slice.what` during revision. Do not rely on finalize to synthesize it.
-
-Update the YAML via:
-
-```bash
-htmlgraph plan rewrite-yaml <plan-id> --file /tmp/revised.yaml
-```
-
-This validates the revised structure and auto-commits with version history.
-
-### 7b. Finalize via the Canonical Command
-
-Call the single, atomic finalize command:
-
-```bash
-htmlgraph plan finalize <plan-id>
-```
-
-This command:
-1. Reads approvals and answers from SQLite `plan_feedback` table
-2. Loops over approved slices and creates features using the slice's Title and What (or Why fallback) as content
-3. Writes each created `FeatureID` back into the slice YAML
-4. Emits edges: `planned_in` (feature→plan), `part_of`/`contains` (feature↔track), `implemented_in` (plan→track)
-5. Sets plan status to `finalized` and locks it (subsequent calls error with "plan is locked … use 'plan reopen'")
-
-If finalize errors with "plan is locked", the plan was previously finalized. Run `htmlgraph plan reopen <plan-id>` first, revise Step 7a, then re-finalize. The finalize command is idempotent: slices whose `feature_id` is already set and whose feature exists will be reused rather than duplicated; only new or orphaned slices create new features.
-
-If finalize errors on missing track, description, or slices, the error message is actionable — fix the YAML and re-run.
-
-### 7c. Announce the Finalized Plan
-
-```
-Plan finalized. Track: <track-id>
-
-Approved slices (N of M):
-  feat-XXXX  Slice 1 title       -> implement
-  feat-XXXX  Slice 2 title       -> implement
-
-Rejected slices:
-  Slice 3 title                  -> excluded (not approved)
-
-Design decisions:
-  Q1: Migration caching: schema-version (recommended, accepted)
-  Q2: Error handling: metric-counter (overrode recommendation: structured-log)
-  Q3: SessionStart scope: git-only (recommended, accepted)
-```
-
-Then hand off to `/htmlgraph:execute`.
+| Command | Usage | Effect |
+|---------|-------|--------|
+| `approve-slice` | `htmlgraph plan approve-slice <plan-id> <num>` | Sets `approval_status=approved` in `plan_feedback` |
+| `reject-slice` | `htmlgraph plan reject-slice <plan-id> <num> [--changes-requested]` | Sets `approval_status=rejected` or `changes_requested` |
+| `answer-slice-question` | `htmlgraph plan answer-slice-question <plan-id> <num> <question-id> <answer-key>` | Records answer to a slice-local question |
+| `set-slice-status` | `htmlgraph plan set-slice-status <plan-id> <num> <status>` | Sets `execution_status` (`not_started\|promoted\|in_progress\|done\|blocked\|superseded`) |
+| `promote-slice` | `htmlgraph plan promote-slice <plan-id> <num> [--waive-deps]` | Creates `feat-XXX`, wires edges, sets `execution_status=promoted` |
 
 ---
 
-## Agent Type Selection
+## Section-Naming Contract
 
-| Agent | When to Use |
-|-------|------------|
-| `htmlgraph:haiku-coder` | Critique (design review), single-file tasks, <50 lines |
-| `htmlgraph:sonnet-coder` | Critique (feasibility), multi-file tasks, moderate complexity |
-| `htmlgraph:opus-coder` | Architecture decisions, complex algorithms, novel design |
+State stored in `plan_feedback` uses these section keys:
 
-Default to sonnet unless the task is trivially simple (haiku) or requires deep reasoning (opus).
+| Key pattern | What it stores |
+|-------------|----------------|
+| `slice-<num>` | Slice-level approval (`action=approve`) and execution status (`action=set_execution_status`) |
+| `slice-<num>-question-<id>` | Answer to a slice-local question (`action=answer`) |
+| `design` | Design section approval |
+| `questions` | Plan-level question answers |
+
+The `answer-slice-question` command maps `<slice-num>` and `<question-id>` to the section key automatically.
+
+---
+
+## Minimal Example (2-slice plan)
+
+```yaml
+meta:
+  id: plan-a1b2c3d4
+  track_id: trk-xyz
+  title: "Add rate limiting to API"
+  status: active
+  created_at: "2026-04-28"
+
+design:
+  problem: >
+    The /api/ingest endpoint accepts unbounded request volume. Under load,
+    the SQLite writer becomes a bottleneck and drops events silently.
+  goals:
+    - "**Throughput cap** — reject requests above 100 req/s per client with 429"
+    - "**Visibility** — expose a counter metric for throttled requests"
+  constraints:
+    - "No new runtime dependencies — use stdlib only"
+  approved: false
+  comment: ""
+
+slices:
+  - id: slice-1
+    num: 1
+    title: "In-memory rate limiter middleware"
+    what: |
+      Add `internal/ratelimit/limiter.go`: a token-bucket limiter keyed by
+      client IP. Wire it as HTTP middleware in `cmd/htmlgraph/serve.go`.
+      Return HTTP 429 with a JSON error body when the bucket is empty.
+    why: |
+      Protects the SQLite writer from burst overload. Addresses the throughput
+      cap goal.
+    files:
+      - internal/ratelimit/limiter.go
+      - cmd/htmlgraph/serve.go
+    deps: []
+    done_when:
+      - "Requests above the configured limit receive HTTP 429"
+      - "Requests within the limit pass through unchanged"
+    effort: S
+    risk: Low
+    tests: |
+      Unit: TestLimiter_Allow — burst of 10 req/s, expect first 5 allowed, next rejected
+      Integration: TestServeRateLimit — spin up server, hammer /api/ingest, assert 429s
+    approval_status: pending
+    execution_status: not_started
+
+  - id: slice-2
+    num: 2
+    title: "Throttle counter metric"
+    what: |
+      Increment a `htmlgraph_throttled_total` counter in the limiter middleware.
+      Expose it on the existing `/metrics` endpoint via the Prometheus-compatible
+      text format already used by `cmd/htmlgraph/metrics.go`.
+    why: |
+      Addresses the visibility goal. Without this, operators cannot tell whether
+      rate limiting is firing or calibrated correctly.
+    files:
+      - internal/ratelimit/limiter.go
+      - cmd/htmlgraph/metrics.go
+    deps: [1]
+    done_when:
+      - "`htmlgraph_throttled_total` increments on each 429 response"
+      - "Counter is present in /metrics output"
+    effort: S
+    risk: Low
+    tests: |
+      Unit: TestLimiterMetric — after N rejections, counter equals N
+      Regression: existing /metrics tests still pass
+    approval_status: pending
+    execution_status: not_started
+
+questions: []
+critique: null
+```
+
+---
+
+## Legacy Compatibility
+
+Plans created before v2 (without `approval_status`, `execution_status`, `questions`, or `critic_revisions` on slices) remain valid. The schema treats these fields as optional (`omitempty`). The dashboard renders them via a global Questions/Critique fallback when the v2 slice-card fields are absent.
+
+Legacy plans can be migrated incrementally: add v2 fields to individual slices as they come up for review, without touching the rest of the YAML.
 
 ---
 
 ## Key Rules
 
-- **Plans are YAML files** — agents write structured data, not HTML strings
-- **All slice fields are mandatory** — What, Why, Files, DoneWhen, Tests, Effort, Risk
-- **All questions need context** — description + recommended option
-- **Design has three subsections** — Problem, Goals, Constraints (not a single blob)
-- **Critique challenges assumptions** — not just verifies code
-- **Approvals persist to SQLite** — human can close and reopen without losing state
-- **Finalize is explicit** — human clicks the button, not the agent
-- **TDD is mandatory** — every dispatched task includes tests before implementation
-- **Only approved slices** become features on dispatch
-- **Finalize is atomic** — `htmlgraph plan finalize` handles feature creation, edge wiring, and status transition in one command. Agents do not call `feature create` or `plan wire` directly during finalization.
+- **v2 slices are slice cards** — each card contains its own questions, critic revisions, approval status, and execution status
+- **Use literal blocks** (`|`) for `what`, `why`, `tests` so Markdown renders in the dashboard
+- **Promote incrementally** — `promote-slice` does not require full-plan finalization
+- **Critique is embedded per-slice** — use `critic_revisions` instead of a global critique section for v2 plans
+- **All slice fields are mandatory** — missing fields will fail `validate-yaml`
+- **Finalize is for legacy plans** — v2 plans use `promote-slice` per slice; `htmlgraph plan finalize` is the legacy all-at-once path

--- a/packages/gemini-extension/static/components.js
+++ b/packages/gemini-extension/static/components.js
@@ -65,21 +65,58 @@ class HgActivityFeed extends HTMLElement {
 
   async refresh() {
     try {
-      const resp = await fetch('/api/events/recent?limit=20');
+      const resp = await fetch('/api/events/feed?limit=20');
       if (!resp.ok) return;
-      const events = await resp.json();
+      const data = await resp.json();
+      const events = data.events || [];
       const feed = this.querySelector('.hg-feed');
+      // Build DOM nodes via textContent/dataset rather than innerHTML so
+      // OTel-sourced summaries — which now include raw user prompts and
+      // tool content — cannot inject HTML or script into the dashboard.
+      feed.replaceChildren();
       if (!events.length) {
-        feed.innerHTML = '<p class="hg-feed-empty">No recent activity</p>';
+        const empty = document.createElement('p');
+        empty.className = 'hg-feed-empty';
+        empty.textContent = 'No recent activity';
+        feed.appendChild(empty);
         return;
       }
-      feed.innerHTML = events.map(e => `
-        <div class="hg-feed-item" data-event-type="${e.event_type || ''}">
-          <span class="hg-feed-time">${new Date(e.timestamp).toLocaleTimeString()}</span>
-          <span class="hg-feed-tool">${e.tool_name || e.event_type || 'event'}</span>
-          <span class="hg-feed-summary">${e.output_summary || e.input_summary || ''}</span>
-        </div>
-      `).join('');
+      for (const e of events) {
+        const item = document.createElement('div');
+        item.className = 'hg-feed-item';
+        item.dataset.eventType = e.type || '';
+        item.dataset.source = e.source || '';
+
+        const time = document.createElement('span');
+        time.className = 'hg-feed-time';
+        time.textContent = new Date(e.timestamp).toLocaleTimeString();
+        item.appendChild(time);
+
+        const tool = document.createElement('span');
+        tool.className = 'hg-feed-tool';
+        tool.textContent = e.tool_name || e.type || 'event';
+        item.appendChild(tool);
+
+        if (e.duration_ms > 0) {
+          const dur = document.createElement('span');
+          dur.className = 'hg-feed-badge hg-feed-badge-dur';
+          dur.textContent = `${e.duration_ms}ms`;
+          item.appendChild(dur);
+        }
+        if (e.cost_usd > 0) {
+          const cost = document.createElement('span');
+          cost.className = 'hg-feed-badge hg-feed-badge-cost';
+          cost.textContent = `$${e.cost_usd.toFixed(3)}`;
+          item.appendChild(cost);
+        }
+
+        const summary = document.createElement('span');
+        summary.className = 'hg-feed-summary';
+        summary.textContent = e.summary || '';
+        item.appendChild(summary);
+
+        feed.appendChild(item);
+      }
     } catch (_) { /* server not available */ }
   }
 }

--- a/plugin/skills/execute/SKILL.md
+++ b/plugin/skills/execute/SKILL.md
@@ -62,6 +62,8 @@ LOOP:
 
 This maximizes parallelism automatically. If 10 of 13 tasks are independent, all 10 run in the first dispatch — no artificial wave boundaries.
 
+Slices promoted via `htmlgraph plan promote-slice` from a still-active plan are dispatched through the same dependency-readiness loop — they appear as features linked to the track via `part_of` edges and are ready to dispatch as soon as their `blocked_by` deps are complete.
+
 ---
 
 ## Step 1: Query Unblocked Tasks

--- a/plugin/skills/execute/SKILL.md
+++ b/plugin/skills/execute/SKILL.md
@@ -64,6 +64,10 @@ This maximizes parallelism automatically. If 10 of 13 tasks are independent, all
 
 Slices promoted via `htmlgraph plan promote-slice` from a still-active plan are dispatched through the same dependency-readiness loop — they appear as features linked to the track via `part_of` edges and are ready to dispatch as soon as their `blocked_by` deps are complete.
 
+### Incremental slice promotion
+
+When a track is executing a v2 plan, slices may be promoted one at a time rather than all at once. Each call to `htmlgraph plan promote-slice <plan-id> <num>` creates a `feat-XXX` linked to the track and marks the slice `execution_status=promoted`. That feature immediately appears in `htmlgraph execute-preview <trk-id>` and enters the dispatch loop. Dep-blocked slices stay in the `blocked` bucket until their dependencies complete, exactly like manually created features. No special handling is required — promoted slices are regular features from the executor's perspective.
+
 ---
 
 ## Step 1: Query Unblocked Tasks

--- a/plugin/skills/plan/SKILL.md
+++ b/plugin/skills/plan/SKILL.md
@@ -1,25 +1,28 @@
 ---
 name: htmlgraph:plan
-description: Plan development work with interactive dashboard review before any code is written. Generates a YAML plan, populates slices and questions, runs dual-agent critique, opens dashboard for human review (approvals persist to SQLite), then reads finalized decisions to dispatch tasks. Use when asked to plan, create a development plan, or build a feature with design clarity first.
+description: Plan development work using v2 slice-card YAML. Generates a plan with slice cards as executable specs, runs critique, pauses for human review, then promotes approved slices to features. Use when asked to plan, create a development plan, or build a feature with design clarity first.
 ---
 
 # HtmlGraph Plan
 
-Use this skill when asked to plan development work, create a parallel execution plan, organize tasks for multi-agent execution, or build a feature with human review before implementation.
+Use this skill when asked to plan development work, organize tasks for multi-agent execution, or design a feature with human review before implementation.
 
-**Trigger keywords:** create plan, development plan, parallel plan, plan tasks, parallelize work, organize work, task breakdown, crispi, interactive plan, plan with review, design and build, plan this feature, review before building, generate plan, scaffold plan
+**Trigger keywords:** create plan, development plan, parallel plan, plan tasks, plan this feature, review before building, generate plan, scaffold plan, slice plan, crispi
 
 ---
 
-## What This Skill Does
+## Overview
 
-Generates a structured YAML plan, populates it with vertical slices, design questions with recommendations, and dual-agent critique. Opens the dashboard for interactive human review — approvals persist to SQLite on every click. After finalization, reads approved slices and design decisions to dispatch tasks via `/htmlgraph:execute`.
+A v2 plan is a YAML document containing slice cards. Each slice card is an executable spec — it defines what to build, why it matters, acceptance criteria, and tests. The human reviews and approves slices individually. Approved slices are promoted to feature work items incrementally via `htmlgraph plan promote-slice`.
 
-**Architecture:**
-- **YAML** = plan content (agent-written, read by dashboard)
-- **SQLite `plan_feedback`** = human approvals (persisted on every interaction)
-- **Dashboard** = interactive review UI (reads both, writes approvals to SQLite)
-- **Static HTML** = archival export (on finalize)
+**Spec-driven mapping:**
+
+| Artifact | Role |
+|----------|------|
+| `.htmlgraph/plans/<plan-id>.yaml` | Plan = context document (problem, goals, constraints, slices) |
+| Each slice card (`what/why/done_when/tests`) | Executable spec — what an agent implements |
+| `feat-XXX` work item | Promoted feature = implementation tracker |
+| Sessions and commits | Evidence linked via `implemented_in` edges |
 
 ---
 
@@ -27,388 +30,154 @@ Generates a structured YAML plan, populates it with vertical slices, design ques
 
 Before anything else:
 
-1. Check: `htmlgraph status` — is there an active feature/track for this work?
+1. `htmlgraph status` — is there an active feature/track?
 2. If yes: `htmlgraph feature start <id>`
 3. If no: `htmlgraph feature create "<title>" --track <trk-id>` then `htmlgraph feature start <id>`
 
-Plans without attribution produce untracked work.
-
 ---
 
-## Step 0.5: Check for Already-Finalized Plan
+## Step 1: Research
 
-If the user's request mentions a specific plan ID (e.g. "dispatch plan-a1b2c3d4" or "run step 7 for plan-xxxx"), check its status first:
-
-```bash
-htmlgraph plan show <plan-id> | grep -i status
-```
-
-**If status is `finalized`:** skip Steps 1-6 entirely and go straight to Step 7. The approvals and question answers are already persisted in `plan_feedback`. The plan has already been locked (read-only) — no further revisions are possible without reopening. Hand off directly to `/htmlgraph:execute <plan-id>` or the `htmlgraph yolo` command from the plan details view.
-
-**Do NOT re-run research, critique, or human review on a finalized plan.** If the plan needs revision, ask the user explicitly before reopening.
-
-If the plan status is `draft` or `review`, proceed to Step 1.
-
----
-
-## Step 1b: Check for Existing Plan from Plan Mode
-
-If the user just exited Claude Code's plan mode, the `ExitPlanMode` hook may have already created a skeleton YAML:
-
-```bash
-# Check for recently-created plan YAMLs (within last 5 minutes)
-find .htmlgraph/plans/ -name "plan-*.yaml" -mmin -5 2>/dev/null
-```
-
-If a recent YAML exists:
-1. Read the skeleton YAML — it will have slices with `what` partially populated but `why`, `done_when`, `tests`, `files` mostly empty. The slices may not map to proper delivery slices.
-2. **Do NOT create a new plan** — use this plan ID as the base
-3. Also locate the original `.md` plan file (same directory, most recent `.md` file)
-4. Proceed to Step 1 (research) as normal — the research output will inform the enrichment
-5. In Step 2, **launch enrichment agents instead of writing YAML from scratch** (see Step 2 below)
-
-If no recent YAML exists, proceed to Step 1 (research) and Step 2 as normal.
-
----
-
-## Step 1: Research (Parallel Agents)
-
-Spawn research agents in a single message — do not proceed until both complete:
-
-```
-Agent(description="Understand current codebase state", subagent_type="htmlgraph:researcher",
-      prompt="Investigate [area]. Answer: current state, key files, existing patterns, constraints.")
-
-Agent(description="Check for prior work", subagent_type="Explore",
-      prompt="Search .htmlgraph/ for any features or spikes related to [area]. Report feature IDs and status.")
-```
-
-Research must answer:
-- Current state of the codebase in this area
-- Desired end state (from the request)
-- Open design questions (choices that affect the architecture)
+Research the area before writing any YAML. Answer:
+- Current state of the codebase
+- Desired end state
+- Open design questions (architecture choices)
 - Candidate vertical slices (end-to-end, not horizontal layers)
 - Real dependencies between slices
-- Prior art or existing patterns to leverage
+- Prior art and existing patterns
 
-**Skip research only for:** trivial changes (<10 lines), bug fixes with known root cause, documentation-only changes.
+**Skip only for:** trivial changes, bug fixes with known root cause, documentation-only work.
 
 ---
 
-## Step 2: Generate Plan YAML
+## Step 2: Create the Plan YAML
 
-### Path A: Enriching a skeleton from plan mode (Step 1b found a YAML)
-
-The hook-generated skeleton has structural issues: headings may not map to delivery slices, mandatory fields are empty, and the design section is sparse. **This requires agent reasoning, not just a CLI command.**
-
-Launch parallel enrichment agents — each reads the skeleton YAML + original `.md` + research output, and produces one section of the complete CRISPI YAML:
-
-```
-Agent(description="Enrich design section", subagent_type="htmlgraph:sonnet-coder",
-      prompt="Read the skeleton YAML at .htmlgraph/plans/<plan-id>.yaml and the original
-      plan at .htmlgraph/plans/<name>.md. Also use these research findings: [paste findings].
-      
-      Populate the design section:
-      - design.problem: evidence-based description from the markdown's context/background
-      - design.goals: measurable outcomes extracted from the plan's objectives
-      - design.constraints: real limitations from research findings
-      
-      Write ONLY the design section as YAML to /tmp/design-section.yaml")
-
-Agent(description="Restructure slices", subagent_type="htmlgraph:sonnet-coder",
-      prompt="Read the skeleton YAML at .htmlgraph/plans/<plan-id>.yaml and the original
-      plan at .htmlgraph/plans/<name>.md. Also use these research findings: [paste findings].
-      
-      The skeleton slices may be document sections (Context, Testing, Files Changed),
-      not delivery slices. Restructure them into proper vertical slices:
-      - Each slice = one end-to-end deliverable, not a horizontal layer
-      - Populate ALL mandatory fields: what, why, files, done_when, tests, effort, risk
-      - Set real dependency order in deps
-      - Use slice-N IDs (e.g. slice-1, slice-2) — real feat- IDs are issued at finalize (Step 7b)
-      - Collapse structural sections into slice metadata (testing → done_when, files → files)
-      
-      Write ONLY the slices section as YAML to /tmp/slices-section.yaml")
-
-Agent(description="Generate design questions", subagent_type="htmlgraph:haiku-coder",
-      prompt="Read the skeleton YAML at .htmlgraph/plans/<plan-id>.yaml and the original
-      plan at .htmlgraph/plans/<name>.md. Also use these research findings: [paste findings].
-      
-      Identify 2-5 open design questions where the plan has implicit choices.
-      Each question needs: text, description (context + tradeoffs), recommended option,
-      and 2+ options with descriptive labels.
-      
-      Write ONLY the questions section as YAML to /tmp/questions-section.yaml")
-```
-
-After all agents return, the orchestrator assembles the complete YAML from the three sections, preserving the existing `meta` from the skeleton. Write the assembled plan via:
 ```bash
-htmlgraph plan rewrite-yaml <plan-id> --file /tmp/assembled-plan.yaml
+htmlgraph plan create-yaml "<title>" --description "<description>" --track <trk-id>
 ```
 
-### Path B: Creating a new plan from scratch (no skeleton)
+Note the returned plan ID. Then write the YAML to `.htmlgraph/plans/<plan-id>.yaml` using `htmlgraph plan rewrite-yaml <plan-id> --file /tmp/plan.yaml`.
 
-Generate the plan ID:
-```bash
-htmlgraph plan create "<title>" --description "<description>"
-```
-Note the returned plan ID. Then create the YAML file at `.htmlgraph/plans/<plan-id>.yaml`.
-
-The orchestrator constructs the full YAML structure and writes it directly, or launches the same parallel agents as Path A but without a skeleton to start from (agents use research findings only).
-
-### YAML Schema
-
-Every plan YAML MUST follow this exact structure:
+### v2 YAML Schema
 
 ```yaml
 meta:
-  id: plan-<hex8>          # from plan create
-  track_id: <trk-id>       # if retroactive, empty if plan-first
+  id: plan-<hex8>
+  track_id: <trk-id>
   title: "<plan title>"
   description: >
-    One paragraph describing what this plan designs and why.
+    One paragraph: what this plan designs and why.
   created_at: "YYYY-MM-DD"
-  status: draft             # draft | review | finalized
-  created_by: claude-opus   # agent that generated it
+  status: active              # active | completed
+  created_by: claude-opus
 
 design:
   problem: >
-    What is the current state? What's wrong? Why does this matter?
-    Include measurements, evidence, or user impact.
+    Current state, what is broken, and why it matters.
   goals:
     - "**Goal 1** — measurable outcome"
     - "**Goal 2** — measurable outcome"
   constraints:
-    - "Constraint 1 — why it exists"
-    - "Constraint 2 — why it exists"
+    - "Constraint — why it exists"
   approved: false
   comment: ""
 
 slices:
-  - id: slice-1             # slice-N until finalize; real feat- IDs issued at Step 7b
+  - id: slice-1
     num: 1
     title: "<slice title>"
-    what: >
-      What exactly will be implemented. Be specific — name functions,
-      files, APIs. An agent reading this should know what to build.
-    why: >
-      Why this slice exists. What problem does it solve? What breaks
-      without it? Link to the design goals.
+    what: |
+      What exactly will be implemented. Name functions, files, APIs.
+      An agent reading this should know what to build without asking.
+    why: |
+      Why this slice exists. What problem does it solve? Which goal does
+      it serve? What breaks without it?
     files:
       - path/to/file1.go
       - path/to/file2.go
-    deps: []                 # slice numbers this depends on, e.g. [1, 3]
+    deps: []                  # slice numbers this depends on, e.g. [1, 3]
     done_when:
-      - "Acceptance criterion 1 — testable, concrete"
-      - "Acceptance criterion 2 — testable, concrete"
-    effort: S                # S | M | L
-    risk: Low                # Low | Med | High
+      - "Acceptance criterion 1 — testable and concrete"
+      - "Acceptance criterion 2 — testable and concrete"
+    effort: S                 # S | M | L
+    risk: Low                 # Low | Med | High
     tests: |
-      Unit: specific test description with expected input/output
-      Integration: specific integration test
-      Regression: what existing tests must still pass
+      Unit: specific test with expected input/output
+      Integration: specific integration scenario
+      Regression: which existing tests must still pass
     approved: false
     comment: ""
 
+    # V2 slice-local lifecycle (omit from legacy plans — they remain valid)
+    approval_status: pending  # pending | approved | rejected | changes_requested
+    execution_status: not_started  # not_started | promoted | in_progress | done | blocked | superseded
+    questions:                # slice-local open questions (optional)
+      - id: q-approach
+        text: "Should we use X or Y approach here?"
+        answer: ""            # empty = unanswered
+    critic_revisions:         # critic feedback scoped to this slice (optional)
+      - source: sonnet
+        severity: HIGH
+        summary: "Missing error handling for network timeout path"
+
+  - id: slice-2
+    num: 2
+    # ... (same fields as slice-1)
+
+# Plan-level design questions (optional — prefer slice-local questions for v2)
 questions:
   - id: q-<kebab-name>
-    text: "The design question in plain English?"
+    text: "Design question?"
     description: >
-      Context paragraph explaining WHY this question matters, what
-      tradeoffs are involved, and what evidence exists for each option.
-      The reviewer needs this to make an informed decision.
-    recommended: <option-key>  # agent's best judgment
+      Context: why this question matters and what the tradeoffs are.
+    recommended: option-a
     options:
       - key: option-a
-        label: "A: Short name — Full description of what this option means and its implications"
+        label: "A: Short name — full description"
       - key: option-b
-        label: "B: Short name — Full description of what this option means and its implications"
-    answer: null               # null = unanswered, set by human
+        label: "B: Short name — full description"
+    answer: null              # null = unanswered
 
-critique: null                 # null = not yet run, populated by Step 4
+critique: null                # null = not yet run; populated in Step 4
 ```
 
-### Quality Requirements for Each Section
+### Mandatory slice fields
 
-**Slices — ALL fields are MANDATORY:**
-- `what`: Specific enough that an agent can implement it without asking questions
-- `why`: Links to a design goal or explains the business need
-- `files`: At least one file path (check codebase if unsure)
-- `done_when`: At least two concrete, testable acceptance criteria
-- `tests`: At least one unit test and one integration/regression test
-- `effort`: S (<50 lines), M (50-200 lines), L (>200 lines)
-- `risk`: Low (pure addition), Med (modifies existing), High (changes hot path or shared interfaces)
+All of these must be present and non-empty on every slice:
 
-**Questions — ALL fields are MANDATORY:**
-- `description`: At least 2 sentences explaining context and tradeoffs
-- `recommended`: Agent MUST pick a default — the human overrides only where they disagree
-- `options`: At least 2 options, each with a descriptive label (not just a key)
+| Field | Requirement |
+|-------|-------------|
+| `what` | Specific enough for an agent to implement without further questions |
+| `why` | Links to a design goal or explains the business need |
+| `files` | At least one file path |
+| `done_when` | At least two testable acceptance criteria |
+| `tests` | At least one unit test and one integration/regression test |
+| `effort` | `S` (<50 lines), `M` (50–200 lines), `L` (>200 lines) |
+| `risk` | `Low` (pure addition), `Med` (modifies existing), `High` (changes hot path or shared interface) |
 
-**Design — ALL subsections are MANDATORY:**
-- `problem`: Evidence-based description of current state
-- `goals`: Measurable outcomes (not vague aspirations)
-- `constraints`: Real limitations that affect design choices
+Use `what: |`, `why: |`, and `tests: |` (YAML literal blocks) so Markdown renders correctly in the dashboard.
 
 ---
 
-## Step 3: Validate Plan Structure
-
-Before proceeding, validate the YAML:
-
-1. All required fields present on every slice
-2. All questions have description + recommended
-3. Design has problem + goals + constraints
-4. Slice deps reference valid slice numbers
-5. Effort and risk values are valid (S/M/L, Low/Med/High)
-6. No duplicate slice numbers or question IDs
+## Step 3: Validate
 
 ```bash
 htmlgraph plan validate-yaml <plan-id>
-
 ```
+
+Fix any schema errors before proceeding.
 
 ---
 
-## Step 4: Critique (Parallel Agents)
+## Step 4: Critique (for plans with 3+ slices)
 
-**Trigger:** Always run critique for plans with >= 3 slices. Skip for trivial plans.
+Run two critique agents in parallel. Each reads the plan YAML and produces findings.
 
-Dispatch two critique agents in parallel. Each reads the plan YAML and produces structured findings.
-
-```
-Agent(description="Design critique", subagent_type="htmlgraph:haiku-coder",
-      prompt="Read [plan.yaml]. Produce structured critique. [See prompt template below]")
-
-Agent(description="Feasibility critique", subagent_type="htmlgraph:sonnet-coder",
-      prompt="Read [plan.yaml]. Verify feasibility. [See prompt template below]")
-```
-
-### What Critique Agents Must Do
-
-**For ALL plan types:**
-- **Identify gaps** — what does the plan not address? What's missing?
-- **Challenge assumptions** — what might be wrong? What is the plan taking for granted?
-- **Suggest prior art** — what existing solutions, patterns, libraries, or examples are relevant?
-- **Assess risks** — what could go wrong? What's the worst case? What's the blast radius?
-- **Propose alternatives** — is there a simpler or different approach the plan missed?
-
-**For plans involving existing code, also:**
-- Verify claims against actual code (cite file:line numbers)
-- Check if proposed changes conflict with existing patterns
-- Identify functions/utilities that already exist and can be leveraged
-
-**For greenfield or new ideas, also:**
-- Question user/market assumptions — is there evidence of demand?
-- Identify MVP scope vs full scope — what can be cut?
-- Find real-world examples of similar systems — what can we learn from them?
-- Flag "unknown unknowns" — what will we only discover by building?
-
-### Critique Output Format
-
-Each critique agent produces text in this format:
-
-```
-ASSUMPTIONS:
-A1: [VERIFIED|PLAUSIBLE|UNVERIFIED|QUESTIONABLE|FALSIFIED] text | evidence
-
-SLICE_ASSESSMENTS:
-S1: [assessment with specific concerns]
-
-RISKS:
-R1: risk description | severity: Low/Medium/High | mitigation
-
-GAPS:
-- What the plan doesn't address
-
-ALTERNATIVES:
-- Different approaches worth considering
-
-PRIOR_ART:
-- Relevant existing solutions or patterns
-```
-
-### Writing Critique to YAML
-
-The orchestrator parses both agents' output and writes the `critique` section:
-
-```yaml
-critique:
-  reviewed_at: "YYYY-MM-DD"
-  reviewers:
-    - "Haiku (design review)"
-    - "Sonnet (feasibility)"
-  assumptions:
-    - id: A1
-      status: verified       # verified|plausible|unverified|questionable|falsified
-      text: "The assumption being tested"
-      evidence: "file:line or reasoning"
-  critics:
-    - title: "DESIGN CRITIC"
-      sections:
-        - heading: "Slice Assessment"
-          items:
-            - badge: "S1"
-              kind: success   # success|warn|danger|info
-              text: "Assessment text"
-        - heading: "Gaps & Missing Considerations"
-          items:
-            - badge: "Gap"
-              kind: warn
-              text: "What the plan doesn't address"
-        - heading: "Alternative Approaches"
-          items:
-            - badge: "Alt"
-              kind: info
-              text: "A different approach worth considering"
-    - title: "FEASIBILITY CRITIC"
-      sections:
-        - heading: "What Exists to Leverage"
-          items: [...]
-        - heading: "What the Plan Gets Wrong"
-          items: [...]
-        - heading: "Prior Art & Examples"
-          items: [...]
-  risks:
-    - risk: "Risk description"
-      severity: High          # High|Medium|Low
-      mitigation: "How to mitigate"
-  synthesis: >
-    Summary of key findings. What must change before the plan is approved?
-    Numbered action items.
-```
+After critique, integrate HIGH/DANGER findings directly into the affected slice cards as `critic_revisions` entries. Rewrite the YAML via `htmlgraph plan rewrite-yaml`.
 
 ---
 
-## Step 4b: Address Critique Findings (MANDATORY before review)
-
-After critique agents return, the orchestrator MUST update the plan to address findings before launching review. The human should review the critique-informed version, not the stale original.
-
-**For each FALSIFIED assumption:**
-- Update the affected slice's `what` and `done_when` to address the falsification
-- Add the corrected understanding to `design.constraints` if it affects the whole plan
-
-**For each HIGH severity risk:**
-- Add the mitigation as a `done_when` criterion on the affected slice
-- If no slice owns the risk, add it to design constraints
-
-**For each missing consideration identified by critics:**
-- Add as a new question (if it's a design choice) or a new constraint (if it's a fact)
-
-**Process:**
-1. Parse both critique outputs for FALSIFIED/HIGH items
-2. Read the current plan YAML
-3. Modify the affected sections in memory
-4. Write to temp file
-5. Run: `htmlgraph plan rewrite-yaml <plan-id> --file /tmp/revised.yaml`
-6. Git auto-commits the revision with message: `plan(<id>): address critique findings`
-7. Proceed to Step 5 (review) with the updated plan
-
-**Skip Step 4b only if:** all assumptions are verified/plausible AND no HIGH severity risks exist.
-
----
-
-## Step 5: Open for Human Review (PAUSE HERE)
-
-Direct the human to review the plan in the dashboard:
+## Step 5: Open for Human Review (PAUSE)
 
 ```bash
 htmlgraph serve
@@ -417,160 +186,199 @@ htmlgraph serve
 Tell the human:
 
 ```
-Plan ready for review in the dashboard:
+Plan ready for review in the dashboard at http://localhost:8088/#plans
 
-  htmlgraph serve
-  Open http://localhost:8080/#plans and click the plan.
+Per-slice review:
+  1. Read each slice card — what/why/done_when/tests
+  2. Approve or reject each slice individually
+  3. Answer any slice-local questions
+  4. Read the critique revisions embedded in each card
 
-Please:
-1. Read the Design Discussion — Problem, Goals, Constraints
-2. Review each Slice — approve or leave unchecked
-3. Answer the Open Questions — defaults are recommended, override where you disagree
-4. Read the AI Critique — note any risks or gaps
-5. Check the Feedback Summary — progress bar shows completion
-6. Click Finalize when all sections are approved
+CLI shortcuts (if reviewing outside the dashboard):
+  htmlgraph plan approve-slice <plan-id> <num>
+  htmlgraph plan reject-slice <plan-id> <num> [--changes-requested]
+  htmlgraph plan answer-slice-question <plan-id> <num> <question-id> <answer-key>
 
-Your approvals persist automatically — you can close and reopen without losing progress.
-
-I will wait until you finalize the plan before writing any code.
+I will wait until you signal readiness before promoting any slices.
 ```
 
-**STOP. Do not proceed until the human finalizes the plan.**
+**STOP. Do not promote slices until the human has reviewed.**
 
-### Monitoring Review Progress
+---
 
-Poll SQLite to check if the human has finalized:
+## Step 6: Read Decisions and Integrate Feedback
 
 ```bash
-# Check approval progress
-sqlite3 .htmlgraph/htmlgraph.db \
-  "SELECT section, value FROM plan_feedback WHERE plan_id='<plan-id>' AND action='approve'"
+htmlgraph plan read-feedback-yaml <plan-id>
+```
 
-# Check if all slices approved
-sqlite3 .htmlgraph/htmlgraph.db \
-  "SELECT COUNT(*) as approved FROM plan_feedback WHERE plan_id='<plan-id>' AND action='approve' AND value='True'"
+For rejected slices: update the YAML to address the rejection, then re-run Step 5.
+For slices with `changes_requested`: revise the slice card and re-present.
+For answered questions: bake the decision into the affected slice's `what` field.
 
-# Check question answers
-sqlite3 .htmlgraph/htmlgraph.db \
-  "SELECT question_id, value FROM plan_feedback WHERE plan_id='<plan-id>' AND action='answer'"
+---
+
+## Step 7: Promote Approved Slices
+
+Promote slices incrementally as they are approved — no need to wait for full-plan finalization.
+
+```bash
+# Promote a single approved slice (creates feat-XXX, wires edges):
+htmlgraph plan promote-slice <plan-id> <slice-num>
+
+# If a slice's deps are already done externally (e.g. already in-flight):
+htmlgraph plan promote-slice <plan-id> <slice-num> --waive-deps
+```
+
+Rules:
+- The slice must have `approval_status=approved` (set via `approve-slice`).
+- All dependency slices must have `execution_status=done` or `superseded`, unless `--waive-deps`.
+- `promote-slice` is idempotent: if `feature_id` is already set, it reuses the existing feature.
+- After promotion, `execution_status` is set to `promoted` in both YAML and `plan_feedback`.
+
+The command prints the promoted `feat-XXX` ID. That feature is now part of the track and participates in the dependency-driven dispatch loop (see `/htmlgraph:execute`).
+
+### Promotion workflow for a multi-slice plan
+
+```
+for each slice (in dependency order):
+  1. Review → htmlgraph plan approve-slice <plan-id> <num>
+  2. Promote → htmlgraph plan promote-slice <plan-id> <num>
+  3. Track execution → htmlgraph plan set-slice-status <plan-id> <num> in_progress
+  4. When done → htmlgraph plan set-slice-status <plan-id> <num> done
 ```
 
 ---
 
-## Step 6: Read Finalized Decisions
+## Step 8: Close the Plan
 
-After the human clicks Finalize in the dashboard, read all feedback:
+When all slices are done, rejected, or superseded:
 
 ```bash
-# Read all feedback — approvals, answers, amendments, chat
-htmlgraph plan feedback <plan-id>
+htmlgraph plan set-status <plan-id> completed
 ```
-
-This outputs JSON with the complete review context:
-
-```json
-{
-  "plan_id": "plan-abc123",
-  "approvals": {"slice-1": {"approved": true}, "slice-2": {"approved": false, "comment": "too risky"}},
-  "answers": {"q-caching": "lazy", "q-error-handling": "metric-counter"},
-  "amendments": [{"field": "what", "slice": 1, "op": "set", "value": "updated description"}],
-  "chat_messages": [{"role": "user", "content": "...", "timestamp": "..."}]
-}
-```
-
-Parse the results:
-- If any slice has `approved: false`: summarize what was rejected. Ask the human — revise or proceed without?
-- If revising: update the YAML, loop to Step 5.
-- If proceeding: note excluded slices.
 
 ---
 
-## Step 7: Revise Plan, Create Features, and Dispatch
+## CLI Reference for Slice Lifecycle
 
-Finalization is an **agentic process**. You synthesize all review feedback into a revised plan, then create properly structured features.
-
-### 7a. Revise the Plan
-
-Read the plan YAML and the feedback from Step 6. Produce a **revised version** of the plan that incorporates:
-
-- **Amendments**: Apply accepted amendment changes to slice descriptions, titles, deps
-- **Chat discussion**: If the chat contains decisions, clarifications, or scope changes, reflect them in the affected slices
-- **Design decisions**: Bake answered questions into relevant slice descriptions under "Accepted Design Decisions"
-- **Rejected slices**: Remove or mark as excluded
-- **Critique insights**: If critique raised risks or assumptions that were discussed, note mitigations in affected slices
-
-The revised YAML's `slice.what` field becomes the feature description at finalize time (via `buildSliceFeatureContent`). If you need richer per-feature content — e.g., incorporating chat discussion specific to that slice — write it into `slice.what` during revision. Do not rely on finalize to synthesize it.
-
-Update the YAML via:
-
-```bash
-htmlgraph plan rewrite-yaml <plan-id> --file /tmp/revised.yaml
-```
-
-This validates the revised structure and auto-commits with version history.
-
-### 7b. Finalize via the Canonical Command
-
-Call the single, atomic finalize command:
-
-```bash
-htmlgraph plan finalize <plan-id>
-```
-
-This command:
-1. Reads approvals and answers from SQLite `plan_feedback` table
-2. Loops over approved slices and creates features using the slice's Title and What (or Why fallback) as content
-3. Writes each created `FeatureID` back into the slice YAML
-4. Emits edges: `planned_in` (feature→plan), `part_of`/`contains` (feature↔track), `implemented_in` (plan→track)
-5. Sets plan status to `finalized` and locks it (subsequent calls error with "plan is locked … use 'plan reopen'")
-
-If finalize errors with "plan is locked", the plan was previously finalized. Run `htmlgraph plan reopen <plan-id>` first, revise Step 7a, then re-finalize. The finalize command is idempotent: slices whose `feature_id` is already set and whose feature exists will be reused rather than duplicated; only new or orphaned slices create new features.
-
-If finalize errors on missing track, description, or slices, the error message is actionable — fix the YAML and re-run.
-
-### 7c. Announce the Finalized Plan
-
-```
-Plan finalized. Track: <track-id>
-
-Approved slices (N of M):
-  feat-XXXX  Slice 1 title       -> implement
-  feat-XXXX  Slice 2 title       -> implement
-
-Rejected slices:
-  Slice 3 title                  -> excluded (not approved)
-
-Design decisions:
-  Q1: Migration caching: schema-version (recommended, accepted)
-  Q2: Error handling: metric-counter (overrode recommendation: structured-log)
-  Q3: SessionStart scope: git-only (recommended, accepted)
-```
-
-Then hand off to `/htmlgraph:execute`.
+| Command | Usage | Effect |
+|---------|-------|--------|
+| `approve-slice` | `htmlgraph plan approve-slice <plan-id> <num>` | Sets `approval_status=approved` in `plan_feedback` |
+| `reject-slice` | `htmlgraph plan reject-slice <plan-id> <num> [--changes-requested]` | Sets `approval_status=rejected` or `changes_requested` |
+| `answer-slice-question` | `htmlgraph plan answer-slice-question <plan-id> <num> <question-id> <answer-key>` | Records answer to a slice-local question |
+| `set-slice-status` | `htmlgraph plan set-slice-status <plan-id> <num> <status>` | Sets `execution_status` (`not_started\|promoted\|in_progress\|done\|blocked\|superseded`) |
+| `promote-slice` | `htmlgraph plan promote-slice <plan-id> <num> [--waive-deps]` | Creates `feat-XXX`, wires edges, sets `execution_status=promoted` |
 
 ---
 
-## Agent Type Selection
+## Section-Naming Contract
 
-| Agent | When to Use |
-|-------|------------|
-| `htmlgraph:haiku-coder` | Critique (design review), single-file tasks, <50 lines |
-| `htmlgraph:sonnet-coder` | Critique (feasibility), multi-file tasks, moderate complexity |
-| `htmlgraph:opus-coder` | Architecture decisions, complex algorithms, novel design |
+State stored in `plan_feedback` uses these section keys:
 
-Default to sonnet unless the task is trivially simple (haiku) or requires deep reasoning (opus).
+| Key pattern | What it stores |
+|-------------|----------------|
+| `slice-<num>` | Slice-level approval (`action=approve`) and execution status (`action=set_execution_status`) |
+| `slice-<num>-question-<id>` | Answer to a slice-local question (`action=answer`) |
+| `design` | Design section approval |
+| `questions` | Plan-level question answers |
+
+The `answer-slice-question` command maps `<slice-num>` and `<question-id>` to the section key automatically.
+
+---
+
+## Minimal Example (2-slice plan)
+
+```yaml
+meta:
+  id: plan-a1b2c3d4
+  track_id: trk-xyz
+  title: "Add rate limiting to API"
+  status: active
+  created_at: "2026-04-28"
+
+design:
+  problem: >
+    The /api/ingest endpoint accepts unbounded request volume. Under load,
+    the SQLite writer becomes a bottleneck and drops events silently.
+  goals:
+    - "**Throughput cap** — reject requests above 100 req/s per client with 429"
+    - "**Visibility** — expose a counter metric for throttled requests"
+  constraints:
+    - "No new runtime dependencies — use stdlib only"
+  approved: false
+  comment: ""
+
+slices:
+  - id: slice-1
+    num: 1
+    title: "In-memory rate limiter middleware"
+    what: |
+      Add `internal/ratelimit/limiter.go`: a token-bucket limiter keyed by
+      client IP. Wire it as HTTP middleware in `cmd/htmlgraph/serve.go`.
+      Return HTTP 429 with a JSON error body when the bucket is empty.
+    why: |
+      Protects the SQLite writer from burst overload. Addresses the throughput
+      cap goal.
+    files:
+      - internal/ratelimit/limiter.go
+      - cmd/htmlgraph/serve.go
+    deps: []
+    done_when:
+      - "Requests above the configured limit receive HTTP 429"
+      - "Requests within the limit pass through unchanged"
+    effort: S
+    risk: Low
+    tests: |
+      Unit: TestLimiter_Allow — burst of 10 req/s, expect first 5 allowed, next rejected
+      Integration: TestServeRateLimit — spin up server, hammer /api/ingest, assert 429s
+    approval_status: pending
+    execution_status: not_started
+
+  - id: slice-2
+    num: 2
+    title: "Throttle counter metric"
+    what: |
+      Increment a `htmlgraph_throttled_total` counter in the limiter middleware.
+      Expose it on the existing `/metrics` endpoint via the Prometheus-compatible
+      text format already used by `cmd/htmlgraph/metrics.go`.
+    why: |
+      Addresses the visibility goal. Without this, operators cannot tell whether
+      rate limiting is firing or calibrated correctly.
+    files:
+      - internal/ratelimit/limiter.go
+      - cmd/htmlgraph/metrics.go
+    deps: [1]
+    done_when:
+      - "`htmlgraph_throttled_total` increments on each 429 response"
+      - "Counter is present in /metrics output"
+    effort: S
+    risk: Low
+    tests: |
+      Unit: TestLimiterMetric — after N rejections, counter equals N
+      Regression: existing /metrics tests still pass
+    approval_status: pending
+    execution_status: not_started
+
+questions: []
+critique: null
+```
+
+---
+
+## Legacy Compatibility
+
+Plans created before v2 (without `approval_status`, `execution_status`, `questions`, or `critic_revisions` on slices) remain valid. The schema treats these fields as optional (`omitempty`). The dashboard renders them via a global Questions/Critique fallback when the v2 slice-card fields are absent.
+
+Legacy plans can be migrated incrementally: add v2 fields to individual slices as they come up for review, without touching the rest of the YAML.
 
 ---
 
 ## Key Rules
 
-- **Plans are YAML files** — agents write structured data, not HTML strings
-- **All slice fields are mandatory** — What, Why, Files, DoneWhen, Tests, Effort, Risk
-- **All questions need context** — description + recommended option
-- **Design has three subsections** — Problem, Goals, Constraints (not a single blob)
-- **Critique challenges assumptions** — not just verifies code
-- **Approvals persist to SQLite** — human can close and reopen without losing state
-- **Finalize is explicit** — human clicks the button, not the agent
-- **TDD is mandatory** — every dispatched task includes tests before implementation
-- **Only approved slices** become features on dispatch
-- **Finalize is atomic** — `htmlgraph plan finalize` handles feature creation, edge wiring, and status transition in one command. Agents do not call `feature create` or `plan wire` directly during finalization.
+- **v2 slices are slice cards** — each card contains its own questions, critic revisions, approval status, and execution status
+- **Use literal blocks** (`|`) for `what`, `why`, `tests` so Markdown renders in the dashboard
+- **Promote incrementally** — `promote-slice` does not require full-plan finalization
+- **Critique is embedded per-slice** — use `critic_revisions` instead of a global critique section for v2 plans
+- **All slice fields are mandatory** — missing fields will fail `validate-yaml`
+- **Finalize is for legacy plans** — v2 plans use `promote-slice` per slice; `htmlgraph plan finalize` is the legacy all-at-once path


### PR DESCRIPTION
## Summary

Implements plan-1c14d560 (track: Agentic Engineering Gaps): redesigns HtmlGraph planning around slice-centered executable specs. Plans stay open while individual slices can be approved, promoted into features, executed, and completed independently. Critique becomes per-slice revision metadata; questions become slice-local. YAML stays the source of truth — multiline ` what`, `why`, and `tests` fields are now Markdown-capable.

8 commits on this branch:

- `8336e75e` feat(planyaml): v2 slice-card schema (`feat-44d8c24f`) — adds slice-local `questions`, `critic_revisions`, `approval_status`, `execution_status`; validate.go meta.status accepts `active|completed`; documents the section-naming contract for `plan_feedback` (`slice-N`, `slice-N-question-<id>`).
- `2ffc9bf3` feat(plantmpl): Markdown rendering (`feat-33807582`) — goldmark + bluemonday for sanitized rendering of slice what/why/tests.
- `b398b84f` fix(worktree): reindex test hook (`bug-bb5b26f6`) — fixes a pre-existing subprocess hang in cmd/htmlgraph worktree-helper tests.
- `f54032e8` feat(plan): slice-level approval/lifecycle APIs (`feat-58e5975f`) — `htmlgraph plan approve-slice|reject-slice|answer-slice-question|set-slice-status`; extends validSectionRe at api_plans.go to accept slice-local section keys.
- `a1658a2d` feat(plantmpl): slice cards as primary review surface (`feat-6dbc7112`) — renders approval/execution status badges, slice-local questions, critic-revision badges; v2 plans suppress global Questions/Critique zones.
- `9002cc7d` feat(plan): promote-slice for incremental execution (`feat-19396f85`) — `htmlgraph plan promote-slice <plan> <num> [--waive-deps]` creates one feature per approved slice without finalizing the whole plan; emits part_of/planned_in/blocked_by edges.
- `8afe2495` docs(plan-skill): rewrite plan skill for v2 slice-card workflow (`feat-f18d5c35`) — full rewrite of plan SKILL.md, execute SKILL.md update for promoted slices, regenerated codex/gemini ports, blog post + CLI reference updated.
- `2b0fc741` fix(plan): roborev job 43 findings — standardizes plan_feedback action name (`set_execution_status`), drops meta.status==`active` as IsV2 marker, mirrors slice approval into YAML, extends validPlanStatuses to include `active`/`completed`, logs idempotent re-promote write errors.

## Test plan

- [ ] `go build ./... && go vet ./... && go test ./...` — all green locally
- [ ] Run a v2 plan end-to-end: create with v2 schema → approve slice via `htmlgraph plan approve-slice` → verify dashboard checkbox state matches → `htmlgraph plan promote-slice` → confirm feature created with correct edges → `htmlgraph execute-preview <track>` includes the promoted feature
- [ ] Mark a dep slice done via `htmlgraph plan set-slice-status <plan> 1 done` → promote dependent slice without `--waive-deps` (regression test for job 43 HIGH finding)
- [ ] `htmlgraph plan set-status <plan> completed` succeeds (regression for skill-doc command)
- [ ] Legacy YAML plans still validate and render their global Questions/Critique zones unchanged
- [ ] Markdown sanitization: confirm `<script>` and event handlers are stripped from slice card output

🤖 Generated with [Claude Code](https://claude.com/claude-code)