### PR TITLE
fix(registry): prevent test-tempdir pollution + auto-prune stale entries

### DIFF
--- a/cmd/htmlgraph/main.go
+++ b/cmd/htmlgraph/main.go
@@ -321,7 +321,7 @@ func persistentPreRunE(cmd *cobra.Command, _ []string) error {
 		database.Close()
 	}
 	// Registry upsert — silent, cached git remote lookup.
-	if reg, regErr := registry.Load(registry.DefaultPath()); regErr == nil {
+	if reg, regErr := registry.Load(defaultRegistryPath()); regErr == nil {
 		var cachedRemote string
 		for _, e := range reg.List() {
 			if filepath.Clean(e.ProjectDir) == filepath.Clean(projectDir) {

--- a/cmd/htmlgraph/main_test.go
+++ b/cmd/htmlgraph/main_test.go
@@ -27,6 +27,11 @@ func setupTestProject(t *testing.T) string {
 	if err := os.MkdirAll(hgDir, 0o755); err != nil {
 		t.Fatalf("mkdir .htmlgraph: %v", err)
 	}
+	// Create a .git directory so looksLikeRealProject passes the git-ancestor
+	// check introduced by the registry hardening (bug-cc41e3d2).
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
 	return tmpDir
 }
 
@@ -37,7 +42,11 @@ func TestPersistentPreRunE_UpsertsRegistry(t *testing.T) {
 	homeDir := t.TempDir()
 
 	// Override HOME so DefaultPath() writes to a test-isolated location.
+	// Also clear XDG_DATA_HOME so DefaultPath falls back to the HOME-derived
+	// path (TestMain sets XDG_DATA_HOME for suite-wide isolation, but these
+	// tests control the registry path explicitly via HOME).
 	t.Setenv("HOME", homeDir)
+	t.Setenv("XDG_DATA_HOME", "")
 
 	// Stub out git subprocess — return a known URL.
 	origFn := getGitRemoteURLFn
@@ -94,6 +103,9 @@ func TestPersistentPreRunE_CachesGitRemote(t *testing.T) {
 	homeDir := t.TempDir()
 
 	t.Setenv("HOME", homeDir)
+	// Clear XDG_DATA_HOME so DefaultPath falls back to the HOME-derived path
+	// (TestMain sets XDG_DATA_HOME for suite-wide isolation).
+	t.Setenv("XDG_DATA_HOME", "")
 
 	// Pre-populate the registry with a GitRemoteURL so the second call should
 	// skip the git subprocess entirely.

--- a/cmd/htmlgraph/projects.go
+++ b/cmd/htmlgraph/projects.go
@@ -33,9 +33,13 @@ see all known projects and ` + "`projects prune`" + ` to remove stale entries.`,
 }
 
 func projectsListCmd() *cobra.Command {
-	return &cobra.Command{
+	var goneOnly bool
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all known projects in the registry",
+		Long: `List all known projects in the registry.
+
+With --gone, show only orphan entries whose .htmlgraph directory no longer exists.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			reg, err := registry.Load(defaultRegistryPath())
 			if err != nil {
@@ -44,12 +48,13 @@ func projectsListCmd() *cobra.Command {
 			entries := reg.List()
 			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 			fmt.Fprintln(w, "NAME\tDIR\tLAST_SEEN\tSTATUS\tITEMS")
+			printed := 0
 			for _, e := range entries {
-				status := "missing"
+				alive := false
 				items := "-"
 				hgDir := filepath.Join(e.ProjectDir, ".htmlgraph")
 				if _, statErr := os.Stat(hgDir); statErr == nil {
-					status = "exists"
+					alive = true
 					if dbPath, pathErr := storage.CanonicalDBPath(e.ProjectDir); pathErr == nil {
 						if db, openErr := registry.OpenReadOnly(dbPath); openErr == nil {
 							items = countItems(db)
@@ -57,14 +62,28 @@ func projectsListCmd() *cobra.Command {
 						}
 					}
 				}
+				if goneOnly && alive {
+					continue
+				}
+				status := "missing"
+				if alive {
+					status = "exists"
+				}
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", e.Name, e.ProjectDir, e.LastSeen, status, items)
+				printed++
 			}
-			if len(entries) == 0 {
-				fmt.Fprintln(w, "(no projects registered)")
+			if printed == 0 {
+				if goneOnly {
+					fmt.Fprintln(w, "(no orphan projects)")
+				} else {
+					fmt.Fprintln(w, "(no projects registered)")
+				}
 			}
 			return w.Flush()
 		},
 	}
+	cmd.Flags().BoolVar(&goneOnly, "gone", false, "show only orphan entries whose .htmlgraph directory no longer exists")
+	return cmd
 }
 
 func projectsPruneCmd() *cobra.Command {
@@ -76,12 +95,14 @@ func projectsPruneCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("load registry: %w", err)
 			}
+			before := len(reg.List())
 			pruned := reg.Prune()
+			kept := before - len(pruned)
 			for _, p := range pruned {
 				fmt.Fprintln(cmd.OutOrStdout(), "pruned:", p)
 			}
+			fmt.Fprintf(cmd.OutOrStdout(), "pruned %d stale projects, kept %d\n", len(pruned), kept)
 			if len(pruned) == 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "(nothing to prune)")
 				return nil
 			}
 			return reg.Save()

--- a/cmd/htmlgraph/projects_test.go
+++ b/cmd/htmlgraph/projects_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"database/sql"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -62,13 +61,15 @@ func makeProjectDBWithSchema(t *testing.T, numFeatures, numBugs, numSpikes int) 
 
 // withRegistryAtAndStale sets up a registry with entries that were previously registered
 // but whose .htmlgraph directories may have been deleted (stale). It writes entries directly
-// to bypass Upsert's looksLikeRealProject guard, allowing the tests to verify prune behavior.
+// via registry.WriteEntriesForTest — bypassing Upsert's looksLikeRealProject guard so the
+// tests can verify prune behavior. The on-disk format is sourced from the same atomic-write
+// path Save uses, so this helper cannot drift if the schema evolves.
 func withRegistryAtAndStale(t *testing.T, entries []registry.Entry) string {
 	t.Helper()
 	tmpHome := t.TempDir()
 	regPath := filepath.Join(tmpHome, "projects.json")
 
-	// Manually construct entries with valid timestamps so they can be saved
+	// Manually fill in the metadata Upsert would normally populate.
 	for i := range entries {
 		if entries[i].LastSeen == "" {
 			entries[i].LastSeen = time.Now().UTC().Format(time.RFC3339)
@@ -78,16 +79,7 @@ func withRegistryAtAndStale(t *testing.T, entries []registry.Entry) string {
 		}
 	}
 
-	// Write entries directly to bypass Upsert guard
-	data, err := json.MarshalIndent(entries, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	data = append(data, '\n')
-	if err := os.MkdirAll(filepath.Dir(regPath), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(regPath, data, 0o644); err != nil {
+	if err := registry.WriteEntriesForTest(regPath, entries); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/htmlgraph/projects_test.go
+++ b/cmd/htmlgraph/projects_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bytes"
 	"database/sql"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/shakestzd/htmlgraph/internal/registry"
 )
@@ -20,6 +22,10 @@ func makeProjectDBWithSchema(t *testing.T, numFeatures, numBugs, numSpikes int) 
 	tmp := t.TempDir()
 	hgDir := filepath.Join(tmp, ".htmlgraph")
 	if err := os.MkdirAll(filepath.Join(hgDir, ".db"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Create .git directory so project passes looksLikeRealProject check
+	if err := os.MkdirAll(filepath.Join(tmp, ".git"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	dbPath := filepath.Join(hgDir, ".db", "htmlgraph.db")
@@ -54,19 +60,37 @@ func makeProjectDBWithSchema(t *testing.T, numFeatures, numBugs, numSpikes int) 
 	return tmp
 }
 
-// withRegistryAt points the package-level defaultRegistryPath at a tmpdir
-// path and seeds it with the given entries. Returns the registry file path.
-func withRegistryAt(t *testing.T, entries []registry.Entry) string {
+// withRegistryAtAndStale sets up a registry with entries that were previously registered
+// but whose .htmlgraph directories may have been deleted (stale). It writes entries directly
+// to bypass Upsert's looksLikeRealProject guard, allowing the tests to verify prune behavior.
+func withRegistryAtAndStale(t *testing.T, entries []registry.Entry) string {
 	t.Helper()
 	tmpHome := t.TempDir()
 	regPath := filepath.Join(tmpHome, "projects.json")
-	reg, _ := registry.Load(regPath)
-	for _, e := range entries {
-		reg.Upsert(e.ProjectDir, e.Name, e.GitRemoteURL)
+
+	// Manually construct entries with valid timestamps so they can be saved
+	for i := range entries {
+		if entries[i].LastSeen == "" {
+			entries[i].LastSeen = time.Now().UTC().Format(time.RFC3339)
+		}
+		if entries[i].ID == "" {
+			entries[i].ID = registry.ComputeID(entries[i].ProjectDir)
+		}
 	}
-	if err := reg.Save(); err != nil {
+
+	// Write entries directly to bypass Upsert guard
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
 		t.Fatal(err)
 	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(regPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(regPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	orig := defaultRegistryPath
 	defaultRegistryPath = func() string { return regPath }
 	t.Cleanup(func() { defaultRegistryPath = orig })
@@ -77,11 +101,21 @@ func withRegistryAt(t *testing.T, entries []registry.Entry) string {
 // registry entry with correct STATUS and ITEMS columns.
 func TestProjectsList_Output(t *testing.T) {
 	realProject := makeProjectDBWithSchema(t, 3, 2, 1)
-	fakeProject := filepath.Join(t.TempDir(), "does-not-exist")
+	staleProjectDir := filepath.Join(t.TempDir(), "stale-project")
+	if err := os.MkdirAll(filepath.Join(staleProjectDir, ".htmlgraph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(staleProjectDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Remove .htmlgraph to make it stale
+	if err := os.RemoveAll(filepath.Join(staleProjectDir, ".htmlgraph")); err != nil {
+		t.Fatal(err)
+	}
 
-	withRegistryAt(t, []registry.Entry{
+	withRegistryAtAndStale(t, []registry.Entry{
 		{ProjectDir: realProject, Name: "real"},
-		{ProjectDir: fakeProject, Name: "fake"},
+		{ProjectDir: staleProjectDir, Name: "stale"},
 	})
 
 	cmd := projectsCmd()
@@ -95,14 +129,14 @@ func TestProjectsList_Output(t *testing.T) {
 	if !strings.Contains(out, "real") {
 		t.Errorf("expected 'real' in output, got: %s", out)
 	}
-	if !strings.Contains(out, "fake") {
-		t.Errorf("expected 'fake' in output, got: %s", out)
+	if !strings.Contains(out, "stale") {
+		t.Errorf("expected 'stale' in output, got: %s", out)
 	}
 	if !strings.Contains(out, "exists") {
 		t.Errorf("expected STATUS=exists for real project, got: %s", out)
 	}
 	if !strings.Contains(out, "missing") {
-		t.Errorf("expected STATUS=missing for fake project, got: %s", out)
+		t.Errorf("expected STATUS=missing for stale project, got: %s", out)
 	}
 	if !strings.Contains(out, "3f 2b 1s") {
 		t.Errorf("expected ITEMS '3f 2b 1s' for real project, got: %s", out)
@@ -113,11 +147,21 @@ func TestProjectsList_Output(t *testing.T) {
 // and persists the result.
 func TestProjectsPrune_RemovesAndSaves(t *testing.T) {
 	realProject := makeProjectDBWithSchema(t, 0, 0, 0)
-	fakeProject := filepath.Join(t.TempDir(), "does-not-exist")
+	staleProjectDir := filepath.Join(t.TempDir(), "stale-project")
+	if err := os.MkdirAll(filepath.Join(staleProjectDir, ".htmlgraph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(staleProjectDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Remove .htmlgraph to make it stale
+	if err := os.RemoveAll(filepath.Join(staleProjectDir, ".htmlgraph")); err != nil {
+		t.Fatal(err)
+	}
 
-	regPath := withRegistryAt(t, []registry.Entry{
+	regPath := withRegistryAtAndStale(t, []registry.Entry{
 		{ProjectDir: realProject, Name: "real"},
-		{ProjectDir: fakeProject, Name: "fake"},
+		{ProjectDir: staleProjectDir, Name: "stale"},
 	})
 
 	cmd := projectsCmd()
@@ -128,7 +172,7 @@ func TestProjectsPrune_RemovesAndSaves(t *testing.T) {
 		t.Fatalf("execute: %v", err)
 	}
 
-	// Reload the registry and check the fake project is gone.
+	// Reload the registry and check the stale project is gone.
 	reloaded, err := registry.Load(regPath)
 	if err != nil {
 		t.Fatal(err)
@@ -140,8 +184,12 @@ func TestProjectsPrune_RemovesAndSaves(t *testing.T) {
 	if entries[0].ProjectDir != realProject {
 		t.Errorf("wrong entry remaining: %s", entries[0].ProjectDir)
 	}
-	if !strings.Contains(buf.String(), "pruned:") {
-		t.Errorf("expected 'pruned:' in output, got: %s", buf.String())
+	out := buf.String()
+	if !strings.Contains(out, "pruned:") {
+		t.Errorf("expected 'pruned:' in output, got: %s", out)
+	}
+	if !strings.Contains(out, "pruned 1 stale projects, kept 1") {
+		t.Errorf("expected summary line in output, got: %s", out)
 	}
 }
 
@@ -149,7 +197,7 @@ func TestProjectsPrune_RemovesAndSaves(t *testing.T) {
 // new tables in foreign project DBs — it must use registry.OpenReadOnly.
 func TestProjectsList_NoMigrations(t *testing.T) {
 	realProject := makeProjectDBWithSchema(t, 1, 1, 1)
-	withRegistryAt(t, []registry.Entry{{ProjectDir: realProject, Name: "real"}})
+	withRegistryAtAndStale(t, []registry.Entry{{ProjectDir: realProject, Name: "real"}})
 
 	// Snapshot table set before.
 	dbPath := filepath.Join(realProject, ".htmlgraph", ".db", "htmlgraph.db")

--- a/cmd/htmlgraph/serve_child.go
+++ b/cmd/htmlgraph/serve_child.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -9,7 +10,10 @@ import (
 	"path/filepath"
 
 	dbpkg "github.com/shakestzd/htmlgraph/internal/db"
+	"github.com/shakestzd/htmlgraph/internal/otel/indexer"
+	otelreceiver "github.com/shakestzd/htmlgraph/internal/otel/receiver"
 	"github.com/shakestzd/htmlgraph/internal/otel/retention"
+	sqls "github.com/shakestzd/htmlgraph/internal/otel/sink/sqlite"
 	"github.com/shakestzd/htmlgraph/internal/registry"
 	"github.com/shakestzd/htmlgraph/internal/storage"
 	"github.com/spf13/cobra"
@@ -63,15 +67,18 @@ func runServeChild(port int) error {
 
 	mux := buildSingleProjectMux(database, htmlgraphDir)
 
-	// NOTE(bug-28a9d7a7 Part B): The NDJSON→SQLite indexer and its dedicated
-	// otelreceiver.NewWriter have been removed. Opening a second sql.DB writer
-	// (MaxOpenConns=1) against the same WAL SQLite file contended with the
-	// read-pool handle used by the API handlers, causing SQLITE_BUSY errors.
-	// The per-session otel-collect process is now the sole writer to otel_signals.
-	// serve-child is read-only with respect to otel_signals.
-	// TODO(bug-28a9d7a7): If NDJSON→SQLite replay is needed for pre-existing
-	// sessions, run the indexer inside the otel-collect process so only one
-	// writer DB handle exists across the entire project.
+	// NDJSON→SQLite indexer (unconditional per Q5 cutover decision).
+	// A dedicated Writer is opened for the indexer so it does not contend
+	// with the OTLP receiver's Writer (each has MaxOpenConns=1).
+	if idxWriter, err := otelreceiver.NewWriter(dbPath); err != nil {
+		fmt.Fprintf(os.Stderr, "indexer writer init: %v\n", err)
+	} else {
+		idxr := indexer.New(htmlgraphDir, sqls.New(idxWriter)).WithDB(database)
+		ctx := context.Background()
+		go idxr.Start(ctx)
+		// /api/indexer/status — per-file health for observability (Q7).
+		mux.Handle("/api/indexer/status", indexerStatusHandler(idxr))
+	}
 
 	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
@@ -120,3 +127,14 @@ func runServeChild(port int) error {
 	return (&http.Server{Handler: mux}).Serve(ln)
 }
 
+// indexerStatusHandler returns an HTTP handler for GET /api/indexer/status.
+// The response body is a JSON object with per-session file health metrics.
+func indexerStatusHandler(idxr *indexer.Indexer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		status := idxr.Status()
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{"files": status}); err != nil {
+			http.Error(w, "encode error", http.StatusInternalServerError)
+		}
+	})
+}

--- a/cmd/htmlgraph/serve_child.go
+++ b/cmd/htmlgraph/serve_child.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -10,10 +9,7 @@ import (
 	"path/filepath"
 
 	dbpkg "github.com/shakestzd/htmlgraph/internal/db"
-	"github.com/shakestzd/htmlgraph/internal/otel/indexer"
-	otelreceiver "github.com/shakestzd/htmlgraph/internal/otel/receiver"
 	"github.com/shakestzd/htmlgraph/internal/otel/retention"
-	sqls "github.com/shakestzd/htmlgraph/internal/otel/sink/sqlite"
 	"github.com/shakestzd/htmlgraph/internal/registry"
 	"github.com/shakestzd/htmlgraph/internal/storage"
 	"github.com/spf13/cobra"
@@ -67,18 +63,15 @@ func runServeChild(port int) error {
 
 	mux := buildSingleProjectMux(database, htmlgraphDir)
 
-	// NDJSON→SQLite indexer (unconditional per Q5 cutover decision).
-	// A dedicated Writer is opened for the indexer so it does not contend
-	// with the OTLP receiver's Writer (each has MaxOpenConns=1).
-	if idxWriter, err := otelreceiver.NewWriter(dbPath); err != nil {
-		fmt.Fprintf(os.Stderr, "indexer writer init: %v\n", err)
-	} else {
-		idxr := indexer.New(htmlgraphDir, sqls.New(idxWriter)).WithDB(database)
-		ctx := context.Background()
-		go idxr.Start(ctx)
-		// /api/indexer/status — per-file health for observability (Q7).
-		mux.Handle("/api/indexer/status", indexerStatusHandler(idxr))
-	}
+	// NOTE(bug-28a9d7a7 Part B): The NDJSON→SQLite indexer and its dedicated
+	// otelreceiver.NewWriter have been removed. Opening a second sql.DB writer
+	// (MaxOpenConns=1) against the same WAL SQLite file contended with the
+	// read-pool handle used by the API handlers, causing SQLITE_BUSY errors.
+	// The per-session otel-collect process is now the sole writer to otel_signals.
+	// serve-child is read-only with respect to otel_signals.
+	// TODO(bug-28a9d7a7): If NDJSON→SQLite replay is needed for pre-existing
+	// sessions, run the indexer inside the otel-collect process so only one
+	// writer DB handle exists across the entire project.
 
 	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
@@ -127,14 +120,3 @@ func runServeChild(port int) error {
 	return (&http.Server{Handler: mux}).Serve(ln)
 }
 
-// indexerStatusHandler returns an HTTP handler for GET /api/indexer/status.
-// The response body is a JSON object with per-session file health metrics.
-func indexerStatusHandler(idxr *indexer.Indexer) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		status := idxr.Status()
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(map[string]any{"files": status}); err != nil {
-			http.Error(w, "encode error", http.StatusInternalServerError)
-		}
-	})
-}

--- a/cmd/htmlgraph/serve_global.go
+++ b/cmd/htmlgraph/serve_global.go
@@ -78,7 +78,7 @@ func buildGlobalMux() *http.ServeMux {
 // registered project. We exclude it from the landing so the user sees
 // one card per real project, not one card per worktree branch.
 func listRegisteredProjects() []projectSummary {
-	reg, err := registry.Load(registry.DefaultPath())
+	reg, err := registry.Load(defaultRegistryPath())
 	if err != nil {
 		return []projectSummary{}
 	}

--- a/cmd/htmlgraph/serve_global_test.go
+++ b/cmd/htmlgraph/serve_global_test.go
@@ -18,6 +18,8 @@ import (
 // the pre-doorway version, it does NOT populate a SQLite schema because
 // the doorway server no longer opens project DBs. A bare .htmlgraph/
 // directory is enough for registry.Upsert to accept the path.
+// A .git directory is also created so looksLikeRealProject passes the
+// git-ancestor check introduced by the registry hardening (bug-cc41e3d2).
 func globalTestProject(t *testing.T) string {
 	t.Helper()
 	tmp := t.TempDir()
@@ -32,6 +34,10 @@ func globalTestProject(t *testing.T) string {
 		t.Fatal(err)
 	}
 	f.Close()
+	// Create a .git directory so looksLikeRealProject passes.
+	if err := os.MkdirAll(filepath.Join(tmp, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	return tmp
 }
 
@@ -43,6 +49,10 @@ func setupGlobalRegistry(t *testing.T, projectDirs ...string) string {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	// Clear XDG_DATA_HOME so DefaultPath falls back to the HOME-derived path
+	// (TestMain sets XDG_DATA_HOME for suite-wide isolation, but these tests
+	// control the registry path explicitly via HOME).
+	t.Setenv("XDG_DATA_HOME", "")
 	regPath := registry.DefaultPath()
 	if err := os.MkdirAll(filepath.Dir(regPath), 0o755); err != nil {
 		t.Fatal(err)

--- a/cmd/htmlgraph/serve_parent.go
+++ b/cmd/htmlgraph/serve_parent.go
@@ -156,6 +156,15 @@ func runParentServer(bind string, port int) error {
 
 	mux := buildParentMux(sup)
 
+	// One-time startup prune: self-heal a corrupted registry by removing
+	// entries whose .htmlgraph/ directory no longer exists, then save.
+	// This runs once at server startup so stale entries from previous test
+	// runs or deleted projects don't accumulate indefinitely. Best-effort:
+	// errors are silently ignored so a broken registry never blocks startup.
+	if reg, err := registry.Load(registry.DefaultPath()); err == nil {
+		_ = reg.Save() // Save calls Prune internally before writing.
+	}
+
 	addr := fmt.Sprintf("%s:%d", bind, port)
 
 	// Auto-detect & print URLs.

--- a/cmd/htmlgraph/serve_parent.go
+++ b/cmd/htmlgraph/serve_parent.go
@@ -162,16 +162,20 @@ func runParentServer(bind string, port int) error {
 	// runs or deleted projects don't accumulate indefinitely. Best-effort:
 	// errors are silently ignored so a broken registry never blocks startup.
 	//
-	// Stat-then-skip: only Save when Prune actually removed entries. The
-	// previous unconditional Save() rewrote the registry on every startup
-	// even when nothing changed, generating gratuitous filesystem churn
-	// (PR #62 review issue #6).
+	// Save is triggered when EITHER:
+	//   - Prune removed entries (the registry on disk is now stale), OR
+	//   - Load resolved this Registry via the legacy-path fallback
+	//     (MigrationPending) and we still need to materialise it into the
+	//     canonical XDG path. Without the second arm, a clean legacy ->
+	//     canonical migration with no stale entries never writes the
+	//     canonical file at startup (review #55 F4).
 	//
 	// Uses defaultRegistryPath (the package-level indirection used by every
 	// other registry caller in this binary) so tests can stub the path
 	// once and have all subcommands plus this startup hook agree.
 	if reg, err := registry.Load(defaultRegistryPath()); err == nil {
-		if pruned := reg.Prune(); len(pruned) > 0 {
+		pruned := reg.Prune()
+		if len(pruned) > 0 || reg.MigrationPending() {
 			_ = reg.Save()
 		}
 	}

--- a/cmd/htmlgraph/serve_parent.go
+++ b/cmd/htmlgraph/serve_parent.go
@@ -64,7 +64,7 @@ func proxyHandler(sup *childproc.Supervisor) http.HandlerFunc {
 			return
 		}
 
-		reg, err := registry.Load(registry.DefaultPath())
+		reg, err := registry.Load(defaultRegistryPath())
 		if err != nil {
 			http.Error(w, "load registry: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -115,7 +115,7 @@ func autoDetectCurrentProject() *registry.Entry {
 	projectRoot := filepath.Dir(htmlgraphDir)
 	id := registry.ComputeID(projectRoot)
 
-	regPath := registry.DefaultPath()
+	regPath := defaultRegistryPath()
 	reg, _ := registry.Load(regPath)
 	for _, e := range reg.List() {
 		if e.ID == id {
@@ -161,8 +161,19 @@ func runParentServer(bind string, port int) error {
 	// This runs once at server startup so stale entries from previous test
 	// runs or deleted projects don't accumulate indefinitely. Best-effort:
 	// errors are silently ignored so a broken registry never blocks startup.
-	if reg, err := registry.Load(registry.DefaultPath()); err == nil {
-		_ = reg.Save() // Save calls Prune internally before writing.
+	//
+	// Stat-then-skip: only Save when Prune actually removed entries. The
+	// previous unconditional Save() rewrote the registry on every startup
+	// even when nothing changed, generating gratuitous filesystem churn
+	// (PR #62 review issue #6).
+	//
+	// Uses defaultRegistryPath (the package-level indirection used by every
+	// other registry caller in this binary) so tests can stub the path
+	// once and have all subcommands plus this startup hook agree.
+	if reg, err := registry.Load(defaultRegistryPath()); err == nil {
+		if pruned := reg.Prune(); len(pruned) > 0 {
+			_ = reg.Save()
+		}
 	}
 
 	addr := fmt.Sprintf("%s:%d", bind, port)

--- a/cmd/htmlgraph/worktree_helpers_test.go
+++ b/cmd/htmlgraph/worktree_helpers_test.go
@@ -12,12 +12,33 @@ import (
 	"github.com/shakestzd/htmlgraph/internal/worktree"
 )
 
-// TestMain disables the reindex subprocess fork (`htmlgraph reindex`) for the
-// whole package so worktree-helper tests don't hang in environments where the
-// fork blocks on missing canonical state. Tracked as bug-bb5b26f6.
+// TestMain is the test suite entry point for the unit test suite. It:
+//  1. Disables the reindex subprocess fork so worktree-helper tests don't hang
+//     in environments where the fork blocks on missing canonical state (bug-bb5b26f6).
+//  2. Redirects XDG base dirs to isolated tempdirs so registry writes from
+//     persistentPreRunE (or any code path calling registry.DefaultPath) never
+//     touch ~/.local/share/htmlgraph/projects.json during test runs (bug-cc41e3d2).
+//  3. Cleans up the binary temp dir created by buildOtelCollectTestBinary.
 func TestMain(m *testing.M) {
 	worktree.SetReindexFnForTest(func(string, io.Writer) {})
-	os.Exit(m.Run())
+
+	// Redirect XDG base dirs to isolated tempdirs.
+	xdgData, err := os.MkdirTemp("", "htmlgraph-test-xdg-data-*")
+	if err == nil {
+		os.Setenv("XDG_DATA_HOME", xdgData)   //nolint:errcheck
+		defer os.RemoveAll(xdgData)
+	}
+	xdgConfig, err2 := os.MkdirTemp("", "htmlgraph-test-xdg-config-*")
+	if err2 == nil {
+		os.Setenv("XDG_CONFIG_HOME", xdgConfig) //nolint:errcheck
+		defer os.RemoveAll(xdgConfig)
+	}
+
+	code := m.Run()
+	if otelCollectTestBinaryTmpDir != "" {
+		_ = os.RemoveAll(otelCollectTestBinaryTmpDir)
+	}
+	os.Exit(code)
 }
 
 // setupWorktreeGitRepo creates a temp git repo with an initial commit and returns its path.

--- a/cmd/htmlgraph/worktree_helpers_test.go
+++ b/cmd/htmlgraph/worktree_helpers_test.go
@@ -19,24 +19,32 @@ import (
 //     persistentPreRunE (or any code path calling registry.DefaultPath) never
 //     touch ~/.local/share/htmlgraph/projects.json during test runs (bug-cc41e3d2).
 //  3. Cleans up the binary temp dir created by buildOtelCollectTestBinary.
+//
+// Cleanup runs explicitly before os.Exit; deferred cleanups would never fire
+// because os.Exit skips deferred functions.
 func TestMain(m *testing.M) {
 	worktree.SetReindexFnForTest(func(string, io.Writer) {})
 
 	// Redirect XDG base dirs to isolated tempdirs.
 	xdgData, err := os.MkdirTemp("", "htmlgraph-test-xdg-data-*")
 	if err == nil {
-		os.Setenv("XDG_DATA_HOME", xdgData)   //nolint:errcheck
-		defer os.RemoveAll(xdgData)
+		os.Setenv("XDG_DATA_HOME", xdgData) //nolint:errcheck
 	}
 	xdgConfig, err2 := os.MkdirTemp("", "htmlgraph-test-xdg-config-*")
 	if err2 == nil {
 		os.Setenv("XDG_CONFIG_HOME", xdgConfig) //nolint:errcheck
-		defer os.RemoveAll(xdgConfig)
 	}
 
 	code := m.Run()
-	if otelCollectTestBinaryTmpDir != "" {
-		_ = os.RemoveAll(otelCollectTestBinaryTmpDir)
+
+	if xdgData != "" {
+		_ = os.RemoveAll(xdgData)
+	}
+	if xdgConfig != "" {
+		_ = os.RemoveAll(xdgConfig)
+	}
+	if otelCollectTestBinary != "" {
+		_ = os.RemoveAll(filepath.Dir(otelCollectTestBinary))
 	}
 	os.Exit(code)
 }

--- a/internal/agent/detect.go
+++ b/internal/agent/detect.go
@@ -29,9 +29,9 @@ type Info struct {
 var uuidPattern = regexp.MustCompile(`([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})`)
 
 // Detect returns the identity of the calling agent using env var priority:
-//  1. HTMLGRAPH_AGENT_ID — explicit override (e.g. "codex", "copilot")
-//  2. CLAUDE_CODE=1      — running inside Claude Code → "claude-code"
-//  3. fallback           — "human" (CLI user, not an AI agent)
+//  1. HTMLGRAPH_AGENT_ID  — explicit override (e.g. "codex", "copilot")
+//  2. CLAUDE_CODE=1 / CLAUDECODE=1 — running inside Claude Code → "claude-code"
+//  3. fallback            — "human" (CLI user, not an AI agent)
 //
 // Model is always read from CLAUDE_MODEL (empty string if unset).
 func Detect() Info {
@@ -46,7 +46,13 @@ func detectID() string {
 	if v := os.Getenv("HTMLGRAPH_AGENT_ID"); v != "" {
 		return v
 	}
-	if os.Getenv("CLAUDE_CODE") != "" {
+	// Claude Code 2.x sets CLAUDECODE=1 (no underscore); older builds set
+	// CLAUDE_CODE=1. Accept either so agent_id never silently falls back to
+	// "human" — that fallback collides with the agent_events CHECK constraint
+	// `NOT (event_type='tool_call' AND agent_id='human' AND tool_name != 'UserQuery')`,
+	// which silently rejects every Read/Bash/Edit insert and blinds the
+	// research-first yolo guard.
+	if os.Getenv("CLAUDE_CODE") != "" || os.Getenv("CLAUDECODE") != "" {
 		return "claude-code"
 	}
 	return "human"

--- a/internal/agent/detect_test.go
+++ b/internal/agent/detect_test.go
@@ -26,6 +26,23 @@ func TestDetect_ExplicitAgentID(t *testing.T) {
 func TestDetect_ClaudeCode(t *testing.T) {
 	t.Setenv("HTMLGRAPH_AGENT_ID", "")
 	t.Setenv("CLAUDE_CODE", "1")
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_MODEL", "")
+	info := agent.Detect()
+	if info.ID != "claude-code" {
+		t.Errorf("got ID=%q, want %q", info.ID, "claude-code")
+	}
+}
+
+// TestDetect_ClaudeCodeNoUnderscore covers the env var name shipped by
+// Claude Code 2.x (`CLAUDECODE=1`, no underscore). Without this fallback
+// the orchestrator's agent_id silently became "human", which the
+// agent_events CHECK constraint then rejected for every non-UserQuery
+// tool_call insert, blinding the research-first yolo guard.
+func TestDetect_ClaudeCodeNoUnderscore(t *testing.T) {
+	t.Setenv("HTMLGRAPH_AGENT_ID", "")
+	t.Setenv("CLAUDE_CODE", "")
+	t.Setenv("CLAUDECODE", "1")
 	t.Setenv("CLAUDE_MODEL", "")
 	info := agent.Detect()
 	if info.ID != "claude-code" {
@@ -36,6 +53,7 @@ func TestDetect_ClaudeCode(t *testing.T) {
 func TestDetect_Human(t *testing.T) {
 	t.Setenv("HTMLGRAPH_AGENT_ID", "")
 	t.Setenv("CLAUDE_CODE", "")
+	t.Setenv("CLAUDECODE", "")
 	t.Setenv("CLAUDE_MODEL", "")
 	info := agent.Detect()
 	if info.ID != "human" {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -82,8 +82,10 @@ func Load(path string) (*Registry, error) {
 }
 
 // Save persists the registry to disk using a tempfile + os.Rename so the
-// write is atomic from the reader's perspective.
+// write is atomic from the reader's perspective. It calls Prune before
+// writing so stale entries are automatically removed on every save.
 func (r *Registry) Save() error {
+	r.Prune()
 	dir := filepath.Dir(r.path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("registry.Save: mkdir %s: %w", dir, err)
@@ -107,12 +109,42 @@ func (r *Registry) Save() error {
 	return nil
 }
 
+// looksLikeRealProject returns true only when dir contains a .htmlgraph/
+// subdirectory AND has a .git directory somewhere in its ancestor chain.
+// Temporary test directories (e.g. os.MkdirTemp paths) are typically not
+// inside a git repository, so they fail this check and are silently skipped
+// by Upsert — preventing registry pollution from test runs.
+func looksLikeRealProject(dir string) bool {
+	if _, err := os.Stat(filepath.Join(dir, ".htmlgraph")); err != nil {
+		return false
+	}
+	// Walk up looking for a .git directory.
+	for d := dir; ; {
+		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
+			return true
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			// Reached filesystem root without finding .git.
+			return false
+		}
+		d = parent
+	}
+}
+
 // Upsert inserts or updates the entry for dir.  If an entry with the same
 // cleaned absolute path already exists, its LastSeen (and optionally Name /
 // GitRemoteURL) is updated and the original ID is preserved.  Otherwise a new
 // entry is appended with a freshly computed ID.
+//
+// Upsert silently skips directories that do not look like real projects (no
+// .htmlgraph/ subdirectory or no .git ancestor). This prevents test tempdirs
+// from polluting the registry. Before saving, callers should also call Prune.
 func (r *Registry) Upsert(dir, name, remoteURL string) {
 	dir = filepath.Clean(dir)
+	if !looksLikeRealProject(dir) {
+		return
+	}
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	for i := range r.entries {
@@ -191,9 +223,13 @@ func (r *Registry) DropLinkedWorktrees(resolveMain func(dir string) string) []st
 	return dropped
 }
 
-// DefaultPath returns the canonical registry file path:
-// ~/.local/share/htmlgraph/projects.json
+// DefaultPath returns the canonical registry file path.
+// It honors XDG_DATA_HOME if set, otherwise falls back to
+// ~/.local/share/htmlgraph/projects.json.
 func DefaultPath() string {
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		return filepath.Join(xdg, "htmlgraph", "projects.json")
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		// Fallback that will be visible to the caller.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -61,6 +61,13 @@ type Entry struct {
 type Registry struct {
 	path    string
 	entries []Entry
+
+	// migrated is set when Load resolved this Registry's contents from the
+	// legacy ~/.local/share/htmlgraph/projects.json instead of the supplied
+	// canonical path. Callers can query MigrationPending() to learn whether
+	// a Save is needed solely to materialise the migration into the
+	// canonical XDG location, even when the in-memory slice is unchanged.
+	migrated bool
 }
 
 // Load reads the registry from path.  If the file does not exist an empty
@@ -77,8 +84,12 @@ func Load(path string) (*Registry, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if entries, ok := loadLegacyForCanonical(path); ok {
-				return &Registry{path: path, entries: entries}, nil
+			entries, found, lerr := loadLegacyForCanonical(path)
+			if lerr != nil {
+				return nil, fmt.Errorf("registry.Load: legacy fallback: %w", lerr)
+			}
+			if found {
+				return &Registry{path: path, entries: entries, migrated: true}, nil
 			}
 			return &Registry{path: path}, nil
 		}
@@ -92,26 +103,48 @@ func Load(path string) (*Registry, error) {
 	return &Registry{path: path, entries: entries}, nil
 }
 
-// loadLegacyForCanonical reads the legacy registry file (if it exists and
-// the supplied path matches the current canonical DefaultPath). It returns
-// (entries, true) on a successful migration read; (nil, false) otherwise.
-// Malformed legacy JSON is treated the same as a missing legacy file —
-// the caller falls through to an empty registry rather than blocking startup.
-func loadLegacyForCanonical(path string) ([]Entry, bool) {
+// loadLegacyForCanonical reads the legacy registry file when path is the
+// current canonical DefaultPath. It returns:
+//
+//   - (entries, true, nil)   — legacy file exists, was readable, parsed cleanly
+//   - (nil,     false, nil)  — legacy file genuinely missing, OR path is not
+//                              the canonical default (no fallback applies)
+//   - (nil,     false, err)  — legacy file exists but read or JSON parse failed
+//
+// The third case is critical (review #55 F3): without it, a corrupt or
+// unreadable legacy file would be silently masked as "no legacy registry,"
+// the caller would fall through to an empty Registry, and the next Save
+// would overwrite the canonical path with `[]` — destroying the user's
+// project list. Propagating the error forces a hard stop until the
+// human sorts the file out by hand.
+func loadLegacyForCanonical(path string) ([]Entry, bool, error) {
 	canonical := canonicalDefaultPath()
 	legacy := legacyDefaultPath()
 	if path != canonical || canonical == legacy {
-		return nil, false
+		return nil, false, nil
 	}
 	data, err := os.ReadFile(legacy)
 	if err != nil {
-		return nil, false
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("read legacy %s: %w", legacy, err)
 	}
 	var entries []Entry
 	if err := json.Unmarshal(data, &entries); err != nil {
-		return nil, false
+		return nil, false, fmt.Errorf("parse legacy %s: %w", legacy, err)
 	}
-	return entries, true
+	return entries, true, nil
+}
+
+// MigrationPending reports whether this Registry was populated via the
+// legacy-path fallback (i.e. the canonical XDG path did not exist, but
+// the legacy path did, and Load read the legacy contents). When true,
+// callers SHOULD invoke Save at a convenient point so the canonical
+// path is materialised — otherwise a clean migration with no stale
+// entries would persist legacy-only forever.
+func (r *Registry) MigrationPending() bool {
+	return r != nil && r.migrated
 }
 
 // Save persists the registry to disk using a tempfile + os.Rename so the
@@ -128,12 +161,27 @@ func loadLegacyForCanonical(path string) ([]Entry, bool) {
 // deferred to keep the call-site churn small; this godoc is the contract.
 func (r *Registry) Save() error {
 	r.Prune()
-	return writeEntriesAtomic(r.path, r.entries)
+	if err := writeEntriesAtomic(r.path, r.entries); err != nil {
+		return err
+	}
+	// Migration is now materialised into the canonical path. Clearing the
+	// flag prevents a subsequent caller from re-saving on a stable Registry
+	// that already lives in canonical.
+	r.migrated = false
+	return nil
 }
 
 // writeEntriesAtomic is the shared atomic write used by Save and the
 // test-only WriteEntriesForTest helper. Keeping the on-disk format in one
 // place ensures the test helper cannot silently drift from production.
+//
+// The temp file is created via os.CreateTemp with a unique randomised
+// suffix in the same directory as the target so concurrent Save calls do
+// not stomp each other (review #55 F2 — the previous fixed `<path>.tmp`
+// allowed two writers to overwrite each other's tempfile and rename a
+// half-written file into place). os.Rename within the same directory is
+// atomic on POSIX. Any tempfile left behind on a partial failure is
+// cleaned up; the persistent file is never modified except by Rename.
 func writeEntriesAtomic(path string, entries []Entry) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -144,12 +192,28 @@ func writeEntriesAtomic(path string, entries []Entry) error {
 		return fmt.Errorf("registry: marshal: %w", err)
 	}
 	data = append(data, '\n')
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+
+	base := filepath.Base(path)
+	tmp, err := os.CreateTemp(dir, base+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("registry: create tmp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("registry: write tmp: %w", err)
 	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("registry: close tmp: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0o644); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("registry: chmod tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("registry: rename: %w", err)
 	}
 	return nil
@@ -166,27 +230,19 @@ func WriteEntriesForTest(path string, entries []Entry) error {
 	return writeEntriesAtomic(path, entries)
 }
 
-// looksLikeRealProject returns true only when dir contains a .htmlgraph/
-// subdirectory AND has a .git directory somewhere in its ancestor chain.
-// Temporary test directories (e.g. os.MkdirTemp paths) are typically not
-// inside a git repository, so they fail this check and are silently skipped
-// by Upsert — preventing registry pollution from test runs.
+// looksLikeRealProject returns true when dir contains a .htmlgraph/
+// subdirectory. That is the sole signal: HtmlGraph projects are not
+// required to be Git repositories, so a `.git` ancestor is NOT part of
+// the gate (review #55 F1).
+//
+// Test pollution is prevented at a different layer — every test that
+// could call Upsert isolates the registry via XDG_DATA_HOME, redirecting
+// writes into a per-test tempdir. Production callers that pass a stray
+// tempdir path will still register, which is the correct contract:
+// `htmlgraph init <dir>` on a non-Git directory must succeed.
 func looksLikeRealProject(dir string) bool {
-	if _, err := os.Stat(filepath.Join(dir, ".htmlgraph")); err != nil {
-		return false
-	}
-	// Walk up looking for a .git directory.
-	for d := dir; ; {
-		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
-			return true
-		}
-		parent := filepath.Dir(d)
-		if parent == d {
-			// Reached filesystem root without finding .git.
-			return false
-		}
-		d = parent
-	}
+	_, err := os.Stat(filepath.Join(dir, ".htmlgraph"))
+	return err == nil
 }
 
 // Upsert inserts or updates the entry for dir.  If an entry with the same
@@ -194,9 +250,10 @@ func looksLikeRealProject(dir string) bool {
 // GitRemoteURL) is updated and the original ID is preserved.  Otherwise a new
 // entry is appended with a freshly computed ID.
 //
-// Upsert silently skips directories that do not look like real projects (no
-// .htmlgraph/ subdirectory or no .git ancestor). This prevents test tempdirs
-// from polluting the registry. Before saving, callers should also call Prune.
+// Upsert silently skips directories that do not look like real projects
+// (no .htmlgraph/ subdirectory). Test pollution is prevented by every
+// caller running tests with XDG_DATA_HOME pointed at a tmpdir, not by a
+// .git heuristic. Before saving, callers should also call Prune.
 func (r *Registry) Upsert(dir, name, remoteURL string) {
 	dir = filepath.Clean(dir)
 	if !looksLikeRealProject(dir) {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -128,27 +128,42 @@ func loadLegacyForCanonical(path string) ([]Entry, bool) {
 // deferred to keep the call-site churn small; this godoc is the contract.
 func (r *Registry) Save() error {
 	r.Prune()
-	dir := filepath.Dir(r.path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("registry.Save: mkdir %s: %w", dir, err)
-	}
+	return writeEntriesAtomic(r.path, r.entries)
+}
 
-	data, err := json.MarshalIndent(r.entries, "", "  ")
+// writeEntriesAtomic is the shared atomic write used by Save and the
+// test-only WriteEntriesForTest helper. Keeping the on-disk format in one
+// place ensures the test helper cannot silently drift from production.
+func writeEntriesAtomic(path string, entries []Entry) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("registry: mkdir %s: %w", dir, err)
+	}
+	data, err := json.MarshalIndent(entries, "", "  ")
 	if err != nil {
-		return fmt.Errorf("registry.Save: marshal: %w", err)
+		return fmt.Errorf("registry: marshal: %w", err)
 	}
 	data = append(data, '\n')
-
-	tmp := r.path + ".tmp"
+	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return fmt.Errorf("registry.Save: write tmp: %w", err)
+		return fmt.Errorf("registry: write tmp: %w", err)
 	}
-	if err := os.Rename(tmp, r.path); err != nil {
-		// Best-effort cleanup of the tmp file on rename failure.
+	if err := os.Rename(tmp, path); err != nil {
 		_ = os.Remove(tmp)
-		return fmt.Errorf("registry.Save: rename: %w", err)
+		return fmt.Errorf("registry: rename: %w", err)
 	}
 	return nil
+}
+
+// WriteEntriesForTest writes raw entries to path using the same JSON format
+// Save uses. Tests need this to seed registry files with entries that would
+// be rejected by Upsert (e.g. tempdirs that fail looksLikeRealProject) — and
+// without it, tests hand-rolled the JSON format and risked silently drifting
+// from Save when the schema evolved (PR #62 review issue #7).
+//
+// Production code must go through Upsert+Save. Do NOT call this outside tests.
+func WriteEntriesForTest(path string, entries []Entry) error {
+	return writeEntriesAtomic(path, entries)
 }
 
 // looksLikeRealProject returns true only when dir contains a .htmlgraph/

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -65,10 +65,21 @@ type Registry struct {
 
 // Load reads the registry from path.  If the file does not exist an empty
 // Registry is returned with no error.  Any other I/O error is propagated.
+//
+// Legacy migration: when path is the canonical XDG-aware DefaultPath() and
+// it does not yet exist, Load also probes the legacy
+// ~/.local/share/htmlgraph/projects.json. If that legacy file exists, its
+// contents are returned and the in-memory Registry retains the canonical
+// path — the next Save persists to the canonical location and the legacy
+// file is left untouched. This avoids "all my projects vanished" reports
+// from users who set XDG_DATA_HOME after first run (PR #62 review).
 func Load(path string) (*Registry, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			if entries, ok := loadLegacyForCanonical(path); ok {
+				return &Registry{path: path, entries: entries}, nil
+			}
 			return &Registry{path: path}, nil
 		}
 		return nil, fmt.Errorf("registry.Load: %w", err)
@@ -81,9 +92,40 @@ func Load(path string) (*Registry, error) {
 	return &Registry{path: path, entries: entries}, nil
 }
 
+// loadLegacyForCanonical reads the legacy registry file (if it exists and
+// the supplied path matches the current canonical DefaultPath). It returns
+// (entries, true) on a successful migration read; (nil, false) otherwise.
+// Malformed legacy JSON is treated the same as a missing legacy file —
+// the caller falls through to an empty registry rather than blocking startup.
+func loadLegacyForCanonical(path string) ([]Entry, bool) {
+	canonical := canonicalDefaultPath()
+	legacy := legacyDefaultPath()
+	if path != canonical || canonical == legacy {
+		return nil, false
+	}
+	data, err := os.ReadFile(legacy)
+	if err != nil {
+		return nil, false
+	}
+	var entries []Entry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, false
+	}
+	return entries, true
+}
+
 // Save persists the registry to disk using a tempfile + os.Rename so the
-// write is atomic from the reader's perspective. It calls Prune before
-// writing so stale entries are automatically removed on every save.
+// write is atomic from the reader's perspective.
+//
+// SIDE EFFECT: Save also calls Prune() before writing — entries whose
+// project directory no longer contains a .htmlgraph/ subdirectory are
+// dropped from the in-memory slice and never written. Callers expecting
+// "save exactly what I have in memory" semantics will be surprised; if a
+// project dir was temporarily unmounted or symlinked away at save time,
+// its entry disappears with no log line. If you need pure save-without-
+// pruning behaviour, write the JSON yourself or copy this method without
+// the r.Prune() call. Renaming this to SaveAndPrune was considered but
+// deferred to keep the call-site churn small; this godoc is the contract.
 func (r *Registry) Save() error {
 	r.Prune()
 	dir := filepath.Dir(r.path)
@@ -223,16 +265,33 @@ func (r *Registry) DropLinkedWorktrees(resolveMain func(dir string) string) []st
 	return dropped
 }
 
-// DefaultPath returns the canonical registry file path.
-// It honors XDG_DATA_HOME if set, otherwise falls back to
+// DefaultPath returns the canonical registry file path. It honors
+// XDG_DATA_HOME when set, otherwise falls back to the historical
 // ~/.local/share/htmlgraph/projects.json.
+//
+// Legacy migration is handled by Load(): when the canonical path is
+// missing but the legacy file exists, Load reads from legacy and the
+// next Save persists to the canonical path. DefaultPath itself always
+// returns the canonical (write-target) path.
 func DefaultPath() string {
+	return canonicalDefaultPath()
+}
+
+// canonicalDefaultPath returns the XDG-aware path. When XDG_DATA_HOME is
+// unset this collapses to the legacy path, which is correct: the legacy
+// path IS the canonical default in that case.
+func canonicalDefaultPath() string {
 	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
 		return filepath.Join(xdg, "htmlgraph", "projects.json")
 	}
+	return legacyDefaultPath()
+}
+
+// legacyDefaultPath returns the historical pre-XDG path
+// (~/.local/share/htmlgraph/projects.json), independent of XDG_DATA_HOME.
+func legacyDefaultPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		// Fallback that will be visible to the caller.
 		return filepath.Join(".local", "share", "htmlgraph", "projects.json")
 	}
 	return filepath.Join(home, ".local", "share", "htmlgraph", "projects.json")

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -453,14 +453,20 @@ func TestEntry_StableID(t *testing.T) {
 	}
 }
 
-// TestNoRegistryPollution is a load-bearing regression test that verifies
-// Upsert silently skips directories that are not inside a git repository
-// (the shape of all Go test tempdirs), preventing registry pollution from
-// test runs.
+// TestNoRegistryPollution verifies Upsert's gate: directories without
+// a .htmlgraph/ subdirectory are silently rejected, while directories
+// that do have one are accepted regardless of whether they sit inside
+// a git repository (review #55 F1 — HtmlGraph projects are not required
+// to be Git repos). Test pollution is prevented by the XDG_DATA_HOME
+// isolation set up at the top of this test, NOT by a .git heuristic.
 func TestNoRegistryPollution(t *testing.T) {
-	// Isolate registry writes to a per-test tmpdir.
+	// Isolate BOTH registry locations: XDG (canonical) and HOME (legacy
+	// fallback). Without pinning HOME, the legacy-fallback in Load reads
+	// the user's real ~/.local/share/htmlgraph/projects.json on the first
+	// loadCount() call — corrupting the baseline.
 	xdg := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
 
 	regPath := registry.DefaultPath()
 	loadCount := func() int {
@@ -471,12 +477,16 @@ func TestNoRegistryPollution(t *testing.T) {
 		return len(r.List())
 	}
 
-	baseline := loadCount()
+	// Each sub-test reloads the baseline because Save() calls Prune(),
+	// which drops entries whose ProjectDir was cleaned up by a previous
+	// sub-test's t.TempDir(). Without re-baselining, a "+1 expected" check
+	// can fail because the prior entry was silently pruned mid-flight.
 
-	// Upsert from a plain tempdir (no .htmlgraph/, no .git ancestor).
-	// This simulates a Go test tempdir that should NOT pollute the registry.
-	t.Run("tempdir_rejected", func(t *testing.T) {
-		ghost := t.TempDir() // No .htmlgraph/, no .git
+	// Upsert from a plain tempdir (no .htmlgraph/) — must be rejected so
+	// that hooks running inside a stray cwd cannot register garbage.
+	t.Run("tempdir_no_htmlgraph_rejected", func(t *testing.T) {
+		baseline := loadCount()
+		ghost := t.TempDir()
 		r, _ := registry.Load(regPath)
 		r.Upsert(ghost, "ghost", "")
 		if err := r.Save(); err != nil {
@@ -484,32 +494,35 @@ func TestNoRegistryPollution(t *testing.T) {
 		}
 		after := loadCount()
 		if after != baseline {
-			t.Errorf("registry grew from %d to %d after Upsert of plain tempdir — pollution not blocked",
+			t.Errorf("registry grew from %d to %d after Upsert of plain tempdir — gate did not reject",
 				baseline, after)
 		}
 	})
 
-	// Upsert from a dir that has .htmlgraph/ but no .git ancestor.
-	// Should also be rejected.
-	t.Run("htmlgraph_but_no_git_rejected", func(t *testing.T) {
-		partial := t.TempDir()
-		if err := os.MkdirAll(filepath.Join(partial, ".htmlgraph"), 0o755); err != nil {
+	// Upsert from a dir with .htmlgraph/ but no .git ancestor — must be
+	// ACCEPTED. Non-Git projects are valid HtmlGraph projects.
+	t.Run("htmlgraph_without_git_accepted", func(t *testing.T) {
+		baseline := loadCount()
+		nonGit := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(nonGit, ".htmlgraph"), 0o755); err != nil {
 			t.Fatal(err)
 		}
 		r, _ := registry.Load(regPath)
-		r.Upsert(partial, "partial", "")
+		r.Upsert(nonGit, "non-git", "")
 		if err := r.Save(); err != nil {
 			t.Fatalf("Save: %v", err)
 		}
 		after := loadCount()
-		if after != baseline {
-			t.Errorf("registry grew from %d to %d after Upsert of dir without .git — pollution not blocked",
-				baseline, after)
+		if after != baseline+1 {
+			t.Errorf("non-Git HtmlGraph project must register: registry went from %d to %d, want %d",
+				baseline, after, baseline+1)
 		}
 	})
 
 	// Upsert from a real-looking project (tempdir + .htmlgraph + .git).
-	// Should be accepted and grow the count by exactly 1.
+	// Verify the new entry shows up in the post-Save list — counting
+	// deltas is unreliable because Save's internal Prune drops entries
+	// whose ProjectDir got cleaned up by a previous sub-test's tempdir.
 	t.Run("real_project_accepted", func(t *testing.T) {
 		real := makeRealProject(t)
 		r, _ := registry.Load(regPath)
@@ -517,10 +530,120 @@ func TestNoRegistryPollution(t *testing.T) {
 		if err := r.Save(); err != nil {
 			t.Fatalf("Save: %v", err)
 		}
-		after := loadCount()
-		if after != baseline+1 {
-			t.Errorf("expected registry to grow by 1 (from %d to %d), got %d",
-				baseline, baseline+1, after)
+		reloaded, err := registry.Load(regPath)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		found := false
+		for _, e := range reloaded.List() {
+			if e.ProjectDir == real {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("real project %q missing from saved registry; entries=%+v", real, reloaded.List())
 		}
 	})
+}
+
+// TestSave_AtomicTempfileUnique verifies F2: writeEntriesAtomic must not
+// leave a fixed-name `<path>.tmp` file behind, because two concurrent
+// Save calls would collide on it. We can't easily race-test mid-Save
+// from a test, but we can prove the new contract by writing many times
+// and confirming no `<path>.tmp` artifact ever appears.
+func TestSave_AtomicTempfileUnique(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "projects.json")
+
+	for i := 0; i < 5; i++ {
+		r, _ := registry.Load(path)
+		r.Upsert(filepath.Join(dir, "p"), "p", "")
+		if err := r.Save(); err != nil {
+			t.Fatalf("Save iter %d: %v", i, err)
+		}
+	}
+	if _, err := os.Stat(path + ".tmp"); err == nil {
+		t.Errorf("found leftover %s.tmp — fixed-name tempfile is back", path)
+	}
+	// Any randomised `*.tmp` siblings must also be cleaned up.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("found leftover tempfile after Save: %s", e.Name())
+		}
+	}
+}
+
+// TestLoad_LegacyCorrupt covers F3: when the legacy fallback reads a
+// present-but-corrupt legacy file, Load must surface the error rather
+// than silently treating it as missing (which would let the next Save
+// overwrite the canonical path with `[]`).
+func TestLoad_LegacyCorrupt(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	xdg := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdg)
+
+	canonical := registry.DefaultPath()
+	legacy := filepath.Join(home, ".local", "share", "htmlgraph", "projects.json")
+
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacy, []byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := registry.Load(canonical); err == nil {
+		t.Fatal("Load returned nil error for corrupt legacy file; want error so caller halts before clobbering canonical")
+	}
+}
+
+// TestLoad_MigrationPending covers F4: a successful legacy fallback
+// surfaces a MigrationPending() flag so callers can save even when the
+// in-memory slice is otherwise unchanged. After Save the flag clears.
+func TestLoad_MigrationPending(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	xdg := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdg)
+
+	canonical := registry.DefaultPath()
+	legacy := filepath.Join(home, ".local", "share", "htmlgraph", "projects.json")
+
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projectDir := makeRealProject(t)
+	seed, _ := registry.Load(legacy)
+	seed.Upsert(projectDir, "legacy-proj", "")
+	if err := seed.Save(); err != nil {
+		t.Fatalf("seed legacy save: %v", err)
+	}
+
+	r, err := registry.Load(canonical)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !r.MigrationPending() {
+		t.Fatal("MigrationPending() = false after legacy fallback; want true")
+	}
+
+	if err := r.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if r.MigrationPending() {
+		t.Error("MigrationPending() still true after Save; want false")
+	}
+
+	// A subsequent Load on canonical (which now exists) must NOT report
+	// migration-pending.
+	r2, err := registry.Load(canonical)
+	if err != nil {
+		t.Fatalf("post-migration Load: %v", err)
+	}
+	if r2.MigrationPending() {
+		t.Error("post-migration Load reports MigrationPending(); want false")
+	}
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -332,6 +332,72 @@ func TestDefaultPath(t *testing.T) {
 	})
 }
 
+// TestLoad_LegacyFallback verifies the migrate-on-save behaviour: when the
+// canonical XDG path is missing but the legacy ~/.local/share path exists,
+// Load reads from legacy and the next Save persists to the canonical path
+// (the legacy file is left untouched as a side-effect-free safety copy).
+func TestLoad_LegacyFallback(t *testing.T) {
+	// Redirect $HOME so legacyDefaultPath() points into a tempdir we control,
+	// and XDG_DATA_HOME so canonicalDefaultPath() points elsewhere. With both
+	// pinned to tempdirs the test never touches the real user home.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	xdg := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdg)
+
+	canonical := registry.DefaultPath()
+	legacy := filepath.Join(home, ".local", "share", "htmlgraph", "projects.json")
+	if canonical == legacy {
+		t.Fatalf("canonical %q must differ from legacy %q for this test", canonical, legacy)
+	}
+
+	// Seed the legacy file with a real-looking entry. We bypass Save because
+	// Save would write to canonical via Registry.path; here we want raw JSON
+	// at the legacy location to simulate a pre-XDG install.
+	projectDir := makeRealProject(t)
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatalf("mkdir legacy parent: %v", err)
+	}
+	seed, _ := registry.Load(legacy)
+	seed.Upsert(projectDir, "legacy-proj", "")
+	if err := seed.Save(); err != nil {
+		t.Fatalf("seed legacy save: %v", err)
+	}
+	if _, err := os.Stat(canonical); err == nil {
+		t.Fatalf("canonical %q must not exist before migration", canonical)
+	}
+
+	// Load(canonical) should fall back to legacy and pick up the entry.
+	r, err := registry.Load(canonical)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	entries := r.List()
+	if len(entries) != 1 || entries[0].ProjectDir != projectDir {
+		t.Fatalf("expected legacy entry to surface, got %+v", entries)
+	}
+
+	// Save persists to canonical, not legacy.
+	if err := r.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, err := os.Stat(canonical); err != nil {
+		t.Errorf("canonical not created after Save: %v", err)
+	}
+	if _, err := os.Stat(legacy); err != nil {
+		t.Errorf("legacy file vanished after migration save (should be left intact): %v", err)
+	}
+
+	// Subsequent Load(canonical) reads canonical, not legacy.
+	r2, err := registry.Load(canonical)
+	if err != nil {
+		t.Fatalf("post-migration Load: %v", err)
+	}
+	if len(r2.List()) != 1 {
+		t.Errorf("post-migration entries = %d, want 1", len(r2.List()))
+	}
+}
+
 // TestOpenReadOnly_RejectsWrite opens a SQLite DB read-only and asserts that CREATE TABLE fails.
 func TestOpenReadOnly_RejectsWrite(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -12,6 +12,21 @@ import (
 	"github.com/shakestzd/htmlgraph/internal/registry"
 )
 
+// makeRealProject creates a tempdir that passes looksLikeRealProject:
+// it has a .htmlgraph/ subdirectory and a .git/ directory (in the same dir,
+// satisfying the ancestor walk). Returns the project root.
+func makeRealProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".htmlgraph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
 // TestLoad_MissingFile ensures Load on a nonexistent path returns an empty registry with no error.
 func TestLoad_MissingFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "does-not-exist", "projects.json")
@@ -30,11 +45,12 @@ func TestLoad_MissingFile(t *testing.T) {
 
 // TestUpsert_NewEntry ensures Upsert on a fresh registry appends an entry with a non-empty ID.
 func TestUpsert_NewEntry(t *testing.T) {
+	projectDir := makeRealProject(t)
 	r, err := registry.Load(filepath.Join(t.TempDir(), "projects.json"))
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	r.Upsert("/some/project", "my-project", "https://github.com/example/repo")
+	r.Upsert(projectDir, "my-project", "https://github.com/example/repo")
 
 	entries := r.List()
 	if len(entries) != 1 {
@@ -47,7 +63,7 @@ func TestUpsert_NewEntry(t *testing.T) {
 	if len(e.ID) != 8 {
 		t.Errorf("entry ID must be 8 chars, got %q (len %d)", e.ID, len(e.ID))
 	}
-	if e.ProjectDir != "/some/project" {
+	if e.ProjectDir != projectDir {
 		t.Errorf("unexpected ProjectDir: %q", e.ProjectDir)
 	}
 	if e.Name != "my-project" {
@@ -60,16 +76,20 @@ func TestUpsert_NewEntry(t *testing.T) {
 
 // TestUpsert_UpdatesExisting ensures Upsert on the same dir updates LastSeen without duplicating and preserves the ID.
 func TestUpsert_UpdatesExisting(t *testing.T) {
+	projectDir := makeRealProject(t)
 	r, err := registry.Load(filepath.Join(t.TempDir(), "projects.json"))
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	r.Upsert("/some/project", "project-a", "")
+	r.Upsert(projectDir, "project-a", "")
+	if len(r.List()) == 0 {
+		t.Fatal("expected entry after first Upsert, got 0")
+	}
 	firstID := r.List()[0].ID
 	firstSeen := r.List()[0].LastSeen
 
 	// Re-upsert same dir.
-	r.Upsert("/some/project", "project-a-renamed", "")
+	r.Upsert(projectDir, "project-a-renamed", "")
 	entries := r.List()
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry after second Upsert, got %d", len(entries))
@@ -86,13 +106,16 @@ func TestUpsert_UpdatesExisting(t *testing.T) {
 
 // TestSave_RoundTrip ensures Save followed by Load returns identical entries.
 func TestSave_RoundTrip(t *testing.T) {
+	alphaDir := makeRealProject(t)
+	betaDir := makeRealProject(t)
+
 	path := filepath.Join(t.TempDir(), "sub", "projects.json")
 	r, err := registry.Load(path)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	r.Upsert("/alpha/project", "alpha", "git@github.com:alpha/alpha.git")
-	r.Upsert("/beta/project", "beta", "")
+	r.Upsert(alphaDir, "alpha", "git@github.com:alpha/alpha.git")
+	r.Upsert(betaDir, "beta", "")
 
 	if err := r.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -123,13 +146,14 @@ func TestSave_RoundTrip(t *testing.T) {
 
 // TestSave_AtomicRename verifies that no .tmp file remains after Save.
 func TestSave_AtomicRename(t *testing.T) {
+	projectDir := makeRealProject(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "projects.json")
 	r, err := registry.Load(path)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	r.Upsert("/foo", "foo", "")
+	r.Upsert(projectDir, "foo", "")
 	if err := r.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -146,14 +170,23 @@ func TestSave_AtomicRename(t *testing.T) {
 func TestPrune_RemovesStale(t *testing.T) {
 	tmp := t.TempDir()
 
-	// Valid project: has a .htmlgraph subdirectory.
+	// Valid project: has both .htmlgraph and .git subdirectories (passes Upsert guard).
 	validDir := filepath.Join(tmp, "valid-project")
 	if err := os.MkdirAll(filepath.Join(validDir, ".htmlgraph"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.MkdirAll(filepath.Join(validDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
-	// Stale project: directory does not even exist.
+	// Stale project: was once valid (upserted), then .htmlgraph was removed.
 	staleDir := filepath.Join(tmp, "stale-project")
+	if err := os.MkdirAll(filepath.Join(staleDir, ".htmlgraph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(staleDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	path := filepath.Join(tmp, "projects.json")
 	r, err := registry.Load(path)
@@ -162,6 +195,11 @@ func TestPrune_RemovesStale(t *testing.T) {
 	}
 	r.Upsert(validDir, "valid", "")
 	r.Upsert(staleDir, "stale", "")
+
+	// Simulate staleness by removing .htmlgraph from staleDir.
+	if err := os.RemoveAll(filepath.Join(staleDir, ".htmlgraph")); err != nil {
+		t.Fatal(err)
+	}
 
 	pruned := r.Prune()
 	if len(pruned) != 1 {
@@ -185,10 +223,26 @@ func TestPrune_RemovesStale(t *testing.T) {
 // logic without a real git repo.
 func TestDropLinkedWorktrees(t *testing.T) {
 	tmp := t.TempDir()
+
+	// Create real-looking project dirs (with .htmlgraph + .git) so Upsert
+	// accepts them.
+	makeProjAt := func(dir string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Join(dir, ".htmlgraph"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
 	mainDir := filepath.Join(tmp, "main")
-	wt1 := filepath.Join(tmp, "main", "wt-feat-a")
-	wt2 := filepath.Join(tmp, "main", "wt-feat-b")
+	wt1 := filepath.Join(tmp, "wt-feat-a")
+	wt2 := filepath.Join(tmp, "wt-feat-b")
 	standalone := filepath.Join(tmp, "other-project")
+	makeProjAt(mainDir)
+	makeProjAt(wt1)
+	makeProjAt(wt2)
+	makeProjAt(standalone)
 
 	path := filepath.Join(tmp, "projects.json")
 	r, err := registry.Load(path)
@@ -232,7 +286,14 @@ func TestDropLinkedWorktrees_NilResolver(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "projects.json")
 	r, _ := registry.Load(path)
-	r.Upsert(filepath.Join(tmp, "a"), "a", "")
+	aDir := filepath.Join(tmp, "a")
+	if err := os.MkdirAll(filepath.Join(aDir, ".htmlgraph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(aDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r.Upsert(aDir, "a", "")
 	dropped := r.DropLinkedWorktrees(nil)
 	if dropped != nil {
 		t.Errorf("nil resolver should return nil, got %v", dropped)
@@ -242,17 +303,33 @@ func TestDropLinkedWorktrees_NilResolver(t *testing.T) {
 	}
 }
 
-// TestDefaultPath verifies the path is under ~/.local/share/htmlgraph/projects.json.
+// TestDefaultPath verifies the path falls back to ~/.local/share/htmlgraph/projects.json
+// when XDG_DATA_HOME is not set, and honors XDG_DATA_HOME when it is set.
 func TestDefaultPath(t *testing.T) {
-	got := registry.DefaultPath()
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skipf("cannot determine home dir: %v", err)
-	}
-	expected := filepath.Join(home, ".local", "share", "htmlgraph", "projects.json")
-	if got != expected {
-		t.Errorf("DefaultPath() = %q, want %q", got, expected)
-	}
+	// Sub-test: XDG_DATA_HOME unset — expect home-dir fallback.
+	t.Run("fallback", func(t *testing.T) {
+		t.Setenv("XDG_DATA_HOME", "")
+		got := registry.DefaultPath()
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skipf("cannot determine home dir: %v", err)
+		}
+		expected := filepath.Join(home, ".local", "share", "htmlgraph", "projects.json")
+		if got != expected {
+			t.Errorf("DefaultPath() = %q, want %q", got, expected)
+		}
+	})
+
+	// Sub-test: XDG_DATA_HOME set — expect XDG-rooted path.
+	t.Run("xdg", func(t *testing.T) {
+		xdg := t.TempDir()
+		t.Setenv("XDG_DATA_HOME", xdg)
+		got := registry.DefaultPath()
+		expected := filepath.Join(xdg, "htmlgraph", "projects.json")
+		if got != expected {
+			t.Errorf("DefaultPath() = %q, want %q", got, expected)
+		}
+	})
 }
 
 // TestOpenReadOnly_RejectsWrite opens a SQLite DB read-only and asserts that CREATE TABLE fails.
@@ -286,14 +363,20 @@ func TestOpenReadOnly_RejectsWrite(t *testing.T) {
 
 // TestEntry_StableID verifies the same ProjectDir always yields the same 8-char SHA256 prefix.
 func TestEntry_StableID(t *testing.T) {
-	dir := "/stable/project/dir"
+	dir := makeRealProject(t)
 
 	r1, _ := registry.Load(filepath.Join(t.TempDir(), "p1.json"))
 	r1.Upsert(dir, "proj", "")
+	if len(r1.List()) == 0 {
+		t.Fatal("expected entry after Upsert in r1")
+	}
 	id1 := r1.List()[0].ID
 
 	r2, _ := registry.Load(filepath.Join(t.TempDir(), "p2.json"))
 	r2.Upsert(dir, "proj", "")
+	if len(r2.List()) == 0 {
+		t.Fatal("expected entry after Upsert in r2")
+	}
 	id2 := r2.List()[0].ID
 
 	if id1 != id2 {
@@ -302,4 +385,76 @@ func TestEntry_StableID(t *testing.T) {
 	if len(id1) != 8 {
 		t.Errorf("ID must be 8 chars, got %q", id1)
 	}
+}
+
+// TestNoRegistryPollution is a load-bearing regression test that verifies
+// Upsert silently skips directories that are not inside a git repository
+// (the shape of all Go test tempdirs), preventing registry pollution from
+// test runs.
+func TestNoRegistryPollution(t *testing.T) {
+	// Isolate registry writes to a per-test tmpdir.
+	xdg := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdg)
+
+	regPath := registry.DefaultPath()
+	loadCount := func() int {
+		r, err := registry.Load(regPath)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		return len(r.List())
+	}
+
+	baseline := loadCount()
+
+	// Upsert from a plain tempdir (no .htmlgraph/, no .git ancestor).
+	// This simulates a Go test tempdir that should NOT pollute the registry.
+	t.Run("tempdir_rejected", func(t *testing.T) {
+		ghost := t.TempDir() // No .htmlgraph/, no .git
+		r, _ := registry.Load(regPath)
+		r.Upsert(ghost, "ghost", "")
+		if err := r.Save(); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		after := loadCount()
+		if after != baseline {
+			t.Errorf("registry grew from %d to %d after Upsert of plain tempdir — pollution not blocked",
+				baseline, after)
+		}
+	})
+
+	// Upsert from a dir that has .htmlgraph/ but no .git ancestor.
+	// Should also be rejected.
+	t.Run("htmlgraph_but_no_git_rejected", func(t *testing.T) {
+		partial := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(partial, ".htmlgraph"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		r, _ := registry.Load(regPath)
+		r.Upsert(partial, "partial", "")
+		if err := r.Save(); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		after := loadCount()
+		if after != baseline {
+			t.Errorf("registry grew from %d to %d after Upsert of dir without .git — pollution not blocked",
+				baseline, after)
+		}
+	})
+
+	// Upsert from a real-looking project (tempdir + .htmlgraph + .git).
+	// Should be accepted and grow the count by exactly 1.
+	t.Run("real_project_accepted", func(t *testing.T) {
+		real := makeRealProject(t)
+		r, _ := registry.Load(regPath)
+		r.Upsert(real, "real", "")
+		if err := r.Save(); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		after := loadCount()
+		if after != baseline+1 {
+			t.Errorf("expected registry to grow by 1 (from %d to %d), got %d",
+				baseline, baseline+1, after)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

This PR is the registry-hardening half of the original bundle. The
indexer-removal half was split out per review feedback so each behavioral
change is reviewable in isolation.

**Scope (this PR):**

- **internal/registry**: `looksLikeRealProject` guard rejects test/temp dirs in `Upsert` so test runs cannot pollute the user's live registry. `Save` calls `Prune` before writing so stale entries auto-clean over time. `DefaultPath()` honors `XDG_DATA_HOME`; `Load` falls back to the legacy `~/.local/share/htmlgraph/projects.json` when the canonical path is missing, then `Save` migrates to the canonical path on the next cycle.
- **cmd/htmlgraph/projects**: `persistentPreRunE` wires `defaultRegistryPath` so all subcommands share the same indirection. `projects list` and `projects prune` use it; `serve_parent`, `serve_global`, and `main`'s registry upsert all flow through the same indirection now (no more `registry.DefaultPath()` direct calls in this binary).
- **cmd/htmlgraph/serve_parent**: stat-then-skip startup auto-prune — only `Save()` when `Prune()` actually removed entries, instead of rewriting the file unconditionally on every server boot.
- **cmd/htmlgraph/serve_child**: parent-supplied `HTMLGRAPH_REGISTRY_PATH` is honored so children share the parent's registry view.
- **internal/agent/detect**: also recognise `CLAUDECODE=1` (Claude Code 2.x ships the no-underscore name) so agent_id never silently falls back to "human". Discovered while debugging the yolo-guard during this PR — without this fix the research-first guard never sees Read/Bash/Edit events for orchestrator sessions, because the `agent_events` CHECK constraint silently rejects rows with `agent_id='human'`. Test added.
- **Test hygiene**: deleted `testmain_test.go`; XDG_DATA_HOME/XDG_CONFIG_HOME isolation inlined into `worktree_helpers_test.go` (consolidated TestMain). TestMain cleanup now runs before `os.Exit` rather than via deferred funcs that never fire. `withRegistryAtAndStale` calls a new `registry.WriteEntriesForTest` helper that shares the atomic-write path with `Save`, so the JSON format cannot drift between production and tests. Added `TestLoad_LegacyFallback` to cover the migrate-on-save behavior end-to-end.

**Out of scope (split into a separate PR):**

The NDJSON→SQLite indexer removal in `serve_child.go` (bug-28a9d7a7) was reverted on this branch and will land in its own PR with a proper title/summary so reviewers can evaluate it in isolation.

## Revision notes (post-review)

Addresses every issue from the PR #62 self-review:

1. 🔴 **Scope creep** — indexer removal reverted on this branch; will be filed as its own PR.
2. 🟡 **TestMain defer-after-os.Exit leak** — cleanup now runs before `os.Exit`. Also fixed a pre-existing build error: undefined `otelCollectTestBinaryTmpDir` reference replaced with `filepath.Dir(otelCollectTestBinary)`.
3. 🟡 **PR title overstated** — softened to drop "concurrent writes" (no locking added in this PR; only atomic temp+rename, which pre-existed) and "atomic write" framing.
4. 🟡 **Save() Prune side-effect naming** — godoc expanded to a prominent SIDE EFFECT block; rename deferred to keep call-site churn small.
5. 🟡 **DefaultPath migration gap** — Load now falls back to the legacy path when canonical is missing; Save migrates to canonical on the next cycle. Legacy file is intentionally left intact as a recovery copy. Test added.
6. 🟢 **serve_parent startup auto-prune** — stat-then-skip; reconciled `defaultRegistryPath` indirection across serve_parent / serve_global / main.
7. 🟢 **withRegistryAtAndStale format duplication** — extracted shared `writeEntriesAtomic` writer; tests now go through `registry.WriteEntriesForTest` which uses the same path as `Save`.
8. 🟢 **/api/indexer/status 404 test** — moved to the split-out indexer-removal PR (where the endpoint actually goes away). Restoring the indexer here means the endpoint still serves, so the test is irrelevant on this branch.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — all pass
- [x] `go test ./internal/registry/... -count=1` — 13 tests, all pass (TestLoad_LegacyFallback, TestNoRegistryPollution, TestDefaultPath/{fallback,xdg}, etc.)
- [x] Pre-commit hooks ran the full suite for every commit; all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)