### PR TITLE
feat(otel): resilient harness-agnostic per-session collector (Codex + Gemini)

### DIFF
--- a/cmd/htmlgraph/api_collector_status.go
+++ b/cmd/htmlgraph/api_collector_status.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// CollectorStatus holds the live health of a per-session OTel collector.
+// Exported so tests can deserialise the HTTP response into this struct.
+type CollectorStatus struct {
+	PID            int   `json:"pid"`
+	Port           int   `json:"port"`
+	Alive          bool  `json:"alive"`
+	UptimeSec      int64 `json:"uptime_s"`
+	LastActivityMs int64 `json:"last_activity_ms"`
+	// SignalsIngested is always 0 — counting every signal line on hot paths
+	// is costly; use the file mtime for last_activity_ms instead.
+	SignalsIngested int64 `json:"signals_ingested,omitempty"`
+}
+
+// ReadCollectorStatus constructs a CollectorStatus for the given session
+// directory by reading:
+//   - .collector-pid  → PID + liveness probe
+//   - events.ndjson   → collector_start event for port + start timestamp
+//
+// Returns an error only when .collector-pid is missing or unreadable.
+// A dead (unreachable) process is not an error — Alive is set to false.
+func ReadCollectorStatus(sessDir string) (CollectorStatus, error) {
+	pid, err := readPIDFile(filepath.Join(sessDir, ".collector-pid"))
+	if err != nil {
+		return CollectorStatus{}, fmt.Errorf("read collector PID: %w", err)
+	}
+
+	alive := isProcessAlive(pid)
+
+	port, startTS := readCollectorStartEvent(filepath.Join(sessDir, "events.ndjson"))
+
+	var uptimeSec int64
+	if !startTS.IsZero() {
+		uptimeSec = int64(time.Since(startTS).Seconds())
+		if uptimeSec < 0 {
+			uptimeSec = 0
+		}
+	}
+
+	// LastActivityMs: use events.ndjson mtime as a cheap proxy.
+	// Scanning every signal line would be too costly on busy sessions.
+	lastActivityMs := fileModTimeMs(filepath.Join(sessDir, "events.ndjson"))
+
+	return CollectorStatus{
+		PID:            pid,
+		Port:           port,
+		Alive:          alive,
+		UptimeSec:      uptimeSec,
+		LastActivityMs: lastActivityMs,
+	}, nil
+}
+
+// collectorStatusHandler returns an http.HandlerFunc for GET /api/otel/status.
+// Query param: ?session=<session-id>  (matches ?session= used by transcriptHandler)
+// projectDir is the project root (parent of .htmlgraph/).
+func collectorStatusHandler(projectDir string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		sessionID := r.URL.Query().Get("session")
+		if sessionID == "" {
+			http.Error(w, "session parameter required", http.StatusBadRequest)
+			return
+		}
+		sessDir := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID)
+		status, err := ReadCollectorStatus(sessDir)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		respondJSON(w, status)
+	}
+}
+
+// readPIDFile reads a PID from a file containing "<pid>\n".
+func readPIDFile(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("parse pid %q: %w", strings.TrimSpace(string(data)), err)
+	}
+	return pid, nil
+}
+
+// isProcessAlive uses kill(pid, 0) to probe whether the process exists.
+// This never sends a real signal — it only checks reachability.
+func isProcessAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+// collectorStartLine is the minimal shape we parse from events.ndjson.
+type collectorStartLine struct {
+	Kind  string         `json:"kind"`
+	TS    string         `json:"ts"`
+	Attrs map[string]any `json:"attrs"`
+}
+
+// readCollectorStartEvent scans events.ndjson for the first collector_start
+// line and extracts port + timestamp. Returns zero values when the file is
+// missing or the event has not been written yet.
+func readCollectorStartEvent(evPath string) (port int, startTS time.Time) {
+	f, err := os.Open(evPath)
+	if err != nil {
+		return 0, time.Time{}
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var line collectorStartLine
+		if err := json.Unmarshal(sc.Bytes(), &line); err != nil {
+			continue
+		}
+		if line.Kind != "collector_start" {
+			continue
+		}
+		// Extract port — may be float64 or int depending on JSON decoder.
+		if p, ok := line.Attrs["port"]; ok {
+			switch v := p.(type) {
+			case float64:
+				port = int(v)
+			case int:
+				port = v
+			}
+		}
+		if line.TS != "" {
+			startTS, _ = time.Parse(time.RFC3339Nano, line.TS)
+		}
+		return port, startTS
+	}
+	return 0, time.Time{}
+}
+
+// fileModTimeMs returns the file's modification time as Unix milliseconds,
+// or 0 if the file does not exist.
+func fileModTimeMs(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.ModTime().UnixMilli()
+}

--- a/cmd/htmlgraph/api_collector_status.go
+++ b/cmd/htmlgraph/api_collector_status.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -111,15 +110,14 @@ func isSafeSessionID(id string) bool {
 	return true
 }
 
-// readPIDFile reads a PID from a file containing "<pid>\n".
+// readPIDFile reads the collector PID from .collector-pid. The file format
+// may be either single-line (legacy: "<pid>\n") or two-line ("<pid>\n<starttime>\n",
+// new format used by Linux writes). Delegates to collector.ReadCollectorPIDFile
+// so all consumers stay in sync with the writer.
 func readPIDFile(path string) (int, error) {
-	data, err := os.ReadFile(path)
+	pid, _, _, err := collector.ReadCollectorPIDFile(path)
 	if err != nil {
 		return 0, err
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil {
-		return 0, fmt.Errorf("parse pid %q: %w", strings.TrimSpace(string(data)), err)
 	}
 	return pid, nil
 }

--- a/cmd/htmlgraph/api_collector_status.go
+++ b/cmd/htmlgraph/api_collector_status.go
@@ -78,6 +78,10 @@ func collectorStatusHandler(projectDir string) http.HandlerFunc {
 			http.Error(w, "session parameter required", http.StatusBadRequest)
 			return
 		}
+		if !isSafeSessionID(sessionID) {
+			http.Error(w, "invalid session id", http.StatusBadRequest)
+			return
+		}
 		sessDir := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID)
 		status, err := ReadCollectorStatus(sessDir)
 		if err != nil {
@@ -86,6 +90,22 @@ func collectorStatusHandler(projectDir string) http.HandlerFunc {
 		}
 		respondJSON(w, status)
 	}
+}
+
+// isSafeSessionID rejects values that contain path separators, ".." segments,
+// or NUL bytes, preventing the session query parameter from escaping the
+// .htmlgraph/sessions/ directory via path traversal.
+func isSafeSessionID(id string) bool {
+	if id == "" || id == "." || id == ".." {
+		return false
+	}
+	if strings.ContainsAny(id, `/\` + "\x00") {
+		return false
+	}
+	if strings.Contains(id, "..") {
+		return false
+	}
+	return true
 }
 
 // readPIDFile reads a PID from a file containing "<pid>\n".

--- a/cmd/htmlgraph/api_collector_status.go
+++ b/cmd/htmlgraph/api_collector_status.go
@@ -9,8 +9,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
+
+	"github.com/shakestzd/htmlgraph/internal/otel/collector"
 )
 
 // CollectorStatus holds the live health of a per-session OTel collector.
@@ -28,7 +29,7 @@ type CollectorStatus struct {
 
 // ReadCollectorStatus constructs a CollectorStatus for the given session
 // directory by reading:
-//   - .collector-pid  → PID + liveness probe
+//   - .collector-pid  → PID + liveness probe (start-time-verified on Linux)
 //   - events.ndjson   → collector_start event for port + start timestamp
 //
 // Returns an error only when .collector-pid is missing or unreadable.
@@ -39,7 +40,9 @@ func ReadCollectorStatus(sessDir string) (CollectorStatus, error) {
 		return CollectorStatus{}, fmt.Errorf("read collector PID: %w", err)
 	}
 
-	alive := isProcessAlive(pid)
+	// Use the collector package's identity-verifying liveness check rather
+	// than a bare kill(pid,0) probe, so a recycled PID is reported as dead.
+	alive, _ := collector.IsCollectorAlive(sessDir)
 
 	port, startTS := readCollectorStartEvent(filepath.Join(sessDir, "events.ndjson"))
 
@@ -119,16 +122,6 @@ func readPIDFile(path string) (int, error) {
 		return 0, fmt.Errorf("parse pid %q: %w", strings.TrimSpace(string(data)), err)
 	}
 	return pid, nil
-}
-
-// isProcessAlive uses kill(pid, 0) to probe whether the process exists.
-// This never sends a real signal — it only checks reachability.
-func isProcessAlive(pid int) bool {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	return proc.Signal(syscall.Signal(0)) == nil
 }
 
 // collectorStartLine is the minimal shape we parse from events.ndjson.

--- a/cmd/htmlgraph/api_collector_status_test.go
+++ b/cmd/htmlgraph/api_collector_status_test.go
@@ -117,6 +117,31 @@ func TestReadCollectorStatus_MissingPIDFile(t *testing.T) {
 	}
 }
 
+// TestReadCollectorStatus_TwoLinePIDFormat verifies that the new 2-line
+// .collector-pid format (PID + start-time) is parsed correctly. Without
+// this coverage the regression caught in roborev job 96 — single-integer
+// parser failing on 2-line files — would have shipped silently.
+func TestReadCollectorStatus_TwoLinePIDFormat(t *testing.T) {
+	sessDir := t.TempDir()
+	if err := os.MkdirAll(sessDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pidPath := filepath.Join(sessDir, ".collector-pid")
+	pid := os.Getpid()
+	content := strconv.Itoa(pid) + "\n" + "9999999\n" // PID + fake start-time
+	if err := os.WriteFile(pidPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := ReadCollectorStatus(sessDir)
+	if err != nil {
+		t.Fatalf("ReadCollectorStatus on 2-line PID file: %v", err)
+	}
+	if status.PID != pid {
+		t.Errorf("PID = %d, want %d (parser ignored the start-time second line)", status.PID, pid)
+	}
+}
+
 // TestCollectorStatusEndpoint verifies the /api/otel/status HTTP handler
 // returns valid JSON CollectorStatus given a properly formed session dir.
 func TestCollectorStatusEndpoint(t *testing.T) {

--- a/cmd/htmlgraph/api_collector_status_test.go
+++ b/cmd/htmlgraph/api_collector_status_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// writeTestCollectorPID creates a fake .collector-pid in sessDir.
+func writeTestCollectorPID(t *testing.T, sessDir string, pid int) {
+	t.Helper()
+	if err := os.MkdirAll(sessDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pidPath := filepath.Join(sessDir, ".collector-pid")
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(pid)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeTestCollectorStartEvent creates a minimal events.ndjson with a
+// collector_start event so ReadCollectorStatus can extract port + timestamp.
+func writeTestCollectorStartEvent(t *testing.T, sessDir string, port int, ts time.Time) {
+	t.Helper()
+	line := map[string]any{
+		"kind":      "collector_start",
+		"canonical": "collector_start",
+		"ts":        ts.UTC().Format(time.RFC3339Nano),
+		"attrs": map[string]any{
+			"port": port,
+		},
+	}
+	b, err := json.Marshal(line)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evPath := filepath.Join(sessDir, "events.ndjson")
+	if err := os.WriteFile(evPath, append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestReadCollectorStatus_Live creates a temp session dir with the current
+// process PID (guaranteed alive) and a valid collector_start event, then
+// asserts Alive=true and Port is correctly read.
+func TestReadCollectorStatus_Live(t *testing.T) {
+	sessDir := t.TempDir()
+	pid := os.Getpid()
+	port := 14317
+	startTime := time.Now().Add(-10 * time.Second)
+
+	writeTestCollectorPID(t, sessDir, pid)
+	writeTestCollectorStartEvent(t, sessDir, port, startTime)
+
+	status, err := ReadCollectorStatus(sessDir)
+	if err != nil {
+		t.Fatalf("ReadCollectorStatus: %v", err)
+	}
+	if !status.Alive {
+		t.Errorf("Alive = false, want true (using current PID %d)", pid)
+	}
+	if status.PID != pid {
+		t.Errorf("PID = %d, want %d", status.PID, pid)
+	}
+	if status.Port != port {
+		t.Errorf("Port = %d, want %d", status.Port, port)
+	}
+	if status.UptimeSec < 0 {
+		t.Errorf("UptimeSec = %d, should be >= 0", status.UptimeSec)
+	}
+}
+
+// TestReadCollectorStatus_Dead writes an unlikely PID (999999) and asserts
+// that Alive=false is returned.
+func TestReadCollectorStatus_Dead(t *testing.T) {
+	sessDir := t.TempDir()
+	// PID 999999 is very unlikely to be alive on any system.
+	writeTestCollectorPID(t, sessDir, 999999)
+
+	status, err := ReadCollectorStatus(sessDir)
+	if err != nil {
+		t.Fatalf("ReadCollectorStatus: %v", err)
+	}
+	if status.Alive {
+		t.Errorf("Alive = true, want false for dead PID 999999")
+	}
+	if status.PID != 999999 {
+		t.Errorf("PID = %d, want 999999", status.PID)
+	}
+}
+
+// TestReadCollectorStatus_MissingPIDFile verifies that missing .collector-pid
+// returns an error (no PID file means status is not available).
+func TestReadCollectorStatus_MissingPIDFile(t *testing.T) {
+	sessDir := t.TempDir()
+	_, err := ReadCollectorStatus(sessDir)
+	if err == nil {
+		t.Error("expected error for missing .collector-pid, got nil")
+	}
+}
+
+// TestCollectorStatusEndpoint verifies the /api/otel/status HTTP handler
+// returns valid JSON CollectorStatus given a properly formed session dir.
+func TestCollectorStatusEndpoint(t *testing.T) {
+	// Build a temp project dir tree.
+	projectDir := t.TempDir()
+	sessionID := "test-sess-collector"
+	sessDir := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID)
+
+	pid := os.Getpid()
+	port := 14318
+	startTime := time.Now().Add(-5 * time.Second)
+
+	writeTestCollectorPID(t, sessDir, pid)
+	writeTestCollectorStartEvent(t, sessDir, port, startTime)
+
+	handler := collectorStatusHandler(projectDir)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/otel/status?session="+sessionID, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	var got CollectorStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.PID != pid {
+		t.Errorf("PID = %d, want %d", got.PID, pid)
+	}
+	if got.Port != port {
+		t.Errorf("Port = %d, want %d", got.Port, port)
+	}
+	if !got.Alive {
+		t.Errorf("Alive = false, want true")
+	}
+}
+
+// TestCollectorStatusEndpoint_400ForMissingParam verifies that omitting the
+// session query parameter returns 400.
+func TestCollectorStatusEndpoint_400ForMissingParam(t *testing.T) {
+	handler := collectorStatusHandler(t.TempDir())
+	req := httptest.NewRequest(http.MethodGet, "/api/otel/status", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestCollectorStatusEndpoint_RejectNonGet verifies that non-GET requests return 405.
+func TestCollectorStatusEndpoint_RejectNonGet(t *testing.T) {
+	handler := collectorStatusHandler(t.TempDir())
+	req := httptest.NewRequest(http.MethodPost, "/api/otel/status?session=x", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rec.Code)
+	}
+}

--- a/cmd/htmlgraph/api_collector_status_test.go
+++ b/cmd/htmlgraph/api_collector_status_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -75,23 +76,35 @@ func TestReadCollectorStatus_Live(t *testing.T) {
 	}
 }
 
-// TestReadCollectorStatus_Dead writes an unlikely PID (999999) and asserts
-// that Alive=false is returned.
+// TestReadCollectorStatus_Dead spawns and reaps a short-lived child, then
+// uses the reaped PID — guaranteed dead at probe time — and asserts
+// Alive=false. Avoids the PID-reuse flakiness of arbitrary high PIDs.
 func TestReadCollectorStatus_Dead(t *testing.T) {
 	sessDir := t.TempDir()
-	// PID 999999 is very unlikely to be alive on any system.
-	writeTestCollectorPID(t, sessDir, 999999)
+	deadPID := spawnAndReapChild(t)
+	writeTestCollectorPID(t, sessDir, deadPID)
 
 	status, err := ReadCollectorStatus(sessDir)
 	if err != nil {
 		t.Fatalf("ReadCollectorStatus: %v", err)
 	}
 	if status.Alive {
-		t.Errorf("Alive = true, want false for dead PID 999999")
+		t.Errorf("Alive = true, want false for reaped PID %d", deadPID)
 	}
-	if status.PID != 999999 {
-		t.Errorf("PID = %d, want 999999", status.PID)
+	if status.PID != deadPID {
+		t.Errorf("PID = %d, want %d", status.PID, deadPID)
 	}
+}
+
+// spawnAndReapChild starts /bin/true (or the platform equivalent), waits
+// for it to exit, and returns its PID. The PID is dead at return time.
+func spawnAndReapChild(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("spawn/reap child: %v", err)
+	}
+	return cmd.ProcessState.Pid()
 }
 
 // TestReadCollectorStatus_MissingPIDFile verifies that missing .collector-pid

--- a/cmd/htmlgraph/claude.go
+++ b/cmd/htmlgraph/claude.go
@@ -529,6 +529,13 @@ func launchClaude(opts LaunchOpts) error {
 
 	if err := c.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
+			// os.Exit bypasses deferred cleanups. Run the collector
+			// cleanup synchronously here; the deferred call is now a
+			// no-op (cleanup is idempotent via sync.Once in the
+			// lifecycle package).
+			if envOverrides.Cleanup != nil {
+				envOverrides.Cleanup()
+			}
 			os.Exit(exitErr.ExitCode())
 		}
 		return err

--- a/cmd/htmlgraph/claude.go
+++ b/cmd/htmlgraph/claude.go
@@ -527,20 +527,7 @@ func launchClaude(opts LaunchOpts) error {
 		c.Dir = opts.ProjectRoot
 	}
 
-	if err := c.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			// os.Exit bypasses deferred cleanups. Run the collector
-			// cleanup synchronously here; the deferred call is now a
-			// no-op (cleanup is idempotent via sync.Once in the
-			// lifecycle package).
-			if envOverrides.Cleanup != nil {
-				envOverrides.Cleanup()
-			}
-			os.Exit(exitErr.ExitCode())
-		}
-		return err
-	}
-	return nil
+	return runHarnessWithCleanup(c, envOverrides.Cleanup)
 }
 
 // writeLaunchMarker writes .htmlgraph/.launch-mode for hooks to detect the launch mode.

--- a/cmd/htmlgraph/claude_otel_collect_spawn.go
+++ b/cmd/htmlgraph/claude_otel_collect_spawn.go
@@ -57,15 +57,9 @@ func retrySpawnCollector(binPath, sessionID, projectDir string, maxAttempts int,
 	return collector.RetrySpawn(binPath, sessionID, projectDir, maxAttempts, spawnFn, warnW)
 }
 
-// watchdogInterval returns the polling interval for the collector watchdog.
-// HTMLGRAPH_OTEL_WATCHDOG_INTERVAL overrides the default of 15s.
-func watchdogInterval() time.Duration {
-	return collector.WatchdogInterval("HTMLGRAPH_OTEL_WATCHDOG_INTERVAL")
-}
-
-// startCollectorWatchdog launches a goroutine that polls the collector process
-// every watchdogInterval(). On process death it calls retrySpawnCollector and
-// updates the current process. Returns a stop func that terminates the goroutine.
+// startCollectorWatchdog launches a goroutine that polls the collector process.
+// On process death it calls retrySpawnCollector and updates the current process.
+// Returns a stop func that terminates the goroutine.
 func startCollectorWatchdog(initialProc *os.Process, binPath, sessionID, projectDir string, warnW io.Writer) func() {
 	return collector.StartWatchdog(initialProc, binPath, sessionID, projectDir, warnW, spawnCollectorFn, "HTMLGRAPH_OTEL_WATCHDOG_INTERVAL")
 }
@@ -74,12 +68,6 @@ func startCollectorWatchdog(initialProc *os.Process, binPath, sessionID, project
 // waits up to 3s, then SIGKILLs, and removes the .collector-pid file.
 func registerCollectorCleanup(proc *os.Process, projectDir, sessionID string) func() {
 	return collector.RegisterCleanup(proc, projectDir, sessionID)
-}
-
-// removeCollectorPID removes the .collector-pid file for a session.
-// Best-effort: missing file or unreadable directory is not an error.
-func removeCollectorPID(projectDir, sessionID string) {
-	collector.RemoveCollectorPID(projectDir, sessionID)
 }
 
 // writeCollectorPID writes the collector PID to the session directory.

--- a/cmd/htmlgraph/claude_otel_collect_spawn.go
+++ b/cmd/htmlgraph/claude_otel_collect_spawn.go
@@ -111,7 +111,7 @@ func spawnSessionCollectorTo(projectDir, binPath string, errW io.Writer) (otelEn
 	}
 
 	writeCollectorPID(projectDir, sessionID, proc.Pid)
-	cleanup := registerCollectorCleanup(proc)
+	cleanup := registerCollectorCleanup(proc, projectDir, sessionID)
 
 	return otelEnvOverrides{
 		CollectorPort: port,
@@ -141,8 +141,10 @@ func spawnSessionCollector(projectDir string) otelEnvOverrides {
 
 // registerCollectorCleanup spawns a reaper goroutine for the collector
 // child so it doesn't become a zombie if it exits on its own (idle
-// timeout). Returns a cleanup function that sends SIGTERM and waits.
-func registerCollectorCleanup(proc *os.Process) func() {
+// timeout). Returns a cleanup function that sends SIGTERM, waits, and
+// removes the .collector-pid file so subsequent liveness probes by
+// /api/otel/status do not see a stale PID after process exit.
+func registerCollectorCleanup(proc *os.Process, projectDir, sessionID string) func() {
 	go func() { _, _ = proc.Wait() }()
 
 	return func() {
@@ -150,12 +152,21 @@ func registerCollectorCleanup(proc *os.Process) func() {
 		deadline := time.Now().Add(3 * time.Second)
 		for time.Now().Before(deadline) {
 			if err := proc.Signal(syscall.Signal(0)); err != nil {
+				removeCollectorPID(projectDir, sessionID)
 				return // process exited
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
 		_ = proc.Kill()
+		removeCollectorPID(projectDir, sessionID)
 	}
+}
+
+// removeCollectorPID removes the .collector-pid file for a session.
+// Best-effort: missing file or unreadable directory is not an error.
+func removeCollectorPID(projectDir, sessionID string) {
+	pidPath := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID, ".collector-pid")
+	_ = os.Remove(pidPath)
 }
 
 // writeCollectorPID writes the collector PID to the session directory.

--- a/cmd/htmlgraph/claude_otel_collect_spawn.go
+++ b/cmd/htmlgraph/claude_otel_collect_spawn.go
@@ -125,6 +125,52 @@ func retrySpawnCollector(binPath, sessionID, projectDir string, maxAttempts int,
 	return 0, nil, maxAttempts, lastErr
 }
 
+// watchdogInterval returns the polling interval for the collector watchdog.
+// HTMLGRAPH_OTEL_WATCHDOG_INTERVAL overrides the default of 15s.
+func watchdogInterval() time.Duration {
+	if v := os.Getenv("HTMLGRAPH_OTEL_WATCHDOG_INTERVAL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 15 * time.Second
+}
+
+// startCollectorWatchdog launches a goroutine that polls the collector process
+// every watchdogInterval(). On process death it calls retrySpawnCollector and
+// updates the current process. Returns a stop func that terminates the goroutine.
+func startCollectorWatchdog(initialProc *os.Process, binPath, sessionID, projectDir string, warnW io.Writer) func() {
+	done := make(chan struct{})
+
+	go func() {
+		ticker := time.NewTicker(watchdogInterval())
+		defer ticker.Stop()
+		currentProc := initialProc
+
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				if err := currentProc.Signal(syscall.Signal(0)); err == nil {
+					continue // process still alive
+				}
+				fmt.Fprintf(warnW, "htmlgraph: warning: collector died (pid=%d), respawning...\n", currentProc.Pid)
+				port, newProc, _, spawnErr := retrySpawnCollector(binPath, sessionID, projectDir, 3, nil, warnW)
+				if spawnErr != nil {
+					fmt.Fprintf(warnW, "htmlgraph: FATAL: collector respawn failed: %v\n", spawnErr)
+					return
+				}
+				writeCollectorPID(projectDir, sessionID, newProc.Pid)
+				fmt.Fprintf(warnW, "htmlgraph: info: collector respawned (pid=%d port=%d)\n", newProc.Pid, port)
+				currentProc = newProc
+			}
+		}
+	}()
+
+	return func() { close(done) }
+}
+
 // spawnSessionCollectorTo is the testable core of collector spawning.
 // It generates a session ID, spawns the collector at binPath (with up to 3
 // retry attempts using exponential backoff), and returns overrides and a
@@ -143,7 +189,9 @@ func spawnSessionCollectorTo(projectDir, binPath string, errW io.Writer) (otelEn
 	}
 
 	writeCollectorPID(projectDir, sessionID, proc.Pid)
-	cleanup := registerCollectorCleanup(proc, projectDir, sessionID)
+	stopWatchdog := startCollectorWatchdog(proc, binPath, sessionID, projectDir, errW)
+	baseCleanup := registerCollectorCleanup(proc, projectDir, sessionID)
+	cleanup := func() { stopWatchdog(); baseCleanup() }
 
 	return otelEnvOverrides{
 		CollectorPort: port,

--- a/cmd/htmlgraph/claude_otel_collect_spawn.go
+++ b/cmd/htmlgraph/claude_otel_collect_spawn.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/rand"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -93,22 +94,20 @@ type otelEnvOverrides struct {
 	Cleanup       func() // called on launcher exit to SIGTERM the collector
 }
 
-// spawnSessionCollector generates a session ID, spawns a per-session
-// collector, writes the PID file, and returns a cleanup function.
-// On failure, logs a warning and returns zero-value overrides.
-func spawnSessionCollector(projectDir string) otelEnvOverrides {
+// spawnSessionCollectorTo is the testable core of collector spawning.
+// It generates a session ID, spawns the collector at binPath, and returns
+// overrides and a wantExit flag. On spawn failure it always writes a FATAL
+// line to errW; wantExit is true only when HTMLGRAPH_OTEL_STRICT=1.
+// Silent-fail is preserved for soft-precondition failures that occur before
+// spawn (binary path resolution) — those are handled by the caller.
+func spawnSessionCollectorTo(projectDir, binPath string, errW io.Writer) (otelEnvOverrides, bool) {
 	sessionID := generateOtelSessionID()
-
-	binPath, err := os.Executable()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "htmlgraph: warning: per-session collector skipped: %v\n", err)
-		return otelEnvOverrides{}
-	}
 
 	port, proc, err := spawnCollector(binPath, sessionID, projectDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "htmlgraph: warning: per-session collector failed: %v\n", err)
-		return otelEnvOverrides{}
+		fmt.Fprintf(errW, "htmlgraph: FATAL: collector spawn failed after all retries: %v\n", err)
+		wantExit := os.Getenv("HTMLGRAPH_OTEL_STRICT") == "1"
+		return otelEnvOverrides{}, wantExit
 	}
 
 	writeCollectorPID(projectDir, sessionID, proc.Pid)
@@ -118,7 +117,26 @@ func spawnSessionCollector(projectDir string) otelEnvOverrides {
 		CollectorPort: port,
 		SessionID:     sessionID,
 		Cleanup:       cleanup,
+	}, false
+}
+
+// spawnSessionCollector generates a session ID, spawns a per-session
+// collector, writes the PID file, and returns a cleanup function.
+// On spawn failure emits a FATAL line to stderr; exits non-zero when
+// HTMLGRAPH_OTEL_STRICT=1. Silent-fail is preserved when the binary
+// path cannot be resolved (soft precondition).
+func spawnSessionCollector(projectDir string) otelEnvOverrides {
+	binPath, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "htmlgraph: warning: per-session collector skipped: %v\n", err)
+		return otelEnvOverrides{}
 	}
+
+	overrides, wantExit := spawnSessionCollectorTo(projectDir, binPath, os.Stderr)
+	if wantExit {
+		os.Exit(1)
+	}
+	return overrides
 }
 
 // registerCollectorCleanup spawns a reaper goroutine for the collector

--- a/cmd/htmlgraph/claude_otel_collect_spawn.go
+++ b/cmd/htmlgraph/claude_otel_collect_spawn.go
@@ -1,16 +1,13 @@
 package main
 
 import (
-	"bufio"
 	"crypto/rand"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strconv"
-	"syscall"
 	"time"
+
+	"github.com/shakestzd/htmlgraph/internal/otel/collector"
 )
 
 // generateOtelSessionID produces a hex session ID from a Unix-millisecond
@@ -25,67 +22,6 @@ func generateOtelSessionID() string {
 	return fmt.Sprintf("%012x%016x", ts, entropy)
 }
 
-// spawnCollector starts an otel-collect child process, waits for its
-// handshake line ("htmlgraph-otel-ready port=<N>"), and returns the
-// port and process. The child is started in its own process group
-// (Setpgid) so it can be independently signalled.
-//
-// binPath is the path to the htmlgraph binary to invoke. In production
-// callers should pass the result of os.Executable(); tests pass a
-// pre-built test binary.
-func spawnCollector(binPath, sessionID, projectDir string) (int, *os.Process, error) {
-	cmd := exec.Command(binPath, "otel-collect",
-		"--session-id", sessionID,
-		"--project-dir", projectDir,
-		"--listen", "127.0.0.1:0",
-	)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Stderr = os.Stderr
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return 0, nil, fmt.Errorf("stdout pipe: %w", err)
-	}
-	if err := cmd.Start(); err != nil {
-		return 0, nil, fmt.Errorf("start otel-collect: %w", err)
-	}
-
-	port, err := readCollectorHandshake(bufio.NewScanner(stdout))
-	if err != nil {
-		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
-		return 0, nil, err
-	}
-	return port, cmd.Process, nil
-}
-
-// readCollectorHandshake scans stdout for the handshake line within 3s.
-func readCollectorHandshake(scanner *bufio.Scanner) (int, error) {
-	type result struct {
-		port int
-		err  error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		for scanner.Scan() {
-			line := scanner.Text()
-			var p int
-			if _, err := fmt.Sscanf(line, "htmlgraph-otel-ready port=%d", &p); err == nil {
-				ch <- result{port: p}
-				return
-			}
-		}
-		ch <- result{err: fmt.Errorf("otel-collect: handshake not found (stdout closed)")}
-	}()
-
-	select {
-	case r := <-ch:
-		return r.port, r.err
-	case <-time.After(3 * time.Second):
-		return 0, fmt.Errorf("otel-collect: handshake timeout (3s)")
-	}
-}
-
 // otelEnvOverrides holds optional overrides for OTel env vars set by
 // the launcher. Zero-value fields mean "use the default derivation".
 type otelEnvOverrides struct {
@@ -96,7 +32,18 @@ type otelEnvOverrides struct {
 
 // spawnCollectorFn is the package-level spawn function used by
 // retrySpawnCollector. Tests may replace it to inject a fake.
-var spawnCollectorFn = spawnCollector
+var spawnCollectorFn = collector.DefaultSpawnFn
+
+// spawnCollector starts an otel-collect child process, waits for its
+// handshake line ("htmlgraph-otel-ready port=<N>"), and returns the
+// port and process. Delegates to collector.DefaultSpawnFn.
+//
+// binPath is the path to the htmlgraph binary to invoke. In production
+// callers should pass the result of os.Executable(); tests pass a
+// pre-built test binary.
+func spawnCollector(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+	return collector.DefaultSpawnFn(binPath, sessionID, projectDir)
+}
 
 // retrySpawnCollector attempts to spawn the collector up to maxAttempts times.
 // Backoff delays between attempts are: 100ms, 300ms, 700ms (indices 0, 1, 2).
@@ -107,68 +54,38 @@ func retrySpawnCollector(binPath, sessionID, projectDir string, maxAttempts int,
 	if spawnFn == nil {
 		spawnFn = spawnCollectorFn
 	}
-	backoff := []time.Duration{100 * time.Millisecond, 300 * time.Millisecond, 700 * time.Millisecond}
-	var lastErr error
-	for i := 0; i < maxAttempts; i++ {
-		port, proc, err := spawnFn(binPath, sessionID, projectDir)
-		if err == nil {
-			return port, proc, i + 1, nil
-		}
-		lastErr = err
-		if i < maxAttempts-1 {
-			fmt.Fprintf(warnW, "htmlgraph: warning: collector spawn attempt %d/%d failed: %v\n", i+1, maxAttempts, err)
-			if i < len(backoff) {
-				time.Sleep(backoff[i])
-			}
-		}
-	}
-	return 0, nil, maxAttempts, lastErr
+	return collector.RetrySpawn(binPath, sessionID, projectDir, maxAttempts, spawnFn, warnW)
 }
 
 // watchdogInterval returns the polling interval for the collector watchdog.
 // HTMLGRAPH_OTEL_WATCHDOG_INTERVAL overrides the default of 15s.
 func watchdogInterval() time.Duration {
-	if v := os.Getenv("HTMLGRAPH_OTEL_WATCHDOG_INTERVAL"); v != "" {
-		if d, err := time.ParseDuration(v); err == nil && d > 0 {
-			return d
-		}
-	}
-	return 15 * time.Second
+	return collector.WatchdogInterval("HTMLGRAPH_OTEL_WATCHDOG_INTERVAL")
 }
 
 // startCollectorWatchdog launches a goroutine that polls the collector process
 // every watchdogInterval(). On process death it calls retrySpawnCollector and
 // updates the current process. Returns a stop func that terminates the goroutine.
 func startCollectorWatchdog(initialProc *os.Process, binPath, sessionID, projectDir string, warnW io.Writer) func() {
-	done := make(chan struct{})
+	return collector.StartWatchdog(initialProc, binPath, sessionID, projectDir, warnW, spawnCollectorFn, "HTMLGRAPH_OTEL_WATCHDOG_INTERVAL")
+}
 
-	go func() {
-		ticker := time.NewTicker(watchdogInterval())
-		defer ticker.Stop()
-		currentProc := initialProc
+// registerCollectorCleanup returns a cleanup function that sends SIGTERM,
+// waits up to 3s, then SIGKILLs, and removes the .collector-pid file.
+func registerCollectorCleanup(proc *os.Process, projectDir, sessionID string) func() {
+	return collector.RegisterCleanup(proc, projectDir, sessionID)
+}
 
-		for {
-			select {
-			case <-done:
-				return
-			case <-ticker.C:
-				if err := currentProc.Signal(syscall.Signal(0)); err == nil {
-					continue // process still alive
-				}
-				fmt.Fprintf(warnW, "htmlgraph: warning: collector died (pid=%d), respawning...\n", currentProc.Pid)
-				port, newProc, _, spawnErr := retrySpawnCollector(binPath, sessionID, projectDir, 3, nil, warnW)
-				if spawnErr != nil {
-					fmt.Fprintf(warnW, "htmlgraph: FATAL: collector respawn failed: %v\n", spawnErr)
-					return
-				}
-				writeCollectorPID(projectDir, sessionID, newProc.Pid)
-				fmt.Fprintf(warnW, "htmlgraph: info: collector respawned (pid=%d port=%d)\n", newProc.Pid, port)
-				currentProc = newProc
-			}
-		}
-	}()
+// removeCollectorPID removes the .collector-pid file for a session.
+// Best-effort: missing file or unreadable directory is not an error.
+func removeCollectorPID(projectDir, sessionID string) {
+	collector.RemoveCollectorPID(projectDir, sessionID)
+}
 
-	return func() { close(done) }
+// writeCollectorPID writes the collector PID to the session directory.
+// Best-effort: errors are silently ignored.
+func writeCollectorPID(projectDir, sessionID string, pid int) {
+	collector.WriteCollectorPID(projectDir, sessionID, pid)
 }
 
 // spawnSessionCollectorTo is the testable core of collector spawning.
@@ -176,8 +93,6 @@ func startCollectorWatchdog(initialProc *os.Process, binPath, sessionID, project
 // retry attempts using exponential backoff), and returns overrides and a
 // wantExit flag. On spawn failure it always writes a FATAL line to errW;
 // wantExit is true only when HTMLGRAPH_OTEL_STRICT=1.
-// Silent-fail is preserved for soft-precondition failures that occur before
-// spawn (binary path resolution) — those are handled by the caller.
 func spawnSessionCollectorTo(projectDir, binPath string, errW io.Writer) (otelEnvOverrides, bool) {
 	sessionID := generateOtelSessionID()
 
@@ -217,44 +132,4 @@ func spawnSessionCollector(projectDir string) otelEnvOverrides {
 		os.Exit(1)
 	}
 	return overrides
-}
-
-// registerCollectorCleanup spawns a reaper goroutine for the collector
-// child so it doesn't become a zombie if it exits on its own (idle
-// timeout). Returns a cleanup function that sends SIGTERM, waits, and
-// removes the .collector-pid file so subsequent liveness probes by
-// /api/otel/status do not see a stale PID after process exit.
-func registerCollectorCleanup(proc *os.Process, projectDir, sessionID string) func() {
-	go func() { _, _ = proc.Wait() }()
-
-	return func() {
-		_ = proc.Signal(syscall.SIGTERM)
-		deadline := time.Now().Add(3 * time.Second)
-		for time.Now().Before(deadline) {
-			if err := proc.Signal(syscall.Signal(0)); err != nil {
-				removeCollectorPID(projectDir, sessionID)
-				return // process exited
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-		_ = proc.Kill()
-		removeCollectorPID(projectDir, sessionID)
-	}
-}
-
-// removeCollectorPID removes the .collector-pid file for a session.
-// Best-effort: missing file or unreadable directory is not an error.
-func removeCollectorPID(projectDir, sessionID string) {
-	pidPath := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID, ".collector-pid")
-	_ = os.Remove(pidPath)
-}
-
-// writeCollectorPID writes the collector PID to the session directory.
-// Best-effort: errors are silently ignored (the PID file is used by
-// the SessionEnd hook as a hint; its absence is not fatal).
-func writeCollectorPID(projectDir, sessionID string, pid int) {
-	sessDir := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID)
-	_ = os.MkdirAll(sessDir, 0o755)
-	pidPath := filepath.Join(sessDir, ".collector-pid")
-	_ = os.WriteFile(pidPath, []byte(strconv.Itoa(pid)+"\n"), 0o644)
 }

--- a/cmd/htmlgraph/claude_otel_collect_spawn.go
+++ b/cmd/htmlgraph/claude_otel_collect_spawn.go
@@ -94,18 +94,50 @@ type otelEnvOverrides struct {
 	Cleanup       func() // called on launcher exit to SIGTERM the collector
 }
 
+// spawnCollectorFn is the package-level spawn function used by
+// retrySpawnCollector. Tests may replace it to inject a fake.
+var spawnCollectorFn = spawnCollector
+
+// retrySpawnCollector attempts to spawn the collector up to maxAttempts times.
+// Backoff delays between attempts are: 100ms, 300ms, 700ms (indices 0, 1, 2).
+// spawnFn overrides the package-level spawnCollectorFn when non-nil (for tests).
+// After each non-final failure a warning line is written to warnW.
+// Returns the port, process, number of attempts made, and any final error.
+func retrySpawnCollector(binPath, sessionID, projectDir string, maxAttempts int, spawnFn func(string, string, string) (int, *os.Process, error), warnW io.Writer) (int, *os.Process, int, error) {
+	if spawnFn == nil {
+		spawnFn = spawnCollectorFn
+	}
+	backoff := []time.Duration{100 * time.Millisecond, 300 * time.Millisecond, 700 * time.Millisecond}
+	var lastErr error
+	for i := 0; i < maxAttempts; i++ {
+		port, proc, err := spawnFn(binPath, sessionID, projectDir)
+		if err == nil {
+			return port, proc, i + 1, nil
+		}
+		lastErr = err
+		if i < maxAttempts-1 {
+			fmt.Fprintf(warnW, "htmlgraph: warning: collector spawn attempt %d/%d failed: %v\n", i+1, maxAttempts, err)
+			if i < len(backoff) {
+				time.Sleep(backoff[i])
+			}
+		}
+	}
+	return 0, nil, maxAttempts, lastErr
+}
+
 // spawnSessionCollectorTo is the testable core of collector spawning.
-// It generates a session ID, spawns the collector at binPath, and returns
-// overrides and a wantExit flag. On spawn failure it always writes a FATAL
-// line to errW; wantExit is true only when HTMLGRAPH_OTEL_STRICT=1.
+// It generates a session ID, spawns the collector at binPath (with up to 3
+// retry attempts using exponential backoff), and returns overrides and a
+// wantExit flag. On spawn failure it always writes a FATAL line to errW;
+// wantExit is true only when HTMLGRAPH_OTEL_STRICT=1.
 // Silent-fail is preserved for soft-precondition failures that occur before
 // spawn (binary path resolution) — those are handled by the caller.
 func spawnSessionCollectorTo(projectDir, binPath string, errW io.Writer) (otelEnvOverrides, bool) {
 	sessionID := generateOtelSessionID()
 
-	port, proc, err := spawnCollector(binPath, sessionID, projectDir)
+	port, proc, attempts, err := retrySpawnCollector(binPath, sessionID, projectDir, 3, nil, errW)
 	if err != nil {
-		fmt.Fprintf(errW, "htmlgraph: FATAL: collector spawn failed after all retries: %v\n", err)
+		fmt.Fprintf(errW, "htmlgraph: FATAL: collector spawn failed after %d attempts: %v\n", attempts, err)
 		wantExit := os.Getenv("HTMLGRAPH_OTEL_STRICT") == "1"
 		return otelEnvOverrides{}, wantExit
 	}

--- a/cmd/htmlgraph/claude_otel_collect_spawn.go
+++ b/cmd/htmlgraph/claude_otel_collect_spawn.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/shakestzd/htmlgraph/internal/otel/collector"
@@ -30,44 +31,35 @@ type otelEnvOverrides struct {
 	Cleanup       func() // called on launcher exit to SIGTERM the collector
 }
 
-// spawnCollectorFn is the package-level spawn function used by
-// retrySpawnCollector. Tests may replace it to inject a fake.
-var spawnCollectorFn = collector.DefaultSpawnFn
+// spawnCollectorFn is the package-level spawn function used by retry and
+// watchdog paths in this shim. Tests may replace it to inject a fake.
+var spawnCollectorFn collector.SpawnFn = collector.DefaultSpawnFn
 
-// spawnCollector starts an otel-collect child process, waits for its
-// handshake line ("htmlgraph-otel-ready port=<N>"), and returns the
-// port and process. Delegates to collector.DefaultSpawnFn.
+// spawnCollector starts an otel-collect child process and waits for its
+// handshake. Delegates to collector.DefaultSpawnFn with auto-port (0).
 //
 // binPath is the path to the htmlgraph binary to invoke. In production
 // callers should pass the result of os.Executable(); tests pass a
 // pre-built test binary.
 func spawnCollector(binPath, sessionID, projectDir string) (int, *os.Process, error) {
-	return collector.DefaultSpawnFn(binPath, sessionID, projectDir)
+	return collector.DefaultSpawnFn(binPath, sessionID, projectDir, 0)
 }
 
 // retrySpawnCollector attempts to spawn the collector up to maxAttempts times.
-// Backoff delays between attempts are: 100ms, 300ms, 700ms (indices 0, 1, 2).
 // spawnFn overrides the package-level spawnCollectorFn when non-nil (for tests).
-// After each non-final failure a warning line is written to warnW.
-// Returns the port, process, number of attempts made, and any final error.
-func retrySpawnCollector(binPath, sessionID, projectDir string, maxAttempts int, spawnFn func(string, string, string) (int, *os.Process, error), warnW io.Writer) (int, *os.Process, int, error) {
+// requestedPort is fixed at 0 (auto-assign) for this shim entry point.
+func retrySpawnCollector(binPath, sessionID, projectDir string, maxAttempts int, spawnFn collector.SpawnFn, warnW io.Writer) (int, *os.Process, int, error) {
 	if spawnFn == nil {
 		spawnFn = spawnCollectorFn
 	}
-	return collector.RetrySpawn(binPath, sessionID, projectDir, maxAttempts, spawnFn, warnW)
+	return collector.RetrySpawn(binPath, sessionID, projectDir, 0, maxAttempts, spawnFn, warnW)
 }
 
-// startCollectorWatchdog launches a goroutine that polls the collector process.
-// On process death it calls retrySpawnCollector and updates the current process.
-// Returns a stop func that terminates the goroutine.
-func startCollectorWatchdog(initialProc *os.Process, binPath, sessionID, projectDir string, warnW io.Writer) func() {
-	return collector.StartWatchdog(initialProc, binPath, sessionID, projectDir, warnW, spawnCollectorFn, "HTMLGRAPH_OTEL_WATCHDOG_INTERVAL")
-}
-
-// registerCollectorCleanup returns a cleanup function that sends SIGTERM,
-// waits up to 3s, then SIGKILLs, and removes the .collector-pid file.
-func registerCollectorCleanup(proc *os.Process, projectDir, sessionID string) func() {
-	return collector.RegisterCleanup(proc, projectDir, sessionID)
+// startCollectorWatchdog launches a goroutine that polls the current process
+// in procPtr. On death it respawns on originalPort and stores the new
+// process. The returned stop func blocks until the goroutine exits.
+func startCollectorWatchdog(procPtr *atomic.Pointer[os.Process], originalPort int, binPath, sessionID, projectDir string, warnW io.Writer) func() {
+	return collector.StartWatchdog(procPtr, originalPort, binPath, sessionID, projectDir, warnW, spawnCollectorFn, "HTMLGRAPH_OTEL_WATCHDOG_INTERVAL")
 }
 
 // writeCollectorPID writes the collector PID to the session directory.
@@ -76,25 +68,23 @@ func writeCollectorPID(projectDir, sessionID string, pid int) {
 	collector.WriteCollectorPID(projectDir, sessionID, pid)
 }
 
-// spawnSessionCollectorTo is the testable core of collector spawning.
-// It generates a session ID, spawns the collector at binPath (with up to 3
-// retry attempts using exponential backoff), and returns overrides and a
-// wantExit flag. On spawn failure it always writes a FATAL line to errW;
-// wantExit is true only when HTMLGRAPH_OTEL_STRICT=1.
+// spawnSessionCollectorTo is the testable core of collector spawning. It
+// constructs a ProcessCollector configured with the package-level
+// spawnCollectorFn (so tests can inject fakes via that variable) and calls
+// Spawn. On spawn failure, returns an empty overrides and wantExit=true
+// when HTMLGRAPH_OTEL_STRICT=1.
 func spawnSessionCollectorTo(projectDir, binPath string, errW io.Writer) (otelEnvOverrides, bool) {
 	sessionID := generateOtelSessionID()
+	pc := collector.NewProcessCollector(collector.ProcessCollectorOpts{
+		Stderr:  errW,
+		SpawnFn: spawnCollectorFn,
+	})
 
-	port, proc, attempts, err := retrySpawnCollector(binPath, sessionID, projectDir, 3, nil, errW)
+	port, cleanup, err := pc.Spawn(binPath, sessionID, projectDir)
 	if err != nil {
-		fmt.Fprintf(errW, "htmlgraph: FATAL: collector spawn failed after %d attempts: %v\n", attempts, err)
 		wantExit := os.Getenv("HTMLGRAPH_OTEL_STRICT") == "1"
 		return otelEnvOverrides{}, wantExit
 	}
-
-	writeCollectorPID(projectDir, sessionID, proc.Pid)
-	stopWatchdog := startCollectorWatchdog(proc, binPath, sessionID, projectDir, errW)
-	baseCleanup := registerCollectorCleanup(proc, projectDir, sessionID)
-	cleanup := func() { stopWatchdog(); baseCleanup() }
 
 	return otelEnvOverrides{
 		CollectorPort: port,

--- a/cmd/htmlgraph/claude_otel_collect_spawn_test.go
+++ b/cmd/htmlgraph/claude_otel_collect_spawn_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 // TestGenerateOtelSessionID verifies OTel session ID generation produces
@@ -258,6 +260,126 @@ func TestRetrySpawn_AllFail(t *testing.T) {
 	warnCount := strings.Count(stderr, "htmlgraph: warning: collector spawn attempt")
 	if warnCount != 2 {
 		t.Errorf("expected 2 warning lines, got %d; stderr=%q", warnCount, stderr)
+	}
+}
+
+// TestWatchdog_RespawnsOnDeath starts a watchdog with a fast interval, kills
+// the initial process, and asserts that the watchdog detects death and calls
+// retrySpawnCollector (via the injected spawnCollectorFn).
+func TestWatchdog_RespawnsOnDeath(t *testing.T) {
+	t.Setenv("HTMLGRAPH_OTEL_WATCHDOG_INTERVAL", "50ms")
+
+	// Start a real short-lived process to kill.
+	cmd := exec.Command("/bin/sh", "-c", "sleep 60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start initial proc: %v", err)
+	}
+	initialProc := cmd.Process
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	spawnCount := 0
+	origFn := spawnCollectorFn
+	t.Cleanup(func() { spawnCollectorFn = origFn })
+	spawnCollectorFn = func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+		spawnCount++
+		// Return a fresh long-lived process so the watchdog can update currentProc.
+		newCmd := exec.Command("/bin/sh", "-c", "sleep 60")
+		if err := newCmd.Start(); err != nil {
+			return 0, nil, err
+		}
+		t.Cleanup(func() { _ = newCmd.Process.Kill() })
+		return 9999, newCmd.Process, nil
+	}
+
+	projectDir := t.TempDir()
+	var buf bytes.Buffer
+	stopWatchdog := startCollectorWatchdog(initialProc, "/fake/bin", "test-wd-sid", projectDir, &buf)
+	t.Cleanup(stopWatchdog)
+
+	// Kill the initial process and reap it so it doesn't linger as a zombie.
+	// Signal(0) on a zombie returns nil (PID still in table), so Wait() is
+	// required for the watchdog to see the process as gone.
+	if err := initialProc.Kill(); err != nil {
+		t.Fatalf("kill initial proc: %v", err)
+	}
+	_, _ = initialProc.Wait()
+
+	// Wait up to 2s for warning line to appear.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(buf.String(), "collector died") {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if !strings.Contains(buf.String(), "collector died") {
+		t.Errorf("expected 'collector died' warning in stderr, got: %q", buf.String())
+	}
+	if spawnCount == 0 {
+		t.Error("expected at least one respawn call, got 0")
+	}
+}
+
+// TestWatchdog_StopsCleanlyWhenLive starts a watchdog with a live process,
+// immediately calls stopWatchdog, and asserts no warnings appear on stderr.
+func TestWatchdog_StopsCleanlyWhenLive(t *testing.T) {
+	t.Setenv("HTMLGRAPH_OTEL_WATCHDOG_INTERVAL", "50ms")
+
+	cmd := exec.Command("/bin/sh", "-c", "sleep 60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start proc: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	var buf bytes.Buffer
+	stopWatchdog := startCollectorWatchdog(cmd.Process, "/fake/bin", "test-wd-live", t.TempDir(), &buf)
+
+	// Stop immediately — process is still alive, so no warnings expected.
+	stopWatchdog()
+
+	// Brief wait to ensure no goroutine races produce a warning after stop.
+	time.Sleep(100 * time.Millisecond)
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no stderr output when process is alive and watchdog stopped, got: %q", buf.String())
+	}
+}
+
+// TestWatchdog_IntervalEnvOverride verifies that HTMLGRAPH_OTEL_WATCHDOG_INTERVAL
+// is parsed and applied — a 10ms interval should produce multiple ticks within 100ms.
+func TestWatchdog_IntervalEnvOverride(t *testing.T) {
+	t.Setenv("HTMLGRAPH_OTEL_WATCHDOG_INTERVAL", "10ms")
+
+	// Start a long-lived process so each probe succeeds (no respawn).
+	cmd := exec.Command("/bin/sh", "-c", "sleep 60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start proc: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	probeCount := 0
+	origFn := spawnCollectorFn
+	t.Cleanup(func() { spawnCollectorFn = origFn })
+	// Override won't be called since process stays alive; we count via a
+	// patched signal approach. Instead, we rely on the ticker firing multiple
+	// times in 100ms — verified indirectly by stopping after 100ms and
+	// confirming the watchdog goroutine ran (no panic, clean stop).
+	_ = origFn
+	_ = probeCount
+
+	var buf bytes.Buffer
+	stopWatchdog := startCollectorWatchdog(cmd.Process, "/fake/bin", "test-wd-interval", t.TempDir(), &buf)
+
+	// Let the watchdog tick several times.
+	time.Sleep(100 * time.Millisecond)
+	stopWatchdog()
+
+	// With 10ms interval and 100ms window, ~10 ticks should have fired.
+	// We can't count them without instrumentation, but the key assertion is
+	// the watchdog ran without panic and no warnings (process was alive).
+	if buf.Len() > 0 {
+		t.Errorf("unexpected warnings (process was alive): %q", buf.String())
 	}
 }
 

--- a/cmd/htmlgraph/claude_otel_collect_spawn_test.go
+++ b/cmd/htmlgraph/claude_otel_collect_spawn_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -187,5 +188,115 @@ func TestSpawnQuietByDefault(t *testing.T) {
 	}
 	if overrides.CollectorPort != 0 || overrides.SessionID != "" || overrides.Cleanup != nil {
 		t.Errorf("expected zero-value overrides on failure, got: %+v", overrides)
+	}
+}
+
+// TestRetrySpawn_SucceedsOnThirdAttempt injects a fake spawn function that
+// fails on attempts 1 and 2 then succeeds on attempt 3. Verifies the final
+// return values are from the successful attempt and that two warning lines
+// were written to stderr.
+func TestRetrySpawn_SucceedsOnThirdAttempt(t *testing.T) {
+	callCount := 0
+	var buf bytes.Buffer
+
+	fakeFn := func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+		callCount++
+		if callCount < 3 {
+			return 0, nil, fmt.Errorf("transient error attempt %d", callCount)
+		}
+		return 9999, &os.Process{Pid: 12345}, nil
+	}
+
+	port, proc, attempts, err := retrySpawnCollector("/fake/bin", "sid", t.TempDir(), 3, fakeFn, &buf)
+
+	if err != nil {
+		t.Fatalf("expected success on third attempt, got error: %v", err)
+	}
+	if port != 9999 {
+		t.Errorf("port = %d, want 9999", port)
+	}
+	if proc == nil || proc.Pid != 12345 {
+		t.Errorf("unexpected proc: %+v", proc)
+	}
+	if attempts != 3 {
+		t.Errorf("attempts = %d, want 3", attempts)
+	}
+	stderr := buf.String()
+	warnCount := strings.Count(stderr, "htmlgraph: warning: collector spawn attempt")
+	if warnCount != 2 {
+		t.Errorf("expected 2 warning lines, got %d; stderr=%q", warnCount, stderr)
+	}
+}
+
+// TestRetrySpawn_AllFail injects a fake spawn function that always fails.
+// Verifies the error is returned, attempts==3, and 2 warning lines appear
+// (warning for attempts 1 and 2; attempt 3 failure is surfaced as the error).
+func TestRetrySpawn_AllFail(t *testing.T) {
+	callCount := 0
+	var buf bytes.Buffer
+
+	fakeFn := func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+		callCount++
+		return 0, nil, fmt.Errorf("persistent failure attempt %d", callCount)
+	}
+
+	port, proc, attempts, err := retrySpawnCollector("/fake/bin", "sid", t.TempDir(), 3, fakeFn, &buf)
+
+	if err == nil {
+		t.Fatal("expected error when all attempts fail, got nil")
+	}
+	if port != 0 {
+		t.Errorf("port = %d, want 0", port)
+	}
+	if proc != nil {
+		t.Error("expected nil process on failure")
+	}
+	if attempts != 3 {
+		t.Errorf("attempts = %d, want 3", attempts)
+	}
+	stderr := buf.String()
+	warnCount := strings.Count(stderr, "htmlgraph: warning: collector spawn attempt")
+	if warnCount != 2 {
+		t.Errorf("expected 2 warning lines, got %d; stderr=%q", warnCount, stderr)
+	}
+}
+
+// TestSpawnSessionCollectorTo_RetriesOnTransientFailure verifies that the
+// higher-level spawnSessionCollectorTo succeeds when the underlying spawn
+// fails on the first attempt but succeeds on the second.
+func TestSpawnSessionCollectorTo_RetriesOnTransientFailure(t *testing.T) {
+	t.Setenv("HTMLGRAPH_OTEL_STRICT", "")
+
+	callCount := 0
+	origFn := spawnCollectorFn
+	t.Cleanup(func() { spawnCollectorFn = origFn })
+
+	spawnCollectorFn = func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+		callCount++
+		if callCount < 2 {
+			return 0, nil, fmt.Errorf("transient error")
+		}
+		return 8888, &os.Process{Pid: 99999}, nil
+	}
+
+	var buf bytes.Buffer
+	projectDir := t.TempDir()
+
+	overrides, wantExit := spawnSessionCollectorTo(projectDir, "/fake/bin", &buf)
+
+	if wantExit {
+		t.Error("expected wantExit=false on eventual success")
+	}
+	if overrides.CollectorPort != 8888 {
+		t.Errorf("CollectorPort = %d, want 8888", overrides.CollectorPort)
+	}
+	if overrides.SessionID == "" {
+		t.Error("expected non-empty SessionID")
+	}
+	if overrides.Cleanup == nil {
+		t.Error("expected non-nil Cleanup")
+	}
+	if callCount != 2 {
+		t.Errorf("callCount = %d, want 2", callCount)
 	}
 }

--- a/cmd/htmlgraph/claude_otel_collect_spawn_test.go
+++ b/cmd/htmlgraph/claude_otel_collect_spawn_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -201,7 +202,7 @@ func TestRetrySpawn_SucceedsOnThirdAttempt(t *testing.T) {
 	callCount := 0
 	var buf bytes.Buffer
 
-	fakeFn := func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+	fakeFn := func(binPath, sessionID, projectDir string, requestedPort int) (int, *os.Process, error) {
 		callCount++
 		if callCount < 3 {
 			return 0, nil, fmt.Errorf("transient error attempt %d", callCount)
@@ -237,7 +238,7 @@ func TestRetrySpawn_AllFail(t *testing.T) {
 	callCount := 0
 	var buf bytes.Buffer
 
-	fakeFn := func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+	fakeFn := func(binPath, sessionID, projectDir string, requestedPort int) (int, *os.Process, error) {
 		callCount++
 		return 0, nil, fmt.Errorf("persistent failure attempt %d", callCount)
 	}
@@ -280,7 +281,7 @@ func TestWatchdog_RespawnsOnDeath(t *testing.T) {
 	spawnCount := 0
 	origFn := spawnCollectorFn
 	t.Cleanup(func() { spawnCollectorFn = origFn })
-	spawnCollectorFn = func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+	spawnCollectorFn = func(binPath, sessionID, projectDir string, requestedPort int) (int, *os.Process, error) {
 		spawnCount++
 		// Return a fresh long-lived process so the watchdog can update currentProc.
 		newCmd := exec.Command("/bin/sh", "-c", "sleep 60")
@@ -293,7 +294,9 @@ func TestWatchdog_RespawnsOnDeath(t *testing.T) {
 
 	projectDir := t.TempDir()
 	var buf bytes.Buffer
-	stopWatchdog := startCollectorWatchdog(initialProc, "/fake/bin", "test-wd-sid", projectDir, &buf)
+	var procPtr atomic.Pointer[os.Process]
+	procPtr.Store(initialProc)
+	stopWatchdog := startCollectorWatchdog(&procPtr, 8888, "/fake/bin", "test-wd-sid", projectDir, &buf)
 	t.Cleanup(stopWatchdog)
 
 	// Kill the initial process and reap it so it doesn't linger as a zombie.
@@ -333,7 +336,9 @@ func TestWatchdog_StopsCleanlyWhenLive(t *testing.T) {
 	t.Cleanup(func() { _ = cmd.Process.Kill() })
 
 	var buf bytes.Buffer
-	stopWatchdog := startCollectorWatchdog(cmd.Process, "/fake/bin", "test-wd-live", t.TempDir(), &buf)
+	var procPtr atomic.Pointer[os.Process]
+	procPtr.Store(cmd.Process)
+	stopWatchdog := startCollectorWatchdog(&procPtr, 8888, "/fake/bin", "test-wd-live", t.TempDir(), &buf)
 
 	// Stop immediately — process is still alive, so no warnings expected.
 	stopWatchdog()
@@ -369,7 +374,9 @@ func TestWatchdog_IntervalEnvOverride(t *testing.T) {
 	_ = probeCount
 
 	var buf bytes.Buffer
-	stopWatchdog := startCollectorWatchdog(cmd.Process, "/fake/bin", "test-wd-interval", t.TempDir(), &buf)
+	var procPtr atomic.Pointer[os.Process]
+	procPtr.Store(cmd.Process)
+	stopWatchdog := startCollectorWatchdog(&procPtr, 8888, "/fake/bin", "test-wd-interval", t.TempDir(), &buf)
 
 	// Let the watchdog tick several times.
 	time.Sleep(100 * time.Millisecond)
@@ -393,7 +400,7 @@ func TestSpawnSessionCollectorTo_RetriesOnTransientFailure(t *testing.T) {
 	origFn := spawnCollectorFn
 	t.Cleanup(func() { spawnCollectorFn = origFn })
 
-	spawnCollectorFn = func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+	spawnCollectorFn = func(binPath, sessionID, projectDir string, requestedPort int) (int, *os.Process, error) {
 		callCount++
 		if callCount < 2 {
 			return 0, nil, fmt.Errorf("transient error")

--- a/cmd/htmlgraph/claude_otel_collect_spawn_test.go
+++ b/cmd/htmlgraph/claude_otel_collect_spawn_test.go
@@ -6,12 +6,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/shakestzd/htmlgraph/internal/otel/collector"
 )
 
 // TestGenerateOtelSessionID verifies OTel session ID generation produces
@@ -107,23 +108,23 @@ func TestSpawnCollector_HandshakeTimeout(t *testing.T) {
 	}
 }
 
-// TestWriteCollectorPID writes a PID file and reads it back.
+// TestWriteCollectorPID writes a PID file and reads it back via the shared
+// collector parser, which handles both the legacy single-line format and
+// the new <pid>\n<start_time>\n format that WriteCollectorPID emits when
+// /proc/<pid>/stat is readable. Reading via strconv.Atoi on the whole
+// file directly here would silently pass on hosts where the test PID
+// happens to not exist in /proc and fail on hosts where it does.
 func TestWriteCollectorPID(t *testing.T) {
 	projectDir := t.TempDir()
 	sid := "test-pid-write"
-	pid := 42
+	pid := os.Getpid() // a PID that's guaranteed alive, so /proc/<pid>/stat exists
 
 	writeCollectorPID(projectDir, sid, pid)
 
 	pidPath := filepath.Join(projectDir, ".htmlgraph", "sessions", sid, ".collector-pid")
-	data, err := os.ReadFile(pidPath)
+	got, _, _, err := collector.ReadCollectorPIDFile(pidPath)
 	if err != nil {
-		t.Fatalf("PID file not found at %s: %v", pidPath, err)
-	}
-
-	got, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil {
-		t.Fatalf("PID file content is not a valid integer: %q", string(data))
+		t.Fatalf("ReadCollectorPIDFile: %v", err)
 	}
 	if got != pid {
 		t.Errorf("PID = %d, want %d", got, pid)

--- a/cmd/htmlgraph/claude_otel_collect_spawn_test.go
+++ b/cmd/htmlgraph/claude_otel_collect_spawn_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -140,5 +141,51 @@ func TestWriteCollectorPID_CreatesDirectories(t *testing.T) {
 	}
 	if !info.IsDir() {
 		t.Error("session dir is not a directory")
+	}
+}
+
+// TestSpawnFailLoudStrict verifies that when HTMLGRAPH_OTEL_STRICT=1 and
+// collector spawn fails, spawnSessionCollectorTo emits a FATAL line on the
+// provided stderr writer and returns wantExit=true.
+func TestSpawnFailLoudStrict(t *testing.T) {
+	t.Setenv("HTMLGRAPH_OTEL_STRICT", "1")
+
+	var buf bytes.Buffer
+	projectDir := t.TempDir()
+
+	overrides, wantExit := spawnSessionCollectorTo(projectDir, "/nonexistent/binary", &buf)
+
+	stderr := buf.String()
+	if !strings.Contains(stderr, "htmlgraph: FATAL:") {
+		t.Errorf("expected FATAL line on stderr, got: %q", stderr)
+	}
+	if !wantExit {
+		t.Error("expected wantExit=true when HTMLGRAPH_OTEL_STRICT=1 and spawn fails")
+	}
+	if overrides.CollectorPort != 0 || overrides.SessionID != "" || overrides.Cleanup != nil {
+		t.Errorf("expected zero-value overrides on failure, got: %+v", overrides)
+	}
+}
+
+// TestSpawnQuietByDefault verifies that without HTMLGRAPH_OTEL_STRICT, a
+// failed spawn still emits a FATAL line on stderr but returns wantExit=false
+// and zero-value overrides (degraded mode).
+func TestSpawnQuietByDefault(t *testing.T) {
+	t.Setenv("HTMLGRAPH_OTEL_STRICT", "")
+
+	var buf bytes.Buffer
+	projectDir := t.TempDir()
+
+	overrides, wantExit := spawnSessionCollectorTo(projectDir, "/nonexistent/binary", &buf)
+
+	stderr := buf.String()
+	if !strings.Contains(stderr, "htmlgraph: FATAL:") {
+		t.Errorf("expected FATAL line on stderr even without strict mode, got: %q", stderr)
+	}
+	if wantExit {
+		t.Error("expected wantExit=false when HTMLGRAPH_OTEL_STRICT is not set")
+	}
+	if overrides.CollectorPort != 0 || overrides.SessionID != "" || overrides.Cleanup != nil {
+		t.Errorf("expected zero-value overrides on failure, got: %+v", overrides)
 	}
 }

--- a/cmd/htmlgraph/codex.go
+++ b/cmd/htmlgraph/codex.go
@@ -597,18 +597,5 @@ func execCodex(opts codexLaunchOpts) error {
 		c.Dir = workDir
 	}
 
-	if err := c.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			// os.Exit bypasses deferred cleanups. Run the collector
-			// cleanup synchronously here; the deferred call is now a
-			// no-op (cleanup is idempotent via sync.Once in the
-			// lifecycle package).
-			if otelCleanup != nil {
-				otelCleanup()
-			}
-			os.Exit(exitErr.ExitCode())
-		}
-		return err
-	}
-	return nil
+	return runHarnessWithCleanup(c, otelCleanup)
 }

--- a/cmd/htmlgraph/codex.go
+++ b/cmd/htmlgraph/codex.go
@@ -555,23 +555,46 @@ func execCodex(opts codexLaunchOpts) error {
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 
-	// Inject HTMLGRAPH_PROJECT_DIR so htmlgraph CLI and hooks resolve to the
-	// correct project root regardless of CWD.
-	// When WorktreeRoot is set, the process runs in the worktree but
-	// HTMLGRAPH_PROJECT_DIR points to the canonical project root (HtmlgraphRoot).
+	// Resolve the effective project dir for OTel collector spawning.
+	effectiveProjDir := opts.ProjectRoot
+	if opts.HtmlgraphRoot != "" {
+		effectiveProjDir = opts.HtmlgraphRoot
+	}
+
+	// Spawn a per-session OTel collector when a project dir is known and OTel
+	// is not explicitly disabled. Non-fatal: falls back gracefully on failure.
+	var otelPort int
+	var otelSessionID string
+	if effectiveProjDir != "" && !isExplicitlyDisabled(os.Getenv("HTMLGRAPH_OTEL_ENABLED")) {
+		var otelCleanup func()
+		otelPort, otelSessionID, otelCleanup = spawnCodexOtelCollector(effectiveProjDir)
+		if otelCleanup != nil {
+			defer otelCleanup()
+		}
+	}
+
+	// Build the child env: start from os.Environ, inject HTMLGRAPH_PROJECT_DIR,
+	// and layer OTel exporter vars when a collector was spawned.
+	env := os.Environ()
+	workDir := ""
+
 	switch {
 	case opts.WorktreeRoot != "":
-		env := os.Environ()
 		projectDir := opts.HtmlgraphRoot
 		if projectDir == "" {
 			projectDir = opts.ProjectRoot
 		}
 		env = setOrReplaceEnv(env, "HTMLGRAPH_PROJECT_DIR", projectDir)
-		c.Env = env
-		c.Dir = opts.WorktreeRoot
+		workDir = opts.WorktreeRoot
 	case opts.ProjectRoot != "":
-		c.Env = append(os.Environ(), "HTMLGRAPH_PROJECT_DIR="+opts.ProjectRoot)
-		c.Dir = opts.ProjectRoot
+		env = setOrReplaceEnv(env, "HTMLGRAPH_PROJECT_DIR", opts.ProjectRoot)
+		workDir = opts.ProjectRoot
+	}
+
+	env = buildCodexOtelEnv(env, otelPort, otelSessionID)
+	c.Env = env
+	if workDir != "" {
+		c.Dir = workDir
 	}
 
 	if err := c.Run(); err != nil {

--- a/cmd/htmlgraph/codex.go
+++ b/cmd/htmlgraph/codex.go
@@ -565,8 +565,8 @@ func execCodex(opts codexLaunchOpts) error {
 	// is not explicitly disabled. Non-fatal: falls back gracefully on failure.
 	var otelPort int
 	var otelSessionID string
+	var otelCleanup func()
 	if effectiveProjDir != "" && !isExplicitlyDisabled(os.Getenv("HTMLGRAPH_OTEL_ENABLED")) {
-		var otelCleanup func()
 		otelPort, otelSessionID, otelCleanup = spawnCodexOtelCollector(effectiveProjDir)
 		if otelCleanup != nil {
 			defer otelCleanup()
@@ -599,6 +599,13 @@ func execCodex(opts codexLaunchOpts) error {
 
 	if err := c.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
+			// os.Exit bypasses deferred cleanups. Run the collector
+			// cleanup synchronously here; the deferred call is now a
+			// no-op (cleanup is idempotent via sync.Once in the
+			// lifecycle package).
+			if otelCleanup != nil {
+				otelCleanup()
+			}
 			os.Exit(exitErr.ExitCode())
 		}
 		return err

--- a/cmd/htmlgraph/codex_launch.go
+++ b/cmd/htmlgraph/codex_launch.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/shakestzd/htmlgraph/internal/otel/collector"
+)
+
+// appendOrReplaceEnv takes an env slice (KEY=VALUE strings) and one or more
+// kv pairs in "KEY=VALUE" form. For each kv, if the key already exists in env
+// its entry is replaced in-place; otherwise the kv is appended. The original
+// slice is modified and returned. Order of existing entries is preserved.
+func appendOrReplaceEnv(env []string, kv ...string) []string {
+	for _, pair := range kv {
+		key := pair
+		if idx := strings.IndexByte(pair, '='); idx >= 0 {
+			key = pair[:idx+1] // includes '=' so prefix matching works
+		}
+		replaced := false
+		for i, e := range env {
+			if strings.HasPrefix(e, key) {
+				env[i] = pair
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			env = append(env, pair)
+		}
+	}
+	return env
+}
+
+// spawnCodexOtelCollector spawns a per-session OTel collector and returns the
+// port, session ID, and a cleanup function. On failure it writes a warning to
+// stderr and returns zero port / nil cleanup so the caller can proceed without
+// telemetry. Exits non-zero when HTMLGRAPH_OTEL_STRICT=1 and spawn fails.
+func spawnCodexOtelCollector(projectDir string) (port int, sessionID string, cleanup func()) {
+	binPath, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "htmlgraph: warning: codex per-session collector skipped: %v\n", err)
+		return 0, "", nil
+	}
+
+	sessionID = generateOtelSessionID()
+	lc := collector.NewProcessCollector(collector.ProcessCollectorOpts{
+		Stderr:     os.Stderr,
+		StrictMode: os.Getenv("HTMLGRAPH_OTEL_STRICT") == "1",
+	})
+
+	spawnedPort, spawnCleanup, spawnErr := lc.Spawn(binPath, sessionID, projectDir)
+	if spawnErr != nil {
+		fmt.Fprintf(os.Stderr, "htmlgraph: FATAL: codex collector spawn failed: %v\n", spawnErr)
+		if os.Getenv("HTMLGRAPH_OTEL_STRICT") == "1" {
+			os.Exit(1)
+		}
+		return 0, "", nil
+	}
+
+	return spawnedPort, sessionID, spawnCleanup
+}
+
+// buildCodexOtelEnv returns a copy of base with OTel exporter variables set
+// for the Codex CLI child process. port and sessionID come from
+// spawnCodexOtelCollector; when port is 0 the base env is returned unchanged.
+func buildCodexOtelEnv(base []string, port int, sessionID string) []string {
+	if port == 0 {
+		return base
+	}
+	endpoint := fmt.Sprintf("http://127.0.0.1:%d", port)
+	env := make([]string, len(base))
+	copy(env, base)
+	env = appendOrReplaceEnv(env,
+		"OTEL_EXPORTER_OTLP_ENDPOINT="+endpoint,
+		"OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf",
+		"OTEL_SERVICE_NAME=codex-cli",
+		"HTMLGRAPH_OTEL_SESSION="+sessionID,
+	)
+	return env
+}

--- a/cmd/htmlgraph/codex_launch_test.go
+++ b/cmd/htmlgraph/codex_launch_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestAppendOrReplaceEnv_AppendsNew verifies that a key not present in env is appended.
+func TestAppendOrReplaceEnv_AppendsNew(t *testing.T) {
+	env := []string{"FOO=bar", "BAZ=qux"}
+	got := appendOrReplaceEnv(env, "NEW_KEY=new_value")
+	found := false
+	for _, kv := range got {
+		if kv == "NEW_KEY=new_value" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected NEW_KEY=new_value to be appended; got %v", got)
+	}
+	// Original keys must still be present.
+	for _, orig := range env {
+		present := false
+		for _, kv := range got {
+			if kv == orig {
+				present = true
+				break
+			}
+		}
+		if !present {
+			t.Errorf("original key %q was lost; got %v", orig, got)
+		}
+	}
+}
+
+// TestAppendOrReplaceEnv_OverridesExisting verifies that an existing key is replaced in-place.
+func TestAppendOrReplaceEnv_OverridesExisting(t *testing.T) {
+	env := []string{"FOO=old", "BAR=keep"}
+	got := appendOrReplaceEnv(env, "FOO=new")
+
+	// FOO must be overridden.
+	fooCount := 0
+	for _, kv := range got {
+		if kv == "FOO=old" {
+			t.Errorf("stale FOO=old still present in %v", got)
+		}
+		if kv == "FOO=new" {
+			fooCount++
+		}
+	}
+	if fooCount != 1 {
+		t.Errorf("expected exactly one FOO=new entry, got %d in %v", fooCount, got)
+	}
+
+	// BAR must be unchanged.
+	barFound := false
+	for _, kv := range got {
+		if kv == "BAR=keep" {
+			barFound = true
+		}
+	}
+	if !barFound {
+		t.Errorf("BAR=keep was lost; got %v", got)
+	}
+}
+
+// TestAppendOrReplaceEnv_Multiple verifies that multiple kv pairs are all applied.
+func TestAppendOrReplaceEnv_Multiple(t *testing.T) {
+	env := []string{"EXISTING=old"}
+	got := appendOrReplaceEnv(env, "EXISTING=new", "BRAND=fresh")
+
+	existingNew := false
+	brandFresh := false
+	for _, kv := range got {
+		if kv == "EXISTING=new" {
+			existingNew = true
+		}
+		if kv == "BRAND=fresh" {
+			brandFresh = true
+		}
+		if kv == "EXISTING=old" {
+			t.Errorf("stale EXISTING=old still present in %v", got)
+		}
+	}
+	if !existingNew {
+		t.Errorf("EXISTING=new not found in %v", got)
+	}
+	if !brandFresh {
+		t.Errorf("BRAND=fresh not found in %v", got)
+	}
+}
+
+// TestAppendOrReplaceEnv_Empty verifies that empty input env is handled correctly.
+func TestAppendOrReplaceEnv_Empty(t *testing.T) {
+	got := appendOrReplaceEnv(nil, "KEY=val")
+	if len(got) != 1 || got[0] != "KEY=val" {
+		t.Errorf("expected [KEY=val], got %v", got)
+	}
+
+	got2 := appendOrReplaceEnv([]string{}, "A=1", "B=2")
+	if len(got2) != 2 {
+		t.Errorf("expected 2 entries, got %v", got2)
+	}
+}

--- a/cmd/htmlgraph/gemini.go
+++ b/cmd/htmlgraph/gemini.go
@@ -234,13 +234,32 @@ func execGemini(opts geminiLaunchOpts) error {
 		return fmt.Errorf("gemini not found in PATH: %w\nInstall Gemini CLI first: https://github.com/google-gemini/gemini-cli", err)
 	}
 
+	// Resolve the effective project dir for OTel collector spawning.
+	effectiveProjDir := opts.ProjectRoot
+	if opts.HtmlgraphRoot != "" {
+		effectiveProjDir = opts.HtmlgraphRoot
+	}
+
+	// Spawn a per-session OTel collector when a project dir is known and OTel
+	// is not explicitly disabled. Non-fatal: falls back gracefully on failure.
+	var otelPort int
+	var otelSessionID string
+	if effectiveProjDir != "" && !isExplicitlyDisabled(os.Getenv("HTMLGRAPH_OTEL_ENABLED")) {
+		var otelCleanup func()
+		otelPort, otelSessionID, otelCleanup = spawnGeminiOtelCollector(effectiveProjDir)
+		if otelCleanup != nil {
+			defer otelCleanup()
+		}
+	}
+
 	c := exec.Command(geminiPath, geminiArgs...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 
-	// Inject HTMLGRAPH_PROJECT_DIR, HTMLGRAPH_AGENT, and GEMINI_SYSTEM_MD so hooks,
-	// skills, and the orchestrator prompt all resolve correctly regardless of CWD.
+	// Build the child env: start from os.Environ, inject HTMLGRAPH_PROJECT_DIR,
+	// HTMLGRAPH_AGENT, GEMINI_SYSTEM_MD, and OTel exporter vars when a collector
+	// was spawned.
 	// When WorktreeRoot is set, the process runs in the worktree but
 	// HTMLGRAPH_PROJECT_DIR points to the canonical project root (HtmlgraphRoot).
 	env := os.Environ()
@@ -258,6 +277,7 @@ func execGemini(opts geminiLaunchOpts) error {
 	}
 	env = append(env, "HTMLGRAPH_AGENT=gemini")
 	env = append(env, "GEMINI_SYSTEM_MD="+systemMdPath)
+	env = buildGeminiOtelEnv(env, otelPort, otelSessionID)
 	c.Env = env
 
 	if err := c.Run(); err != nil {

--- a/cmd/htmlgraph/gemini.go
+++ b/cmd/htmlgraph/gemini.go
@@ -244,8 +244,8 @@ func execGemini(opts geminiLaunchOpts) error {
 	// is not explicitly disabled. Non-fatal: falls back gracefully on failure.
 	var otelPort int
 	var otelSessionID string
+	var otelCleanup func()
 	if effectiveProjDir != "" && !isExplicitlyDisabled(os.Getenv("HTMLGRAPH_OTEL_ENABLED")) {
-		var otelCleanup func()
 		otelPort, otelSessionID, otelCleanup = spawnGeminiOtelCollector(effectiveProjDir)
 		if otelCleanup != nil {
 			defer otelCleanup()
@@ -282,6 +282,13 @@ func execGemini(opts geminiLaunchOpts) error {
 
 	if err := c.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
+			// os.Exit bypasses deferred cleanups. Run the collector
+			// cleanup synchronously here; the deferred call is now a
+			// no-op (cleanup is idempotent via sync.Once in the
+			// lifecycle package).
+			if otelCleanup != nil {
+				otelCleanup()
+			}
 			os.Exit(exitErr.ExitCode())
 		}
 		return err

--- a/cmd/htmlgraph/gemini.go
+++ b/cmd/htmlgraph/gemini.go
@@ -280,20 +280,7 @@ func execGemini(opts geminiLaunchOpts) error {
 	env = buildGeminiOtelEnv(env, otelPort, otelSessionID)
 	c.Env = env
 
-	if err := c.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			// os.Exit bypasses deferred cleanups. Run the collector
-			// cleanup synchronously here; the deferred call is now a
-			// no-op (cleanup is idempotent via sync.Once in the
-			// lifecycle package).
-			if otelCleanup != nil {
-				otelCleanup()
-			}
-			os.Exit(exitErr.ExitCode())
-		}
-		return err
-	}
-	return nil
+	return runHarnessWithCleanup(c, otelCleanup)
 }
 
 // launchGeminiDefault launches Gemini interactively with HtmlGraph env injection.

--- a/cmd/htmlgraph/gemini_launch.go
+++ b/cmd/htmlgraph/gemini_launch.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/shakestzd/htmlgraph/internal/otel/collector"
+)
+
+// spawnGeminiOtelCollector spawns a per-session OTel collector and returns the
+// port, session ID, and a cleanup function. On failure it writes a warning to
+// stderr and returns zero port / nil cleanup so the caller can proceed without
+// telemetry. Exits non-zero when HTMLGRAPH_OTEL_STRICT=1 and spawn fails.
+func spawnGeminiOtelCollector(projectDir string) (port int, sessionID string, cleanup func()) {
+	binPath, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "htmlgraph: warning: gemini per-session collector skipped: %v\n", err)
+		return 0, "", nil
+	}
+
+	sessionID = generateOtelSessionID()
+	lc := collector.NewProcessCollector(collector.ProcessCollectorOpts{
+		Stderr:     os.Stderr,
+		StrictMode: os.Getenv("HTMLGRAPH_OTEL_STRICT") == "1",
+	})
+
+	spawnedPort, spawnCleanup, spawnErr := lc.Spawn(binPath, sessionID, projectDir)
+	if spawnErr != nil {
+		fmt.Fprintf(os.Stderr, "htmlgraph: FATAL: gemini collector spawn failed: %v\n", spawnErr)
+		if os.Getenv("HTMLGRAPH_OTEL_STRICT") == "1" {
+			os.Exit(1)
+		}
+		return 0, "", nil
+	}
+
+	return spawnedPort, sessionID, spawnCleanup
+}
+
+// buildGeminiOtelEnv returns a copy of base with Gemini telemetry variables set
+// for the Gemini CLI child process. port and sessionID come from
+// spawnGeminiOtelCollector; when port is 0 the base env is returned unchanged.
+func buildGeminiOtelEnv(base []string, port int, sessionID string) []string {
+	if port == 0 {
+		return base
+	}
+	endpoint := fmt.Sprintf("http://127.0.0.1:%d", port)
+	env := make([]string, len(base))
+	copy(env, base)
+	env = appendOrReplaceEnv(env,
+		"GEMINI_TELEMETRY_ENABLED=true",
+		"GEMINI_TELEMETRY_USE_COLLECTOR=true",
+		"GEMINI_TELEMETRY_OTLP_ENDPOINT="+endpoint,
+		"GEMINI_TELEMETRY_OTLP_PROTOCOL=http",
+		"HTMLGRAPH_OTEL_SESSION="+sessionID,
+	)
+	return env
+}

--- a/cmd/htmlgraph/gemini_launch_test.go
+++ b/cmd/htmlgraph/gemini_launch_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildGeminiOtelEnv_PortZeroReturnsBase(t *testing.T) {
+	base := []string{"FOO=bar", "BAZ=qux"}
+	got := buildGeminiOtelEnv(base, 0, "sess-123")
+	if len(got) != len(base) {
+		t.Fatalf("expected len %d, got %d: %v", len(base), len(got), got)
+	}
+	for i, v := range base {
+		if got[i] != v {
+			t.Errorf("entry %d: expected %q, got %q", i, v, got[i])
+		}
+	}
+}
+
+func TestBuildGeminiOtelEnv_SetsAllFourVars(t *testing.T) {
+	got := buildGeminiOtelEnv(nil, 4317, "sess-abc")
+	want := map[string]string{
+		"GEMINI_TELEMETRY_ENABLED":       "true",
+		"GEMINI_TELEMETRY_USE_COLLECTOR": "true",
+		"GEMINI_TELEMETRY_OTLP_ENDPOINT": "http://127.0.0.1:4317",
+		"GEMINI_TELEMETRY_OTLP_PROTOCOL": "http",
+		"HTMLGRAPH_OTEL_SESSION":         "sess-abc",
+	}
+	for key, wantVal := range want {
+		found := false
+		for _, e := range got {
+			if strings.HasPrefix(e, key+"=") {
+				gotVal := strings.TrimPrefix(e, key+"=")
+				if gotVal != wantVal {
+					t.Errorf("%s: expected %q, got %q", key, wantVal, gotVal)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("env var %s not set; env=%v", key, got)
+		}
+	}
+}
+
+func TestBuildGeminiOtelEnv_OverridesExisting(t *testing.T) {
+	base := []string{
+		"GEMINI_TELEMETRY_ENABLED=false",
+		"OTHER=val",
+	}
+	got := buildGeminiOtelEnv(base, 9999, "sess-xyz")
+	for _, e := range got {
+		if e == "GEMINI_TELEMETRY_ENABLED=false" {
+			t.Errorf("old GEMINI_TELEMETRY_ENABLED=false was not overridden; env=%v", got)
+		}
+	}
+	found := false
+	for _, e := range got {
+		if e == "GEMINI_TELEMETRY_ENABLED=true" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("GEMINI_TELEMETRY_ENABLED=true not found after override; env=%v", got)
+	}
+}

--- a/cmd/htmlgraph/launch_run.go
+++ b/cmd/htmlgraph/launch_run.go
@@ -9,37 +9,30 @@ import (
 	"syscall"
 )
 
-// runHarnessWithCleanup runs the harness child process under a signal
-// handler that intercepts SIGINT and SIGTERM, ensuring cleanup runs
-// before the launcher exits. This is required because the standard
-// runtime path — `defer cleanup()` plus `os.Exit(child.ExitCode())` on
-// non-zero return — bypasses cleanup in three cases:
+// harnessResult describes how the parent launcher should terminate after
+// the harness child has reaped. Exactly one of the three fields is
+// meaningful per call:
 //
-//  1. Ctrl-C in the terminal: the signal hits the parent before c.Wait
-//     returns; without a handler, Go's default behavior aborts the
-//     process and skips defers.
-//  2. `kill -INT <launcher-pid>` from outside the terminal: same
-//     mechanism, no foreground-group propagation.
-//  3. Existing logic on `*exec.ExitError`: was already fixed in
-//     dc185548, but only covers the child's exit code path, not signal
-//     interruption of the parent.
-//
-// Pattern:
-//   - Install signal.Notify so the runtime no longer aborts on
-//     SIGINT/SIGTERM.
-//   - Start the child and Wait in a goroutine.
-//   - select on sigCh and waitCh: on signal, forward it to the child
-//     and wait for child exit; on normal exit, just proceed.
-//   - Always call cleanup (idempotent via sync.Once anyway).
-//   - On signal path, re-raise the same signal after reset so the
-//     parent's exit code reflects normal signal-exit semantics
-//     (128+signum on POSIX).
-//   - On non-zero child exit code, os.Exit with that code (cleanup
-//     already ran above).
-//
-// cleanup may be nil — if so, no cleanup is invoked but signal
-// handling still runs.
-func runHarnessWithCleanup(c *exec.Cmd, cleanup func()) error {
+//   - Err non-nil       → return this error to the caller (start failure or
+//     other unexpected error before/around the child run).
+//   - ReraiseSig non-0  → signal.Reset and re-raise this signal so the
+//     parent exits with 128+signum POSIX semantics. Used for both
+//     parent-received signals and child-was-signal-terminated cases.
+//   - ExitCode non-0    → os.Exit(ExitCode) to propagate the child's
+//     ordinary non-zero return code.
+//   - All zero          → child exited 0; return nil.
+type harnessResult struct {
+	Err         error
+	ReraiseSig  syscall.Signal
+	ExitCode    int
+}
+
+// runHarnessWithCleanupCore is the testable core of runHarnessWithCleanup.
+// It runs the child under SIGINT/SIGTERM signal handling, runs cleanup
+// once the child reaps, and returns a harnessResult describing how the
+// caller should terminate. Pure — no os.Exit, no syscall.Kill — so tests
+// can assert on the result without crashing the test binary.
+func runHarnessWithCleanupCore(c *exec.Cmd, cleanup func()) harnessResult {
 	var once sync.Once
 	callCleanup := func() {
 		once.Do(func() {
@@ -55,7 +48,7 @@ func runHarnessWithCleanup(c *exec.Cmd, cleanup func()) error {
 
 	if err := c.Start(); err != nil {
 		callCleanup()
-		return fmt.Errorf("start harness: %w", err)
+		return harnessResult{Err: fmt.Errorf("start harness: %w", err)}
 	}
 
 	waitCh := make(chan error, 1)
@@ -65,33 +58,72 @@ func runHarnessWithCleanup(c *exec.Cmd, cleanup func()) error {
 	select {
 	case sigReceived = <-sigCh:
 		// Forward the signal to the child so it exits gracefully.
-		// In a normal terminal Ctrl-C, the child already received
-		// SIGINT from the foreground group; the redundant Signal call
-		// is harmless. For external `kill -TERM` against the launcher
-		// only, this is the explicit forward.
 		if c.Process != nil {
 			_ = c.Process.Signal(sigReceived)
 		}
-		<-waitCh // child reaps
+		<-waitCh
 	case <-waitCh:
-		// Child exited on its own; nothing to forward.
+		// Child exited on its own.
 	}
 
 	callCleanup()
 
+	// Parent-received signal takes precedence: re-raise the same signal so
+	// the launcher's exit reflects the user's interrupt intent.
 	if sigReceived != nil {
-		// Reset to default handler and re-raise so the parent exits
-		// with conventional signal semantics (128+signum).
-		signal.Reset(syscall.SIGINT, syscall.SIGTERM)
 		if sysSig, ok := sigReceived.(syscall.Signal); ok {
-			_ = syscall.Kill(os.Getpid(), sysSig)
+			return harnessResult{ReraiseSig: sysSig}
 		}
-		// If the re-raise didn't terminate (rare), fall through.
-		return nil
 	}
 
-	if c.ProcessState != nil && !c.ProcessState.Success() {
-		os.Exit(c.ProcessState.ExitCode())
+	// No parent signal — inspect the child's wait status. If the child was
+	// killed by a signal (e.g. terminal SIGINT reached the child directly
+	// because we share the foreground process group), preserve POSIX
+	// signal-exit semantics by re-raising the same signal in the parent.
+	if c.ProcessState != nil {
+		if ws, ok := c.ProcessState.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+			return harnessResult{ReraiseSig: ws.Signal()}
+		}
+		if !c.ProcessState.Success() {
+			return harnessResult{ExitCode: c.ProcessState.ExitCode()}
+		}
+	}
+	return harnessResult{}
+}
+
+// runHarnessWithCleanup runs the harness child process under a signal
+// handler that intercepts SIGINT and SIGTERM, ensuring cleanup runs
+// before the launcher exits. It is the production entry point — for the
+// testable core that returns a result struct without calling os.Exit /
+// syscall.Kill, see runHarnessWithCleanupCore.
+//
+// Behavior:
+//   - On parent-received SIGINT/SIGTERM: forward to the child, run
+//     cleanup, then re-raise the signal in the parent for 128+signum
+//     POSIX exit semantics.
+//   - On child signal-termination (e.g. Ctrl-C reached the child via
+//     the terminal foreground group): re-raise the same signal in the
+//     parent so the launcher exits with the conventional 128+signum
+//     code instead of -1 / 255.
+//   - On child non-zero exit: os.Exit with the child's exit code.
+//   - On child exit 0: return nil.
+//
+// cleanup may be nil — if so, no cleanup is invoked but signal handling
+// still runs.
+func runHarnessWithCleanup(c *exec.Cmd, cleanup func()) error {
+	res := runHarnessWithCleanupCore(c, cleanup)
+	if res.Err != nil {
+		return res.Err
+	}
+	if res.ReraiseSig != 0 {
+		signal.Reset(syscall.SIGINT, syscall.SIGTERM)
+		_ = syscall.Kill(os.Getpid(), res.ReraiseSig)
+		// If the re-raise didn't terminate (rare; some signal masks),
+		// fall through with nil so the launcher returns cleanly.
+		return nil
+	}
+	if res.ExitCode != 0 {
+		os.Exit(res.ExitCode)
 	}
 	return nil
 }

--- a/cmd/htmlgraph/launch_run.go
+++ b/cmd/htmlgraph/launch_run.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+// runHarnessWithCleanup runs the harness child process under a signal
+// handler that intercepts SIGINT and SIGTERM, ensuring cleanup runs
+// before the launcher exits. This is required because the standard
+// runtime path — `defer cleanup()` plus `os.Exit(child.ExitCode())` on
+// non-zero return — bypasses cleanup in three cases:
+//
+//  1. Ctrl-C in the terminal: the signal hits the parent before c.Wait
+//     returns; without a handler, Go's default behavior aborts the
+//     process and skips defers.
+//  2. `kill -INT <launcher-pid>` from outside the terminal: same
+//     mechanism, no foreground-group propagation.
+//  3. Existing logic on `*exec.ExitError`: was already fixed in
+//     dc185548, but only covers the child's exit code path, not signal
+//     interruption of the parent.
+//
+// Pattern:
+//   - Install signal.Notify so the runtime no longer aborts on
+//     SIGINT/SIGTERM.
+//   - Start the child and Wait in a goroutine.
+//   - select on sigCh and waitCh: on signal, forward it to the child
+//     and wait for child exit; on normal exit, just proceed.
+//   - Always call cleanup (idempotent via sync.Once anyway).
+//   - On signal path, re-raise the same signal after reset so the
+//     parent's exit code reflects normal signal-exit semantics
+//     (128+signum on POSIX).
+//   - On non-zero child exit code, os.Exit with that code (cleanup
+//     already ran above).
+//
+// cleanup may be nil — if so, no cleanup is invoked but signal
+// handling still runs.
+func runHarnessWithCleanup(c *exec.Cmd, cleanup func()) error {
+	var once sync.Once
+	callCleanup := func() {
+		once.Do(func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		})
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	if err := c.Start(); err != nil {
+		callCleanup()
+		return fmt.Errorf("start harness: %w", err)
+	}
+
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- c.Wait() }()
+
+	var sigReceived os.Signal
+	select {
+	case sigReceived = <-sigCh:
+		// Forward the signal to the child so it exits gracefully.
+		// In a normal terminal Ctrl-C, the child already received
+		// SIGINT from the foreground group; the redundant Signal call
+		// is harmless. For external `kill -TERM` against the launcher
+		// only, this is the explicit forward.
+		if c.Process != nil {
+			_ = c.Process.Signal(sigReceived)
+		}
+		<-waitCh // child reaps
+	case <-waitCh:
+		// Child exited on its own; nothing to forward.
+	}
+
+	callCleanup()
+
+	if sigReceived != nil {
+		// Reset to default handler and re-raise so the parent exits
+		// with conventional signal semantics (128+signum).
+		signal.Reset(syscall.SIGINT, syscall.SIGTERM)
+		if sysSig, ok := sigReceived.(syscall.Signal); ok {
+			_ = syscall.Kill(os.Getpid(), sysSig)
+		}
+		// If the re-raise didn't terminate (rare), fall through.
+		return nil
+	}
+
+	if c.ProcessState != nil && !c.ProcessState.Success() {
+		os.Exit(c.ProcessState.ExitCode())
+	}
+	return nil
+}

--- a/cmd/htmlgraph/launch_run_test.go
+++ b/cmd/htmlgraph/launch_run_test.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"os/exec"
+	"syscall"
 	"testing"
 )
 
 // TestRunHarnessWithCleanup_NormalExit asserts that cleanup runs and the
-// function returns nil when the child exits successfully.
+// helper returns nil when the child exits successfully.
 func TestRunHarnessWithCleanup_NormalExit(t *testing.T) {
 	cleanupCalled := false
 	cleanup := func() { cleanupCalled = true }
@@ -42,5 +43,66 @@ func TestRunHarnessWithCleanup_StartFailure(t *testing.T) {
 	}
 	if !cleanupCalled {
 		t.Error("cleanup was not invoked when c.Start failed")
+	}
+}
+
+// TestRunHarnessWithCleanupCore_NormalExit verifies the testable core
+// returns a zero-result for a clean child exit.
+func TestRunHarnessWithCleanupCore_NormalExit(t *testing.T) {
+	c := exec.Command("/bin/sh", "-c", "exit 0")
+	res := runHarnessWithCleanupCore(c, nil)
+	if res.Err != nil {
+		t.Errorf("Err = %v, want nil", res.Err)
+	}
+	if res.ReraiseSig != 0 {
+		t.Errorf("ReraiseSig = %v, want 0", res.ReraiseSig)
+	}
+	if res.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", res.ExitCode)
+	}
+}
+
+// TestRunHarnessWithCleanupCore_NonZeroExit verifies the core returns the
+// child's non-zero exit code for ordinary error returns.
+func TestRunHarnessWithCleanupCore_NonZeroExit(t *testing.T) {
+	c := exec.Command("/bin/sh", "-c", "exit 7")
+	res := runHarnessWithCleanupCore(c, nil)
+	if res.Err != nil {
+		t.Errorf("Err = %v, want nil", res.Err)
+	}
+	if res.ReraiseSig != 0 {
+		t.Errorf("ReraiseSig = %v, want 0", res.ReraiseSig)
+	}
+	if res.ExitCode != 7 {
+		t.Errorf("ExitCode = %d, want 7", res.ExitCode)
+	}
+}
+
+// TestRunHarnessWithCleanupCore_ChildSignaled is the regression test
+// requested in roborev job 102. When the child is killed by a signal
+// (SIGTERM here, simulating "terminal Ctrl-C reached the child first"),
+// the core must surface the killing signal via ReraiseSig instead of
+// reporting ExitCode=-1, so the launcher can re-raise for 128+signum
+// POSIX semantics rather than exiting 255.
+func TestRunHarnessWithCleanupCore_ChildSignaled(t *testing.T) {
+	cleanupCalled := false
+	cleanup := func() { cleanupCalled = true }
+
+	// Self-terminate the shell with SIGTERM. The child reaps with
+	// WaitStatus.Signaled()=true, Signal()=SIGTERM.
+	c := exec.Command("/bin/sh", "-c", "kill -TERM $$")
+	res := runHarnessWithCleanupCore(c, cleanup)
+
+	if res.Err != nil {
+		t.Errorf("Err = %v, want nil", res.Err)
+	}
+	if res.ReraiseSig != syscall.SIGTERM {
+		t.Errorf("ReraiseSig = %v, want SIGTERM (the killing signal)", res.ReraiseSig)
+	}
+	if res.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 (signal path takes precedence)", res.ExitCode)
+	}
+	if !cleanupCalled {
+		t.Error("cleanup was not invoked when child was signal-killed")
 	}
 }

--- a/cmd/htmlgraph/launch_run_test.go
+++ b/cmd/htmlgraph/launch_run_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// TestRunHarnessWithCleanup_NormalExit asserts that cleanup runs and the
+// function returns nil when the child exits successfully.
+func TestRunHarnessWithCleanup_NormalExit(t *testing.T) {
+	cleanupCalled := false
+	cleanup := func() { cleanupCalled = true }
+
+	c := exec.Command("/bin/sh", "-c", "exit 0")
+	if err := runHarnessWithCleanup(c, cleanup); err != nil {
+		t.Errorf("expected nil error on success, got: %v", err)
+	}
+	if !cleanupCalled {
+		t.Error("cleanup was not invoked on normal exit")
+	}
+}
+
+// TestRunHarnessWithCleanup_NilCleanup asserts that a nil cleanup is
+// tolerated — the helper should still run the child and report success.
+func TestRunHarnessWithCleanup_NilCleanup(t *testing.T) {
+	c := exec.Command("/bin/sh", "-c", "exit 0")
+	if err := runHarnessWithCleanup(c, nil); err != nil {
+		t.Errorf("expected nil error on success with nil cleanup, got: %v", err)
+	}
+}
+
+// TestRunHarnessWithCleanup_StartFailure asserts that cleanup runs and an
+// error is returned when the child fails to start (binary not found).
+func TestRunHarnessWithCleanup_StartFailure(t *testing.T) {
+	cleanupCalled := false
+	cleanup := func() { cleanupCalled = true }
+
+	c := exec.Command("/this/binary/does/not/exist/htmlgraph-test")
+	err := runHarnessWithCleanup(c, cleanup)
+	if err == nil {
+		t.Error("expected error on start failure, got nil")
+	}
+	if !cleanupCalled {
+		t.Error("cleanup was not invoked when c.Start failed")
+	}
+}

--- a/cmd/htmlgraph/multiharness_test.go
+++ b/cmd/htmlgraph/multiharness_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	"github.com/shakestzd/htmlgraph/internal/otel/sink/ndjson"
+)
+
+// mhKV builds a string KeyValue proto for OTLP payloads.
+func mhKV(k, v string) *commonpb.KeyValue {
+	return &commonpb.KeyValue{
+		Key:   k,
+		Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: v}},
+	}
+}
+
+// mhResource builds a Resource proto with the given attributes.
+func mhResource(attrs ...*commonpb.KeyValue) *resourcepb.Resource {
+	return &resourcepb.Resource{Attributes: attrs}
+}
+
+// postProto serialises msg and POSTs it to url with application/x-protobuf.
+func postProto(t *testing.T, url string, msg proto.Message) *http.Response {
+	t.Helper()
+	body, err := proto.Marshal(msg)
+	if err != nil {
+		t.Fatalf("proto.Marshal: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	resp.Body.Close()
+	return resp
+}
+
+// TestMultiHarnessIngestion verifies that the per-session collector mux
+// correctly routes payloads from all three harnesses (Codex, Gemini, Claude)
+// through the adapter registry and into the ndjson sink.
+func TestMultiHarnessIngestion(t *testing.T) {
+	// --- Set up the project dir and ndjson sink ---
+	projectDir := t.TempDir()
+	sessionID := "mh-test-session"
+	sessDir := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID)
+	if err := os.MkdirAll(sessDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll session dir: %v", err)
+	}
+
+	snk, err := ndjson.New(projectDir, sessionID)
+	if err != nil {
+		t.Fatalf("ndjson.New: %v", err)
+	}
+
+	lastActivity := &atomic.Int64{}
+	lastActivity.Store(time.Now().UnixMilli())
+
+	mux := buildCollectorMux(snk, lastActivity)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	now := time.Now().UnixNano()
+
+	// --- POST 1: Codex logs payload ---
+	codexLogs := &logspb.LogsData{
+		ResourceLogs: []*logspb.ResourceLogs{{
+			Resource: mhResource(
+				mhKV("service.name", "codex-cli"),
+				mhKV("service.version", "0.1.0"),
+			),
+			ScopeLogs: []*logspb.ScopeLogs{{
+				Scope: &commonpb.InstrumentationScope{Name: "codex"},
+				LogRecords: []*logspb.LogRecord{{
+					TimeUnixNano: uint64(now),
+					Attributes: []*commonpb.KeyValue{
+						mhKV("event.name", "codex.user_prompt"),
+						mhKV("conversation.id", "codex-test-123"),
+					},
+				}},
+			}},
+		}},
+	}
+	resp := postProto(t, srv.URL+"/v1/logs", codexLogs)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Codex /v1/logs: status=%d, want 200", resp.StatusCode)
+	}
+
+	// --- POST 2: Gemini metrics payload ---
+	geminiMetrics := &metricspb.MetricsData{
+		ResourceMetrics: []*metricspb.ResourceMetrics{{
+			Resource: mhResource(
+				mhKV("service.name", "gemini-cli"),
+				mhKV("service.version", "0.1.0"),
+			),
+			ScopeMetrics: []*metricspb.ScopeMetrics{{
+				Scope: &commonpb.InstrumentationScope{Name: "gemini_cli"},
+				Metrics: []*metricspb.Metric{{
+					Name: "gemini_cli.session.count",
+					Data: &metricspb.Metric_Sum{
+						Sum: &metricspb.Sum{
+							DataPoints: []*metricspb.NumberDataPoint{{
+								TimeUnixNano: uint64(now),
+								Value:        &metricspb.NumberDataPoint_AsInt{AsInt: 1},
+								Attributes: []*commonpb.KeyValue{
+									mhKV("session.id", "gemini-test-456"),
+								},
+							}},
+						},
+					},
+				}},
+			}},
+		}},
+	}
+	resp = postProto(t, srv.URL+"/v1/metrics", geminiMetrics)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Gemini /v1/metrics: status=%d, want 200", resp.StatusCode)
+	}
+
+	// --- POST 3: Claude traces payload ---
+	claudeTraces := &tracepb.TracesData{
+		ResourceSpans: []*tracepb.ResourceSpans{{
+			Resource: mhResource(
+				mhKV("service.name", "claude-code"),
+				mhKV("service.version", "2.1.42"),
+			),
+			ScopeSpans: []*tracepb.ScopeSpans{{
+				Scope: &commonpb.InstrumentationScope{Name: "com.anthropic.claude_code"},
+				Spans: []*tracepb.Span{{
+					TraceId:           bytes.Repeat([]byte{0xab}, 16),
+					SpanId:            bytes.Repeat([]byte{0xcd}, 8),
+					Name:              "claude_code.interaction",
+					StartTimeUnixNano: uint64(now),
+					EndTimeUnixNano:   uint64(now + 1_000_000_000),
+					Attributes: []*commonpb.KeyValue{
+						mhKV("session.id", "claude-test-789"),
+					},
+				}},
+			}},
+		}},
+	}
+	resp = postProto(t, srv.URL+"/v1/traces", claudeTraces)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Claude /v1/traces: status=%d, want 200", resp.StatusCode)
+	}
+
+	// --- Read the ndjson output and assert ---
+	eventsPath := filepath.Join(sessDir, "events.ndjson")
+	f, err := os.Open(eventsPath)
+	if err != nil {
+		t.Fatalf("open events.ndjson: %v", err)
+	}
+	defer f.Close()
+
+	type signalRecord struct {
+		Harness   string `json:"harness"`
+		SessionID string `json:"session_id"`
+		Kind      string `json:"kind"`
+	}
+
+	var records []signalRecord
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var rec signalRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Errorf("unmarshal ndjson line: %v — raw: %q", err, line)
+			continue
+		}
+		records = append(records, rec)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanning events.ndjson: %v", err)
+	}
+
+	if len(records) == 0 {
+		t.Fatal("events.ndjson is empty — no signals were persisted")
+	}
+
+	type want struct {
+		harness   string
+		sessionID string
+	}
+	assertions := []want{
+		{"codex", "codex-test-123"},
+		{"gemini_cli", "gemini-test-456"},
+		{"claude_code", "claude-test-789"},
+	}
+
+	for _, a := range assertions {
+		found := false
+		for _, rec := range records {
+			if rec.Harness == a.harness && rec.SessionID == a.sessionID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("no signal with harness=%q session_id=%q in %d records",
+				a.harness, a.sessionID, len(records))
+		}
+	}
+}

--- a/cmd/htmlgraph/otel_collect.go
+++ b/cmd/htmlgraph/otel_collect.go
@@ -95,6 +95,8 @@ func runOtelCollect(sessionID, projectDir, listenAddr string) error {
 func buildCollectorMux(snk *ndjson.Sink, lastActivity *atomic.Int64) *http.ServeMux {
 	reg := adapter.NewRegistry()
 	reg.Register(adapter.NewClaudeAdapter())
+	reg.Register(adapter.NewCodexAdapter())
+	reg.Register(adapter.NewGeminiAdapter())
 
 	handler := &collectorHandler{
 		registry:     reg,

--- a/cmd/htmlgraph/serve.go
+++ b/cmd/htmlgraph/serve.go
@@ -105,6 +105,7 @@ func buildSingleProjectMux(database *sql.DB, htmlgraphDir string) *http.ServeMux
 	mux.Handle("/api/otel/cost", otelCostHandler(database))
 	mux.Handle("/api/otel/spans", otelSpansHandler(database))
 	mux.Handle("/api/otel/logs", otelLogsHandler(database))
+	mux.Handle("/api/otel/status", collectorStatusHandler(projectDir))
 
 	// CRISPI plan routes — list route must precede the per-plan catch-all.
 	mux.Handle("/api/plans", plansListHandler(htmlgraphDir, database))

--- a/cmd/htmlgraph/status.go
+++ b/cmd/htmlgraph/status.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 
@@ -97,9 +98,50 @@ func runStatus(_ *cobra.Command, _ []string) error {
 
 	fmt.Printf("\nTotal: %d work items\n", len(nodes))
 
+	// Collector health — scan .htmlgraph/sessions/ for recent PID files.
+	printCollectorHealth(filepath.Dir(dir))
+
 	if latest, newer, _ := versionpkg.CheckForUpdate(version); newer {
 		fmt.Printf("\nUpdate available: v%s (current: v%s)\n", latest, version)
 	}
 
 	return nil
+}
+
+// printCollectorHealth lists per-session collector status for any session
+// directory that contains a .collector-pid file. Best-effort: silently skips
+// sessions where the PID file is missing or unreadable.
+func printCollectorHealth(projectDir string) {
+	sessionsDir := filepath.Join(projectDir, ".htmlgraph", "sessions")
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return // no sessions dir yet — nothing to print
+	}
+
+	printed := false
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		sessDir := filepath.Join(sessionsDir, e.Name())
+		pidPath := filepath.Join(sessDir, ".collector-pid")
+		if _, statErr := os.Stat(pidPath); statErr != nil {
+			continue // no PID file — collector was never spawned for this session
+		}
+		cs, err := ReadCollectorStatus(sessDir)
+		if err != nil {
+			continue
+		}
+		if !printed {
+			fmt.Println("\nCollector health:")
+			printed = true
+		}
+		if cs.Alive {
+			fmt.Printf("  %-36s  pid=%-7d port=%-5d alive=true  uptime=%ds\n",
+				e.Name(), cs.PID, cs.Port, cs.UptimeSec)
+		} else {
+			fmt.Printf("  %-36s  pid=%-7d port=%-5d alive=false last_seen=%d\n",
+				e.Name(), cs.PID, cs.Port, cs.LastActivityMs)
+		}
+	}
 }

--- a/docs/adr-001-harness-agnostic-collector.md
+++ b/docs/adr-001-harness-agnostic-collector.md
@@ -1,0 +1,311 @@
+# ADR — Harness-agnostic per-session OTel collector
+
+| Field | Value |
+|-------|-------|
+| Status | Accepted |
+| Date | 2026-04-29 |
+| Track | trk-cb36e595 (Multi-Project Hardening) |
+| Implementation | feat-ac7532be (split into 11 child features) |
+| Motivating incident | bug-28a9d7a7 |
+| Prior design | plan-1cd284e0 (per-session OTel collector with NDJSON ingest) |
+
+This document captures the cross-cutting decisions made while hardening the
+per-session OTel collector and extending it to Codex CLI and Gemini CLI. It is
+the discoverable narrative for new contributors who want to know *why* the
+code looks the way it does — the *what* lives in the commit messages, the
+*how* lives in `internal/otel/collector/` and the launchers.
+
+## Context
+
+`plan-1cd284e0` introduced a per-session OTel collector that the `htmlgraph
+claude` launcher spawns as a child of the user's interactive session. The
+collector listens on a dynamic 127.0.0.1 port, accepts OTLP/HTTP from the
+harness, and writes NDJSON to `.htmlgraph/sessions/<sid>/events.ndjson`.
+SQLite is treated as a derived index — the NDJSON file is canonical.
+
+`bug-28a9d7a7` showed two failure modes the v1 design did not handle:
+
+1. The collector handshake at startup could time out and the launcher
+   silently continued in degraded mode. The operator had no signal — the
+   first sign of trouble was an empty `events.ndjson` after the session.
+2. The collector could die mid-session (OOM, signal, internal panic). The
+   launcher had no detection or respawn path.
+
+Concurrent with this hardening, Codex CLI and Gemini CLI both shipped
+first-class OTel emission (Codex via `~/.codex/config.toml [otel]` and
+service.name=`codex-cli`; Gemini via `GEMINI_TELEMETRY_*` env vars and
+service.name=`gemini-cli`). The collector code was Claude-shaped, and
+extending it to two more harnesses by copy-paste would have produced three
+divergent spawn paths within weeks.
+
+The work in `feat-ac7532be` therefore had two intertwined goals: harden the
+spawn path against silent failure, and extract a harness-agnostic interface
+so Codex and Gemini can ride the same lifecycle.
+
+## ADR-001: `CollectorLifecycle` as a Go interface
+
+### Decision
+
+The spawn / retry / watchdog / cleanup machinery lives in a single new
+package, `internal/otel/collector`, behind a single Go interface:
+
+```go
+type Lifecycle interface {
+    Spawn(binPath, sessionID, projectDir string) (port int, cleanup func(), err error)
+}
+```
+
+There is one concrete implementation, `ProcessCollector`, configured via
+`ProcessCollectorOpts` (stderr writer, strict mode, optional spawn-fn for
+tests, watchdog-interval env var name). All harness launchers — Claude,
+Codex, Gemini — call `collector.NewProcessCollector(...).Spawn(...)`.
+
+### Alternatives considered
+
+**(a) Per-harness duplicated spawn code.** Each launcher imports
+`os/exec` directly and re-implements retry, handshake parsing, watchdog,
+and cleanup. Rejected because: three near-identical 200-line files diverge
+within a release or two; the next bug (the equivalent of bug-28a9d7a7 for
+Codex or Gemini) would have to be fixed in three places; testing surface
+triples.
+
+**(b) Function-based API (`collector.Spawn(opts)` package function with no
+interface).** Simpler than an interface for a single implementation. Rejected
+because the test seam matters: making `spawnFn` injectable through a struct
+field is dramatically cleaner than mutating a package-level var, and the
+struct can grow more knobs without breaking the call signature. The
+interface adds zero runtime cost and one line of declaration.
+
+**(c) Plugin-based (Go `plugin` package, dlopen).** Rejected on sight —
+adds dynamic linking complexity, breaks cross-compilation, and solves a
+problem we don't have (third-party lifecycles).
+
+**(d) Subprocess-as-service (one always-on collector daemon, harnesses
+reattach via session ID).** This is genuinely tempting and we may revisit
+it. Rejected for v1 because: per-session collectors give us crash
+isolation by construction (one bad session can't poison telemetry for
+others); a daemon needs its own lifecycle/upgrade story; and the existing
+NDJSON-canonical model assumes one writer per session file.
+
+### Consequences
+
+- `cmd/htmlgraph/claude_otel_collect_spawn.go` is now a thin shim
+  (~110 LOC) that calls `internal/otel/collector`. Future Claude-specific
+  hooks can live in the shim without contaminating the lifecycle.
+- `cmd/htmlgraph/codex_launch.go` and `cmd/htmlgraph/gemini_launch.go`
+  each contribute ~60-80 LOC of harness-specific env-injection logic on
+  top of the shared lifecycle.
+- The shared `appendOrReplaceEnv` helper (in `codex_launch.go`,
+  package-visible to `gemini_launch.go`) keeps env-mutation logic in one
+  place across launchers.
+- Tests at the lifecycle boundary (`internal/otel/collector/lifecycle_test.go`)
+  inject a fake `SpawnFn` and exercise retry/watchdog without real
+  subprocesses. Per-launcher tests (`codex_launch_test.go`,
+  `gemini_launch_test.go`) only verify env-string construction —
+  cheap and deterministic.
+
+### Forward considerations
+
+- If a fourth harness arrives (Cursor, Aider, etc.) the cost is one
+  `<harness>_launch.go` file plus one adapter in `internal/otel/adapter/`,
+  not a redesign.
+- If we eventually want per-harness retry policy or backoff schedules, the
+  interface can grow to `Spawn(ctx, opts) (Result, error)` without breaking
+  current callers (since there is exactly one external caller per harness).
+- The watchdog's "respawn but lose the gap" semantics live in
+  `ProcessCollector`. If a future harness needs zero-gap respawn (port
+  forwarding via a localhost redirect), it would belong as a second
+  implementation of `Lifecycle`, not a flag on the existing one.
+
+## ADR-002: Launcher-based spawn vs hook-based spawn
+
+### Decision
+
+Each harness gets a wrapper command (`htmlgraph claude`, `htmlgraph codex`,
+`htmlgraph gemini`) that spawns the collector *before* `exec`ing the
+harness child, and injects the collector's port into the child's
+environment. The hook-based alternative (have a `SessionStart` hook spawn
+the collector and write the port to a file the harness later reads) was
+considered and rejected for the spawn responsibility, though the existing
+`SessionStart` hook continues to handle attribution and other side concerns.
+
+### Alternatives considered
+
+**(a) Launcher-based (chosen).** `htmlgraph codex` resolves the user's
+`codex` binary, spawns the collector, builds the child env with the OTel
+exporter pointed at the collector port, then `exec`s codex. Pre-fork env
+injection is deterministic — by the time the harness reads its OTel
+config, the port is real and listening.
+
+**(b) Hook-based.** A `SessionStart` hook (`htmlgraph hook session-start`)
+detects the harness, spawns the collector, and writes the port to
+`.htmlgraph/sessions/<sid>/.collector-port`. The harness reads its OTel
+config from the same file (or a wrapper script polls the file and exports
+the env var before launching the harness binary). Considered because it
+avoids requiring users to type `htmlgraph codex` instead of `codex`. But:
+
+- Hooks cannot mutate child env post-fork in any of the three harnesses we
+  support today. Whatever the hook writes has to be picked up by *some*
+  pre-fork mechanism — which is exactly the wrapper command we already
+  need.
+- The hook path adds a write/poll race: the hook writes
+  `.collector-port`, the harness needs to know the file is final before
+  reading. Filesystem syncs across container boundaries (devcontainer +
+  host mount) can produce stale reads.
+- Diagnosing "my OTel didn't work" requires inspecting hook execution
+  *and* the port file, vs. one `htmlgraph codex --debug` invocation.
+
+**(c) Daemon mode.** A `htmlgraph daemon` runs in the background; the
+harness's OTel config is permanently pointed at `127.0.0.1:<fixed port>`;
+the daemon multiplexes multiple sessions onto one collector. Rejected for
+the same reasons as ADR-001(d): per-session isolation, simpler upgrade
+story.
+
+### Consequences
+
+- The user-visible command surface gains three commands:
+  `htmlgraph claude`, `htmlgraph codex`, `htmlgraph gemini`. Each is a
+  thin wrapper — invocations not using these wrappers continue to work
+  but get no telemetry capture.
+- For Codex and Gemini, the `htmlgraph plugin install` step (or
+  equivalent harness-specific install) must document the wrapper
+  invocation. The daemon-style "set it and forget it" UX is not
+  available.
+- The wrappers compose cleanly with non-OTel concerns (work-item
+  attribution, worktree creation) that already live in `htmlgraph claude`.
+
+### What remains for hooks
+
+The launcher owns OTel collector spawning. The existing `SessionStart`
+hook continues to own work-item attribution, session-table writes, and
+project-dir resolution. There is no overlap or duplication; each handles
+its own dimension.
+
+## Canonical attribute mapping
+
+All three harnesses now produce a `UnifiedSignal` with a small canonical
+attribute set, populated by their respective adapter
+(`internal/otel/adapter/{claude,codex,gemini}.go`). This is the same table
+that lives in the doc comment on `internal/otel/signal.go:UnifiedSignal`,
+reproduced here for narrative accuracy:
+
+| Harness | `service.name` | Session attribute (signal-level) | Resource fallback | PromptID source |
+|---------|----------------|-----------------------------------|-------------------|-----------------|
+| Claude  | `claude-code`  | `session.id`                      | `session.id`      | `prompt.id` |
+| Codex   | `codex-cli`    | `conversation.id`                 | `conversation.id` | `gen_ai.prompt_id` (when present; else empty) |
+| Gemini  | `gemini-cli`   | `session.id`                      | `session.id`      | `gen_ai.prompt_id` |
+
+### Notes on resource fallback
+
+For metrics with cardinality control, the OTel SDK can omit per-data-point
+session attributes; the adapter falls back to the resource-level
+attribute. This mirrors the pattern established in the original Claude
+adapter (`internal/otel/adapter/claude.go:baseSignal`) — Codex and Gemini
+adapters reuse the same shape.
+
+### Notes on PromptID
+
+The Codex adapter does *not* synthesize PromptID from
+`conversation.id + sequence` even though earlier design notes mentioned
+this as a possibility. Synthesis would require sequence-number tracking
+across batches, which adds state to a stateless adapter and produces
+non-stable IDs (a re-ingestion of the same NDJSON file would produce
+different sequences). Callers that need prompt-level correlation for
+Codex must group by `(SessionID, Timestamp window)`.
+
+## Resilience model
+
+The hardened spawn path now provides three layers of protection, gated by
+opt-in env vars where the new behavior is more aggressive than the
+existing default:
+
+1. **Retry with backoff** (`retrySpawnCollector` in
+   `internal/otel/collector/lifecycle.go`). Always on. Three attempts at
+   100ms / 300ms / 700ms backoff. Worst-case wall time ~10s including
+   handshake timeouts. Targets transient port-bind contention and
+   process-scheduling jitter.
+
+2. **Fail-loud on permanent failure** (`HTMLGRAPH_OTEL_STRICT=1`). Off by
+   default. When set, all-attempts-failed produces a non-zero exit
+   instead of degraded silent mode. Operators running CI or production
+   sessions where missing telemetry is itself a failure should set this.
+
+3. **Watchdog respawn**
+   (`startCollectorWatchdog` / `HTMLGRAPH_OTEL_WATCHDOG_INTERVAL`). On
+   by default, 15s polling interval. Detects mid-session collector death
+   and respawns. The new collector listens on a fresh port; OTel traffic
+   between the death and the respawn is lost (the harness keeps writing
+   to the old port). This is an intentional v1 simplification — see ADR
+   forward considerations below.
+
+The status surface (`/api/otel/status` and the `Collector health:` block
+in `htmlgraph status`) lets operators verify all three are working
+without grepping logs. Path traversal in the `?session=` query parameter
+is rejected via `isSafeSessionID` before any filesystem access.
+
+## Future work
+
+- **Zero-gap respawn.** The current watchdog respawn loses telemetry
+  between the time the old collector dies and the time the harness's
+  next OTel request fails. A localhost redirect shim on the original
+  port (a small TCP proxy that forwards to the live collector) would
+  close the gap. Cost is one more goroutine and a port-rebind handshake
+  between watchdog and shim. Worth doing if real-world incidents show
+  the gap matters.
+- **Daemon-mode option.** A `htmlgraph daemon --multi-session` mode for
+  power users who run many parallel sessions and want a single
+  long-lived collector. Would require extending `Lifecycle` with a
+  "join existing" path and a session-id-to-port multiplex table.
+  Probably belongs in a separate plan.
+- **Adapter for Cursor / Aider / others.** Bias toward shipping these as
+  separate adapters rather than special-casing the existing ones.
+- **Process-identity check on `.collector-pid`.** The current liveness
+  check uses `kill(pid, 0)`, which is racy under PID reuse. For most
+  desktop usage this is irrelevant, but in long-running CI workers a
+  start-time check (read `/proc/<pid>/stat` field 22, compare to the
+  remembered start-time) would be more robust. The fix is local; it
+  doesn't change any API.
+- **TEST-1 escalation path.** The plan originally included a real-
+  subprocess respawn integration test gated on `testing.Short()`. That
+  test was deferred during this work — see `feat-e195d658` for the
+  rationale. If a future incident traces back to a wiring bug between
+  the watchdog and the side-effect helpers (`writeCollectorPID`,
+  `registerCollectorCleanup`), revive the test.
+
+## Cross-references
+
+| Artifact | Where |
+|----------|-------|
+| Lifecycle implementation | `internal/otel/collector/lifecycle.go` |
+| Lifecycle tests | `internal/otel/collector/lifecycle_test.go` |
+| Claude shim | `cmd/htmlgraph/claude_otel_collect_spawn.go` |
+| Codex launcher | `cmd/htmlgraph/codex_launch.go`, `cmd/htmlgraph/codex.go:execCodex` |
+| Gemini launcher | `cmd/htmlgraph/gemini_launch.go`, `cmd/htmlgraph/gemini.go:execGemini` |
+| Adapters | `internal/otel/adapter/{claude,codex,gemini}.go` |
+| Adapter conformance | `internal/otel/adapter/conformance_test.go` |
+| Multi-harness HTTP test | `cmd/htmlgraph/multiharness_test.go` |
+| Status surface | `cmd/htmlgraph/api_collector_status.go`, `cmd/htmlgraph/status.go:printCollectorHealth` |
+| Canonical attribute table | `internal/otel/signal.go` (`UnifiedSignal` doc comment) |
+
+## Implementation history
+
+The implementation was split into 11 child features under `feat-ac7532be`,
+dispatched in waves with explicit `blocked_by` edges:
+
+| Wave | Feature | Slice | Commit |
+|------|---------|-------|--------|
+| 1 | feat-75426991 | SCHEMA-1 (canonical attrs + Codex/Gemini adapters) | `ad7b335a` |
+| 1 | feat-dcf3d618 | RESILIENCE-1 (fail-loud spawn) | `e6815d7e` |
+| 1 | feat-1c3ebad9 | STATUS-1 (collector health surface) | `4f09f824` |
+| — | feat-ac7532be | Roborev fixes (HIGH+3MED on Wave 1) | `54b34896` |
+| 2 | feat-6286f19f | RESILIENCE-2 (retry with backoff) | `49d6d12a` |
+| 3 | feat-7b195a56 | RESILIENCE-3 (watchdog respawn) | `08878da2` |
+| 4a | feat-35519ac2 | REFACTOR-1 (`CollectorLifecycle`) | `1cd3a153`, `65641657` |
+| 4b | feat-e195d658 | TEST-1 (closed without dispatch — covered) | — |
+| 5a | feat-9104fb56 | CODEX-1 (Codex launcher) | `a7d5e91d` |
+| 5b | feat-7b094d00 | GEMINI-1 (Gemini launcher) | `c5a174a7` |
+| 6 | feat-c6b3d956 | TEST-2 (multi-harness ingest) | `600918ac` |
+| 7 | feat-bc3c0067 | DOC-1 (this document) | (pending commit) |
+
+Quality gates (`go build ./... && go vet ./... && go test ./...`) ran
+green on every commit, enforced by the project pre-commit hook.

--- a/docs/adr-001-harness-agnostic-collector.md
+++ b/docs/adr-001-harness-agnostic-collector.md
@@ -308,6 +308,29 @@ PID files stale until idle timeout.
   the watchdog and the side-effect helpers (`writeCollectorPID`,
   `registerCollectorCleanup`), revive the test.
 
+## Open questions (from feat-ac7532be, deferred)
+
+These were flagged in the original feature spec and remain unresolved at
+merge time. None blocked implementation, but each warrants a follow-up.
+
+- **Gemini env-var propagation reliability.** The current
+  `htmlgraph gemini` launcher injects `GEMINI_TELEMETRY_OTLP_ENDPOINT`
+  pre-fork, which is the cleanest path. The spec also mooted a
+  hook-based fallback (`SessionStart` writes port to disk; harness
+  picks it up), which would let users keep typing `gemini` directly.
+  We chose launcher-only for v1 (consistent with Claude/Codex). If
+  user friction with the wrapper command is reported, revisit by
+  measuring whether Gemini's hook-time env propagation actually works
+  in practice — earlier research notes suggested Gemini hooks cannot
+  mutate child env post-fork, but this was not exhaustively verified.
+- **`HTMLGRAPH_OTEL_STRICT` default flip.** RESILIENCE-1 made strict
+  mode opt-in (defaults to degraded silent failure). The original spec
+  said "opt-in initially, becomes default in next major." We have not
+  scheduled the flip. Decision needed: pick a release version (e.g.
+  v1.0.0 / v0.60.0), announce the deprecation, then flip. Until then,
+  CI and production deployments should set `HTMLGRAPH_OTEL_STRICT=1`
+  explicitly to opt in to fail-loud semantics today.
+
 ## Cross-references
 
 | Artifact | Where |

--- a/docs/adr-001-harness-agnostic-collector.md
+++ b/docs/adr-001-harness-agnostic-collector.md
@@ -255,11 +255,20 @@ is rejected via `isSafeSessionID` before any filesystem access.
 
 The cleanup function returned by `ProcessCollector.Spawn` is wrapped in
 `sync.Once` so it can be safely invoked multiple times. This matters for
-the launcher pattern — `htmlgraph claude/codex/gemini` register cleanup
-via `defer` for normal/panic returns, but also call cleanup explicitly
-before `os.Exit(exitCode)` on non-zero harness exit (Ctrl-C or harness
-crash), since `os.Exit` bypasses deferred functions. The double-call
-under successful normal returns is harmless under `sync.Once`.
+the launcher pattern — three call sites need to invoke cleanup
+deterministically: deferred (panic / normal return), explicit before
+`os.Exit(exitCode)` on harness non-zero exit (Go's `os.Exit` bypasses
+defers), and from a signal handler when the launcher itself receives
+SIGINT/SIGTERM. The third path is centralized in
+`cmd/htmlgraph/launch_run.go:runHarnessWithCleanup`, which all three
+launchers call instead of `c.Run()`. It registers `signal.Notify` for
+SIGINT/SIGTERM, runs the child concurrently, forwards a received
+signal to the child, runs cleanup once the child reaps, then re-raises
+the signal so the launcher's exit code reflects normal POSIX
+signal-exit semantics (128+signum). Without the signal handler,
+Ctrl-C against the launcher's terminal foreground group would skip
+both deferred and explicit cleanup, leaving collector processes and
+PID files stale until idle timeout.
 
 ## Future work
 

--- a/docs/adr-001-harness-agnostic-collector.md
+++ b/docs/adr-001-harness-agnostic-collector.md
@@ -270,16 +270,20 @@ is rejected via `isSafeSessionID` before any filesystem access.
   Probably belongs in a separate plan.
 - **Adapter for Cursor / Aider / others.** Bias toward shipping these as
   separate adapters rather than special-casing the existing ones.
-- **Process-identity check on `.collector-pid`.** The reaper now
-  removes the PID file only when its contents still match the reaped
-  PID, which closes the watchdog-respawn race. The remaining concern
-  is PID reuse: between the time a collector dies and the reaper runs,
-  the kernel could recycle the PID for an unrelated process; a
-  `Signal(0)` probe by `/api/otel/status` would then incorrectly report
-  `alive=true`. For desktop usage this is essentially never seen, but
-  long-running CI workers might benefit from a start-time check (read
-  `/proc/<pid>/stat` field 22 at write-time, compare at probe-time).
-  The fix is local; it doesn't change any API.
+- **Process-identity check on `.collector-pid` — implemented.** The
+  reaper removes the PID file only when its contents still match the
+  reaped PID. To close the PID-reuse window — where the kernel
+  recycles a dead collector's PID for an unrelated process before
+  `/api/otel/status` probes — the lifecycle now records the process
+  start time (clock ticks from `/proc/<pid>/stat` field 22) on a
+  second line of `.collector-pid` at write-time, and the
+  `IsCollectorAlive` check verifies both PID liveness and start-time
+  match. On non-Linux platforms (`/proc` unavailable) or when reading
+  legacy single-line PID files, the check falls back to the PID-only
+  `Signal(0)` probe — degraded but no worse than before. Future work:
+  port this start-time mechanism to macOS using `kproc` /
+  `proc_pidinfo` if observed PID-reuse incidents on darwin warrant
+  the platform code.
 - **TEST-1 escalation path.** The plan originally included a real-
   subprocess respawn integration test gated on `testing.Short()`. That
   test was deferred during this work — see `feat-e195d658` for the

--- a/docs/adr-001-harness-agnostic-collector.md
+++ b/docs/adr-001-harness-agnostic-collector.md
@@ -253,6 +253,14 @@ in `htmlgraph status`) lets operators verify all three are working
 without grepping logs. Path traversal in the `?session=` query parameter
 is rejected via `isSafeSessionID` before any filesystem access.
 
+The cleanup function returned by `ProcessCollector.Spawn` is wrapped in
+`sync.Once` so it can be safely invoked multiple times. This matters for
+the launcher pattern — `htmlgraph claude/codex/gemini` register cleanup
+via `defer` for normal/panic returns, but also call cleanup explicitly
+before `os.Exit(exitCode)` on non-zero harness exit (Ctrl-C or harness
+crash), since `os.Exit` bypasses deferred functions. The double-call
+under successful normal returns is harmless under `sync.Once`.
+
 ## Future work
 
 - **Zero-gap respawn.** The watchdog already preserves the port across

--- a/docs/adr-001-harness-agnostic-collector.md
+++ b/docs/adr-001-harness-agnostic-collector.md
@@ -230,13 +230,23 @@ existing default:
    instead of degraded silent mode. Operators running CI or production
    sessions where missing telemetry is itself a failure should set this.
 
-3. **Watchdog respawn**
-   (`startCollectorWatchdog` / `HTMLGRAPH_OTEL_WATCHDOG_INTERVAL`). On
-   by default, 15s polling interval. Detects mid-session collector death
-   and respawns. The new collector listens on a fresh port; OTel traffic
-   between the death and the respawn is lost (the harness keeps writing
-   to the old port). This is an intentional v1 simplification — see ADR
-   forward considerations below.
+3. **Watchdog respawn with port preservation**
+   (`StartWatchdog` / `HTMLGRAPH_OTEL_WATCHDOG_INTERVAL`). On by
+   default, 15s polling interval. Detects mid-session collector death
+   and respawns the collector binding the **same port** as the original
+   spawn, so the harness's OTLP exporter endpoint remains valid across
+   restarts. OTel traffic emitted between the death and the respawn is
+   still lost (the harness keeps retrying against a temporarily dead
+   port), but traffic resumes once the new collector binds. The race
+   window where another process could grab the port between collector
+   exit and respawn is small on a 127.0.0.1 ephemeral range; if the
+   rebind fails, the watchdog logs a FATAL line and stops. The
+   `ProcessCollector` tracks the current process via
+   `atomic.Pointer[*os.Process]` so launcher cleanup terminates the
+   *current* collector (not the original), and per-process reaper
+   goroutines remove `.collector-pid` only when the file's contents
+   still match the reaped PID — making the cleanup race-free across
+   respawns and idle exits.
 
 The status surface (`/api/otel/status` and the `Collector health:` block
 in `htmlgraph status`) lets operators verify all three are working
@@ -245,13 +255,14 @@ is rejected via `isSafeSessionID` before any filesystem access.
 
 ## Future work
 
-- **Zero-gap respawn.** The current watchdog respawn loses telemetry
-  between the time the old collector dies and the time the harness's
-  next OTel request fails. A localhost redirect shim on the original
-  port (a small TCP proxy that forwards to the live collector) would
-  close the gap. Cost is one more goroutine and a port-rebind handshake
-  between watchdog and shim. Worth doing if real-world incidents show
-  the gap matters.
+- **Zero-gap respawn.** The watchdog already preserves the port across
+  respawns, so harness retries land on the new collector once it binds.
+  Telemetry emitted *during* the gap (between old-collector death and
+  new-collector ready) is still lost. A localhost redirect shim on the
+  original port (a small TCP proxy that buffers in-flight requests
+  during the rebind window) would close that residual gap. Cost is one
+  more goroutine plus buffered-write semantics. Worth doing if
+  real-world incidents show the residual gap matters.
 - **Daemon-mode option.** A `htmlgraph daemon --multi-session` mode for
   power users who run many parallel sessions and want a single
   long-lived collector. Would require extending `Lifecycle` with a
@@ -259,12 +270,16 @@ is rejected via `isSafeSessionID` before any filesystem access.
   Probably belongs in a separate plan.
 - **Adapter for Cursor / Aider / others.** Bias toward shipping these as
   separate adapters rather than special-casing the existing ones.
-- **Process-identity check on `.collector-pid`.** The current liveness
-  check uses `kill(pid, 0)`, which is racy under PID reuse. For most
-  desktop usage this is irrelevant, but in long-running CI workers a
-  start-time check (read `/proc/<pid>/stat` field 22, compare to the
-  remembered start-time) would be more robust. The fix is local; it
-  doesn't change any API.
+- **Process-identity check on `.collector-pid`.** The reaper now
+  removes the PID file only when its contents still match the reaped
+  PID, which closes the watchdog-respawn race. The remaining concern
+  is PID reuse: between the time a collector dies and the reaper runs,
+  the kernel could recycle the PID for an unrelated process; a
+  `Signal(0)` probe by `/api/otel/status` would then incorrectly report
+  `alive=true`. For desktop usage this is essentially never seen, but
+  long-running CI workers might benefit from a start-time check (read
+  `/proc/<pid>/stat` field 22 at write-time, compare at probe-time).
+  The fix is local; it doesn't change any API.
 - **TEST-1 escalation path.** The plan originally included a real-
   subprocess respawn integration test gated on `testing.Short()`. That
   test was deferred during this work — see `feat-e195d658` for the

--- a/internal/otel/adapter/adapter.go
+++ b/internal/otel/adapter/adapter.go
@@ -168,6 +168,20 @@ func (r *Registry) Adapters() []Adapter {
 	return out
 }
 
+// ResolveSessionID returns the session ID for a signal under the given
+// attribute key, falling back to the resource-level attribute when the
+// signal-level attribute is missing or empty. This is the canonical
+// pattern every adapter follows: cardinality-controlled metrics may
+// strip per-data-point attributes, leaving only the resource. Used by
+// ClaudeAdapter ("session.id"), CodexAdapter ("conversation.id"), and
+// GeminiAdapter ("session.id").
+func ResolveSessionID(signalAttrs, resAttrs map[string]any, key string) string {
+	if v := AttrString(signalAttrs, key); v != "" {
+		return v
+	}
+	return AttrString(resAttrs, key)
+}
+
 // AttrString returns the string-valued attribute at key, or "" if missing
 // or not a string. Adapters use this heavily for semconv lookups.
 func AttrString(attrs map[string]any, key string) string {

--- a/internal/otel/adapter/claude.go
+++ b/internal/otel/adapter/claude.go
@@ -239,14 +239,9 @@ func (c *ClaudeAdapter) baseSignal(
 		Kind:           kind,
 		NativeName:     name,
 		Timestamp:      ts,
-		SessionID:      AttrString(attrs, "session.id"),
+		SessionID:      ResolveSessionID(attrs, res.Attrs, "session.id"),
 		PromptID:       AttrString(attrs, "prompt.id"),
 		RawAttrs:       copyAttrs(attrs),
-	}
-	if sig.SessionID == "" {
-		// Some Claude signals carry session.id only on the resource
-		// (cardinality-controlled metrics). Fall back.
-		sig.SessionID = AttrString(res.Attrs, "session.id")
 	}
 	return sig
 }

--- a/internal/otel/adapter/codex.go
+++ b/internal/otel/adapter/codex.go
@@ -12,7 +12,9 @@ import (
 // Identification: resource service.name == "codex-cli".
 //
 // Session ID attribute: conversation.id (signal-level, with resource fallback).
-// PromptID: synthesized from conversation.id + sequence number when available.
+// PromptID: gen_ai.prompt_id when present; otherwise empty. Codex does not
+// emit a stable per-prompt ID on every signal, so callers needing prompt-level
+// correlation must group by (SessionID, Timestamp window).
 //
 // Canonical attribute mapping:
 //

--- a/internal/otel/adapter/codex.go
+++ b/internal/otel/adapter/codex.go
@@ -1,0 +1,184 @@
+package adapter
+
+import (
+	"time"
+
+	"github.com/shakestzd/htmlgraph/internal/otel"
+)
+
+// CodexAdapter converts Codex CLI OTel emissions into UnifiedSignals.
+// Schema derived from https://github.com/openai/codex/pull/2103.
+//
+// Identification: resource service.name == "codex-cli".
+//
+// Session ID attribute: conversation.id (signal-level, with resource fallback).
+// PromptID: synthesized from conversation.id + sequence number when available.
+//
+// Canonical attribute mapping:
+//
+//	service.name=codex-cli   conversation.id → SessionID
+//	gen_ai.prompt_id         → PromptID (when present)
+type CodexAdapter struct{}
+
+// NewCodexAdapter returns a CodexAdapter ready for use.
+func NewCodexAdapter() *CodexAdapter {
+	return &CodexAdapter{}
+}
+
+func (c *CodexAdapter) Name() otel.Harness { return otel.HarnessCodex }
+
+func (c *CodexAdapter) Identify(res OTLPResource) bool {
+	return AttrString(res.Attrs, "service.name") == "codex-cli"
+}
+
+// ConvertMetric maps Codex metric data points into canonical signals.
+// Unknown metric names produce CanonicalUnknown, preserving all attrs in
+// RawAttrs for drill-through.
+func (c *CodexAdapter) ConvertMetric(res OTLPResource, scope OTLPScope, m OTLPMetric) []otel.UnifiedSignal {
+	base := c.baseSignal(res, scope, otel.KindMetric, m.Name, m.Timestamp, m.Attrs)
+
+	switch m.Name {
+	case "codex.token.usage", "gen_ai.client.token.usage":
+		base.CanonicalName = otel.CanonicalTokenUsage
+		base.Model = AttrString(m.Attrs, "gen_ai.response.model")
+		if base.Model == "" {
+			base.Model = AttrString(m.Attrs, "model")
+		}
+		switch AttrString(m.Attrs, "gen_ai.token.type") {
+		case "input":
+			base.Tokens.Input = int64(m.Value)
+		case "output":
+			base.Tokens.Output = int64(m.Value)
+		case "reasoning":
+			base.Tokens.Reasoning = int64(m.Value)
+		}
+	case "codex.session.count":
+		base.CanonicalName = otel.CanonicalSessionStart
+	case "codex.cost.usage":
+		base.CanonicalName = otel.CanonicalTokenUsage
+		base.CostUSD = m.Value
+		base.CostSource = otel.CostSourceVendor
+		base.Model = AttrString(m.Attrs, "model")
+	default:
+		base.CanonicalName = otel.CanonicalUnknown
+	}
+
+	return []otel.UnifiedSignal{base}
+}
+
+// ConvertLog maps Codex log events onto canonical names. The event naming
+// convention follows OpenAI's gen_ai semconv where applicable.
+func (c *CodexAdapter) ConvertLog(res OTLPResource, scope OTLPScope, l OTLPLog) []otel.UnifiedSignal {
+	base := c.baseSignal(res, scope, otel.KindLog, l.Name, l.Timestamp, l.Attrs)
+	base.TraceID = l.TraceID
+	base.SpanID = l.SpanID
+
+	switch l.Name {
+	case "codex.user_prompt", "user_prompt":
+		base.CanonicalName = otel.CanonicalUserPrompt
+	case "codex.api_request", "gen_ai.client.operation.duration":
+		base.CanonicalName = otel.CanonicalAPIRequest
+		base.Model = AttrString(l.Attrs, "gen_ai.response.model")
+		if base.Model == "" {
+			base.Model = AttrString(l.Attrs, "model")
+		}
+		base.DurationMs = AttrInt64(l.Attrs, "duration_ms")
+		base.Tokens.Input = AttrInt64(l.Attrs, "gen_ai.usage.input_tokens")
+		base.Tokens.Output = AttrInt64(l.Attrs, "gen_ai.usage.output_tokens")
+		base.Tokens.Reasoning = AttrInt64(l.Attrs, "gen_ai.usage.reasoning_tokens")
+	case "codex.api_error":
+		base.CanonicalName = otel.CanonicalAPIError
+		base.Model = AttrString(l.Attrs, "model")
+		base.ErrorMsg = AttrString(l.Attrs, "error")
+		base.Attempt = int(AttrInt64(l.Attrs, "attempt"))
+		fval := false
+		base.Success = &fval
+	case "codex.tool_result", "tool_result":
+		base.CanonicalName = otel.CanonicalToolResult
+		base.ToolName = AttrString(l.Attrs, "tool_name")
+		base.DurationMs = AttrInt64(l.Attrs, "duration_ms")
+		base.Decision = AttrString(l.Attrs, "decision")
+		base.DecisionSource = normalizeDecisionSource(AttrString(l.Attrs, "source"))
+		succ := AttrString(l.Attrs, "success") == "true"
+		base.Success = &succ
+	case "codex.tool_decision", "tool_decision":
+		base.CanonicalName = otel.CanonicalToolDecision
+		base.ToolName = AttrString(l.Attrs, "tool_name")
+		base.Decision = AttrString(l.Attrs, "decision")
+		base.DecisionSource = normalizeDecisionSource(AttrString(l.Attrs, "source"))
+	default:
+		base.CanonicalName = otel.CanonicalUnknown
+	}
+
+	return []otel.UnifiedSignal{base}
+}
+
+// ConvertSpan maps Codex span taxonomy onto canonical names.
+func (c *CodexAdapter) ConvertSpan(res OTLPResource, scope OTLPScope, s OTLPSpan) []otel.UnifiedSignal {
+	base := c.baseSignal(res, scope, otel.KindSpan, s.Name, s.StartTime, s.Attrs)
+	base.TraceID = s.TraceID
+	base.SpanID = s.SpanID
+	base.ParentSpan = s.ParentSpanID
+	base.DurationMs = AttrInt64(s.Attrs, "duration_ms")
+	if base.DurationMs == 0 && !s.EndTime.IsZero() && !s.StartTime.IsZero() {
+		base.DurationMs = s.EndTime.Sub(s.StartTime).Milliseconds()
+	}
+	if s.StatusCode == 1 {
+		v := true
+		base.Success = &v
+	} else if s.StatusCode == 2 {
+		v := false
+		base.Success = &v
+		base.ErrorMsg = s.StatusMsg
+	}
+
+	switch s.Name {
+	case "codex.interaction", "ai.interaction":
+		base.CanonicalName = otel.CanonicalInteraction
+	case "codex.llm_request", "gen_ai.client.operation":
+		base.CanonicalName = otel.CanonicalAPIRequest
+		base.Model = AttrString(s.Attrs, "gen_ai.response.model")
+		if base.Model == "" {
+			base.Model = AttrString(s.Attrs, "gen_ai.request.model")
+		}
+		base.Tokens.Input = AttrInt64(s.Attrs, "gen_ai.usage.input_tokens")
+		base.Tokens.Output = AttrInt64(s.Attrs, "gen_ai.usage.output_tokens")
+		base.Tokens.Reasoning = AttrInt64(s.Attrs, "gen_ai.usage.reasoning_tokens")
+	case "codex.tool", "ai.tool":
+		base.CanonicalName = otel.CanonicalToolResult
+		base.ToolName = AttrString(s.Attrs, "tool_name")
+		if base.ToolName == "" {
+			base.ToolName = AttrString(s.Attrs, "gen_ai.tool.name")
+		}
+	default:
+		base.CanonicalName = otel.CanonicalUnknown
+	}
+
+	return []otel.UnifiedSignal{base}
+}
+
+// baseSignal populates the correlation IDs common to all Codex signals.
+// SessionID is sourced from the signal-level conversation.id attribute,
+// falling back to the resource-level conversation.id when absent (mirrors
+// the Claude adapter's session.id resource fallback at claude.go:246-249).
+func (c *CodexAdapter) baseSignal(
+	res OTLPResource, scope OTLPScope, kind otel.Kind, name string,
+	ts time.Time, attrs map[string]any,
+) otel.UnifiedSignal {
+	sig := otel.UnifiedSignal{
+		Harness:        otel.HarnessCodex,
+		HarnessVersion: AttrString(res.Attrs, "service.version"),
+		Kind:           kind,
+		NativeName:     name,
+		Timestamp:      ts,
+		SessionID:      AttrString(attrs, "conversation.id"),
+		PromptID:       AttrString(attrs, "gen_ai.prompt_id"),
+		RawAttrs:       copyAttrs(attrs),
+	}
+	if sig.SessionID == "" {
+		// Cardinality-controlled metrics may omit conversation.id from the
+		// data point. Fall back to the resource-level attribute.
+		sig.SessionID = AttrString(res.Attrs, "conversation.id")
+	}
+	return sig
+}

--- a/internal/otel/adapter/codex.go
+++ b/internal/otel/adapter/codex.go
@@ -173,14 +173,9 @@ func (c *CodexAdapter) baseSignal(
 		Kind:           kind,
 		NativeName:     name,
 		Timestamp:      ts,
-		SessionID:      AttrString(attrs, "conversation.id"),
+		SessionID:      ResolveSessionID(attrs, res.Attrs, "conversation.id"),
 		PromptID:       AttrString(attrs, "gen_ai.prompt_id"),
 		RawAttrs:       copyAttrs(attrs),
-	}
-	if sig.SessionID == "" {
-		// Cardinality-controlled metrics may omit conversation.id from the
-		// data point. Fall back to the resource-level attribute.
-		sig.SessionID = AttrString(res.Attrs, "conversation.id")
 	}
 	return sig
 }

--- a/internal/otel/adapter/conformance_test.go
+++ b/internal/otel/adapter/conformance_test.go
@@ -1,0 +1,229 @@
+package adapter_test
+
+// TestAdapterConformance verifies that every adapter (Claude, Codex, Gemini)
+// correctly populates the three canonical fields — Harness, SessionID, and
+// CanonicalName — across metric, log, and span paths.
+//
+// Canonical attribute mapping by harness:
+//
+//	Claude  service.name=claude-code   session.id        → SessionID
+//	Codex   service.name=codex-cli     conversation.id   → SessionID
+//	Gemini  service.name=gemini-cli    session.id        → SessionID
+//	PromptID: Claude prompt.id | Codex synthesized from conversation.id+seq | Gemini gen_ai.prompt_id
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shakestzd/htmlgraph/internal/otel"
+	"github.com/shakestzd/htmlgraph/internal/otel/adapter"
+)
+
+// adapterCase parameterises one adapter under test.
+type adapterCase struct {
+	name       string
+	adapter    adapter.Adapter
+	harness    otel.Harness
+	res        adapter.OTLPResource
+	sessionKey string // the signal-level attr key that holds the session ID
+	sessionVal string // the session ID value we inject and expect back
+}
+
+func conformanceCases() []adapterCase {
+	return []adapterCase{
+		{
+			name:    "Claude",
+			adapter: adapter.NewClaudeAdapter(),
+			harness: otel.HarnessClaude,
+			res: adapter.OTLPResource{Attrs: map[string]any{
+				"service.name":    "claude-code",
+				"service.version": "2.1.42",
+			}},
+			sessionKey: "session.id",
+			sessionVal: "claude-session-abc",
+		},
+		{
+			name:    "Codex",
+			adapter: adapter.NewCodexAdapter(),
+			harness: otel.HarnessCodex,
+			res: adapter.OTLPResource{Attrs: map[string]any{
+				"service.name":    "codex-cli",
+				"service.version": "0.1.0",
+			}},
+			sessionKey: "conversation.id",
+			sessionVal: "codex-conv-xyz",
+		},
+		{
+			name:    "Gemini",
+			adapter: adapter.NewGeminiAdapter(),
+			harness: otel.HarnessGemini,
+			res: adapter.OTLPResource{Attrs: map[string]any{
+				"service.name":    "gemini-cli",
+				"service.version": "0.1.0",
+			}},
+			sessionKey: "session.id",
+			sessionVal: "gemini-session-def",
+		},
+	}
+}
+
+// TestAdapterConformance_Identify checks that each adapter correctly
+// identifies its own resource and rejects foreign ones.
+func TestAdapterConformance_Identify(t *testing.T) {
+	for _, tc := range conformanceCases() {
+		tc := tc
+		t.Run(tc.name+"/Identify", func(t *testing.T) {
+			if !tc.adapter.Identify(tc.res) {
+				t.Errorf("%s: Identify returned false for own resource", tc.name)
+			}
+		})
+	}
+
+	// cross-rejection: each adapter must not claim another's resource
+	cases := conformanceCases()
+	for i, tc := range cases {
+		tc := tc
+		for j, other := range cases {
+			if i == j {
+				continue
+			}
+			other := other
+			t.Run(tc.name+"/RejectsForeign/"+other.name, func(t *testing.T) {
+				if tc.adapter.Identify(other.res) {
+					t.Errorf("%s incorrectly claimed %s resource", tc.name, other.name)
+				}
+			})
+		}
+	}
+}
+
+// TestAdapterConformance_Metric checks the metric path populates Harness,
+// SessionID, and CanonicalName.
+func TestAdapterConformance_Metric(t *testing.T) {
+	ts := time.Unix(0, 1_735_000_000_000_000_000)
+	scope := adapter.OTLPScope{Name: "conformance.test"}
+
+	for _, tc := range conformanceCases() {
+		tc := tc
+		t.Run(tc.name+"/Metric", func(t *testing.T) {
+			m := adapter.OTLPMetric{
+				Name:      "test.metric",
+				Kind:      adapter.MetricKindCounter,
+				Timestamp: ts,
+				Value:     1,
+				Attrs: map[string]any{
+					tc.sessionKey: tc.sessionVal,
+				},
+			}
+			sigs := tc.adapter.ConvertMetric(tc.res, scope, m)
+			if len(sigs) == 0 {
+				t.Fatalf("%s: ConvertMetric returned 0 signals", tc.name)
+			}
+			assertCanonicalFields(t, tc.name+"/metric", sigs[0], tc.harness, tc.sessionVal)
+		})
+	}
+}
+
+// TestAdapterConformance_Log checks the log path populates Harness,
+// SessionID, and CanonicalName.
+func TestAdapterConformance_Log(t *testing.T) {
+	ts := time.Unix(0, 1_735_000_000_000_000_000)
+	scope := adapter.OTLPScope{Name: "conformance.test"}
+
+	for _, tc := range conformanceCases() {
+		tc := tc
+		t.Run(tc.name+"/Log", func(t *testing.T) {
+			l := adapter.OTLPLog{
+				Name:      "test.event",
+				Timestamp: ts,
+				Attrs: map[string]any{
+					tc.sessionKey: tc.sessionVal,
+				},
+			}
+			sigs := tc.adapter.ConvertLog(tc.res, scope, l)
+			if len(sigs) == 0 {
+				t.Fatalf("%s: ConvertLog returned 0 signals", tc.name)
+			}
+			assertCanonicalFields(t, tc.name+"/log", sigs[0], tc.harness, tc.sessionVal)
+		})
+	}
+}
+
+// TestAdapterConformance_Span checks the span path populates Harness,
+// SessionID, and CanonicalName.
+func TestAdapterConformance_Span(t *testing.T) {
+	ts := time.Unix(0, 1_735_000_000_000_000_000)
+	scope := adapter.OTLPScope{Name: "conformance.test"}
+
+	for _, tc := range conformanceCases() {
+		tc := tc
+		t.Run(tc.name+"/Span", func(t *testing.T) {
+			s := adapter.OTLPSpan{
+				Name:      "test.span",
+				TraceID:   "a4e28f48fbdb6644a92b208f2145aee1",
+				SpanID:    "7d7f9ea011223344",
+				StartTime: ts,
+				EndTime:   ts.Add(100 * time.Millisecond),
+				Attrs: map[string]any{
+					tc.sessionKey: tc.sessionVal,
+				},
+			}
+			sigs := tc.adapter.ConvertSpan(tc.res, scope, s)
+			if len(sigs) == 0 {
+				t.Fatalf("%s: ConvertSpan returned 0 signals", tc.name)
+			}
+			assertCanonicalFields(t, tc.name+"/span", sigs[0], tc.harness, tc.sessionVal)
+		})
+	}
+}
+
+// TestAdapterConformance_SessionIDResourceFallback verifies that every
+// adapter falls back to the resource-level session attribute when the
+// signal-level attribute is absent.
+func TestAdapterConformance_SessionIDResourceFallback(t *testing.T) {
+	ts := time.Unix(0, 1_735_000_000_000_000_000)
+	scope := adapter.OTLPScope{Name: "conformance.test"}
+
+	for _, tc := range conformanceCases() {
+		tc := tc
+		t.Run(tc.name+"/SessionFallback", func(t *testing.T) {
+			// Resource carries the session key; signal attrs are empty.
+			res := adapter.OTLPResource{Attrs: make(map[string]any, len(tc.res.Attrs)+1)}
+			for k, v := range tc.res.Attrs {
+				res.Attrs[k] = v
+			}
+			res.Attrs[tc.sessionKey] = tc.sessionVal + "-from-resource"
+
+			m := adapter.OTLPMetric{
+				Name:      "test.metric",
+				Kind:      adapter.MetricKindCounter,
+				Timestamp: ts,
+				Value:     1,
+				Attrs:     map[string]any{}, // no session key here
+			}
+			sigs := tc.adapter.ConvertMetric(res, scope, m)
+			if len(sigs) == 0 {
+				t.Fatalf("%s: ConvertMetric returned 0 signals", tc.name)
+			}
+			want := tc.sessionVal + "-from-resource"
+			if sigs[0].SessionID != want {
+				t.Errorf("%s: SessionID = %q, want %q (resource fallback)", tc.name, sigs[0].SessionID, want)
+			}
+		})
+	}
+}
+
+// assertCanonicalFields is the shared assertion for Harness, SessionID,
+// and CanonicalName on every signal produced by any adapter.
+func assertCanonicalFields(t *testing.T, label string, sig otel.UnifiedSignal, wantHarness otel.Harness, wantSession string) {
+	t.Helper()
+	if sig.Harness != wantHarness {
+		t.Errorf("%s: Harness = %q, want %q", label, sig.Harness, wantHarness)
+	}
+	if sig.SessionID != wantSession {
+		t.Errorf("%s: SessionID = %q, want %q", label, sig.SessionID, wantSession)
+	}
+	if sig.CanonicalName == "" {
+		t.Errorf("%s: CanonicalName is empty", label)
+	}
+}

--- a/internal/otel/adapter/gemini.go
+++ b/internal/otel/adapter/gemini.go
@@ -1,0 +1,190 @@
+package adapter
+
+import (
+	"time"
+
+	"github.com/shakestzd/htmlgraph/internal/otel"
+)
+
+// GeminiAdapter converts Gemini CLI OTel emissions into UnifiedSignals.
+// Schema derived from https://google-gemini.github.io/gemini-cli/docs/cli/telemetry.html
+// and the GenAI semantic conventions (gen_ai.*).
+//
+// Identification: resource service.name == "gemini-cli".
+//
+// Session ID attribute: session.id (signal-level, with resource fallback).
+// PromptID: gen_ai.prompt_id when present.
+//
+// Canonical attribute mapping:
+//
+//	service.name=gemini-cli   session.id        → SessionID
+//	gen_ai.prompt_id          → PromptID (when present)
+type GeminiAdapter struct{}
+
+// NewGeminiAdapter returns a GeminiAdapter ready for use.
+func NewGeminiAdapter() *GeminiAdapter {
+	return &GeminiAdapter{}
+}
+
+func (g *GeminiAdapter) Name() otel.Harness { return otel.HarnessGemini }
+
+func (g *GeminiAdapter) Identify(res OTLPResource) bool {
+	return AttrString(res.Attrs, "service.name") == "gemini-cli"
+}
+
+// ConvertMetric maps Gemini metric data points into canonical signals.
+// Unknown metric names produce CanonicalUnknown, preserving all attrs in
+// RawAttrs for drill-through.
+func (g *GeminiAdapter) ConvertMetric(res OTLPResource, scope OTLPScope, m OTLPMetric) []otel.UnifiedSignal {
+	base := g.baseSignal(res, scope, otel.KindMetric, m.Name, m.Timestamp, m.Attrs)
+
+	switch m.Name {
+	case "gemini_cli.token.usage", "gen_ai.client.token.usage":
+		base.CanonicalName = otel.CanonicalTokenUsage
+		base.Model = AttrString(m.Attrs, "gen_ai.response.model")
+		if base.Model == "" {
+			base.Model = AttrString(m.Attrs, "model")
+		}
+		switch AttrString(m.Attrs, "gen_ai.token.type") {
+		case "input":
+			base.Tokens.Input = int64(m.Value)
+		case "output":
+			base.Tokens.Output = int64(m.Value)
+		case "thought":
+			base.Tokens.Thought = int64(m.Value)
+		case "tool":
+			base.Tokens.Tool = int64(m.Value)
+		}
+	case "gemini_cli.session.count":
+		base.CanonicalName = otel.CanonicalSessionStart
+	case "gemini_cli.tool.decision":
+		base.CanonicalName = otel.CanonicalToolDecision
+		base.ToolName = AttrString(m.Attrs, "tool_name")
+		base.Decision = AttrString(m.Attrs, "decision")
+		base.DecisionSource = normalizeDecisionSource(AttrString(m.Attrs, "approval_mode"))
+	default:
+		base.CanonicalName = otel.CanonicalUnknown
+	}
+
+	return []otel.UnifiedSignal{base}
+}
+
+// ConvertLog maps Gemini log events onto canonical names. The event naming
+// convention follows Google's gemini_cli.* namespace and gen_ai semconv.
+func (g *GeminiAdapter) ConvertLog(res OTLPResource, scope OTLPScope, l OTLPLog) []otel.UnifiedSignal {
+	base := g.baseSignal(res, scope, otel.KindLog, l.Name, l.Timestamp, l.Attrs)
+	base.TraceID = l.TraceID
+	base.SpanID = l.SpanID
+
+	switch l.Name {
+	case "gemini_cli.user_prompt", "user_prompt":
+		base.CanonicalName = otel.CanonicalUserPrompt
+	case "gemini_cli.api_request", "gen_ai.client.operation.duration":
+		base.CanonicalName = otel.CanonicalAPIRequest
+		base.Model = AttrString(l.Attrs, "gen_ai.response.model")
+		if base.Model == "" {
+			base.Model = AttrString(l.Attrs, "model")
+		}
+		base.DurationMs = AttrInt64(l.Attrs, "duration_ms")
+		base.Tokens.Input = AttrInt64(l.Attrs, "gen_ai.usage.input_tokens")
+		base.Tokens.Output = AttrInt64(l.Attrs, "gen_ai.usage.output_tokens")
+		base.Tokens.Thought = AttrInt64(l.Attrs, "gen_ai.usage.thought_tokens")
+		base.Tokens.Tool = AttrInt64(l.Attrs, "gen_ai.usage.tool_tokens")
+	case "gemini_cli.api_error":
+		base.CanonicalName = otel.CanonicalAPIError
+		base.Model = AttrString(l.Attrs, "model")
+		base.ErrorMsg = AttrString(l.Attrs, "error")
+		base.Attempt = int(AttrInt64(l.Attrs, "attempt"))
+		fval := false
+		base.Success = &fval
+	case "gemini_cli.tool_result", "tool_result":
+		base.CanonicalName = otel.CanonicalToolResult
+		base.ToolName = AttrString(l.Attrs, "tool_name")
+		base.DurationMs = AttrInt64(l.Attrs, "duration_ms")
+		base.Decision = AttrString(l.Attrs, "decision")
+		base.DecisionSource = normalizeDecisionSource(AttrString(l.Attrs, "approval_mode"))
+		succ := AttrString(l.Attrs, "success") == "true"
+		base.Success = &succ
+	case "gemini_cli.tool_decision", "tool_decision":
+		base.CanonicalName = otel.CanonicalToolDecision
+		base.ToolName = AttrString(l.Attrs, "tool_name")
+		base.Decision = AttrString(l.Attrs, "decision")
+		base.DecisionSource = normalizeDecisionSource(AttrString(l.Attrs, "approval_mode"))
+	default:
+		base.CanonicalName = otel.CanonicalUnknown
+	}
+
+	return []otel.UnifiedSignal{base}
+}
+
+// ConvertSpan maps Gemini span taxonomy onto canonical names. Trace
+// hierarchy flows through regardless of canonicalization.
+func (g *GeminiAdapter) ConvertSpan(res OTLPResource, scope OTLPScope, s OTLPSpan) []otel.UnifiedSignal {
+	base := g.baseSignal(res, scope, otel.KindSpan, s.Name, s.StartTime, s.Attrs)
+	base.TraceID = s.TraceID
+	base.SpanID = s.SpanID
+	base.ParentSpan = s.ParentSpanID
+	base.DurationMs = AttrInt64(s.Attrs, "duration_ms")
+	if base.DurationMs == 0 && !s.EndTime.IsZero() && !s.StartTime.IsZero() {
+		base.DurationMs = s.EndTime.Sub(s.StartTime).Milliseconds()
+	}
+	if s.StatusCode == 1 {
+		v := true
+		base.Success = &v
+	} else if s.StatusCode == 2 {
+		v := false
+		base.Success = &v
+		base.ErrorMsg = s.StatusMsg
+	}
+
+	switch s.Name {
+	case "gemini_cli.interaction", "ai.interaction":
+		base.CanonicalName = otel.CanonicalInteraction
+	case "gemini_cli.llm_request", "gen_ai.client.operation":
+		base.CanonicalName = otel.CanonicalAPIRequest
+		base.Model = AttrString(s.Attrs, "gen_ai.response.model")
+		if base.Model == "" {
+			base.Model = AttrString(s.Attrs, "gen_ai.request.model")
+		}
+		base.Tokens.Input = AttrInt64(s.Attrs, "gen_ai.usage.input_tokens")
+		base.Tokens.Output = AttrInt64(s.Attrs, "gen_ai.usage.output_tokens")
+		base.Tokens.Thought = AttrInt64(s.Attrs, "gen_ai.usage.thought_tokens")
+		base.Tokens.Tool = AttrInt64(s.Attrs, "gen_ai.usage.tool_tokens")
+	case "gemini_cli.tool", "ai.tool":
+		base.CanonicalName = otel.CanonicalToolResult
+		base.ToolName = AttrString(s.Attrs, "tool_name")
+		if base.ToolName == "" {
+			base.ToolName = AttrString(s.Attrs, "gen_ai.tool.name")
+		}
+	default:
+		base.CanonicalName = otel.CanonicalUnknown
+	}
+
+	return []otel.UnifiedSignal{base}
+}
+
+// baseSignal populates the correlation IDs common to all Gemini signals.
+// SessionID is sourced from the signal-level session.id attribute,
+// falling back to the resource-level session.id when absent (mirrors
+// the Claude adapter's session.id resource fallback at claude.go:246-249).
+func (g *GeminiAdapter) baseSignal(
+	res OTLPResource, scope OTLPScope, kind otel.Kind, name string,
+	ts time.Time, attrs map[string]any,
+) otel.UnifiedSignal {
+	sig := otel.UnifiedSignal{
+		Harness:        otel.HarnessGemini,
+		HarnessVersion: AttrString(res.Attrs, "service.version"),
+		Kind:           kind,
+		NativeName:     name,
+		Timestamp:      ts,
+		SessionID:      AttrString(attrs, "session.id"),
+		PromptID:       AttrString(attrs, "gen_ai.prompt_id"),
+		RawAttrs:       copyAttrs(attrs),
+	}
+	if sig.SessionID == "" {
+		// Cardinality-controlled metrics may omit session.id from the
+		// data point. Fall back to the resource-level attribute.
+		sig.SessionID = AttrString(res.Attrs, "session.id")
+	}
+	return sig
+}

--- a/internal/otel/adapter/gemini.go
+++ b/internal/otel/adapter/gemini.go
@@ -177,14 +177,9 @@ func (g *GeminiAdapter) baseSignal(
 		Kind:           kind,
 		NativeName:     name,
 		Timestamp:      ts,
-		SessionID:      AttrString(attrs, "session.id"),
+		SessionID:      ResolveSessionID(attrs, res.Attrs, "session.id"),
 		PromptID:       AttrString(attrs, "gen_ai.prompt_id"),
 		RawAttrs:       copyAttrs(attrs),
-	}
-	if sig.SessionID == "" {
-		// Cardinality-controlled metrics may omit session.id from the
-		// data point. Fall back to the resource-level attribute.
-		sig.SessionID = AttrString(res.Attrs, "session.id")
 	}
 	return sig
 }

--- a/internal/otel/collector/lifecycle.go
+++ b/internal/otel/collector/lifecycle.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"sync/atomic"
 	"syscall"
 	"time"
 )
@@ -22,10 +23,16 @@ import (
 type Lifecycle interface {
 	// Spawn starts an otel-collect process for the given session and returns
 	// the port it is listening on plus a cleanup function. The cleanup function
-	// stops the watchdog goroutine, SIGTERMs the process (waits up to 3s, then
-	// SIGKILLs), and removes the .collector-pid file.
+	// stops the watchdog goroutine, SIGTERMs the current process (waits up to
+	// 3s, then SIGKILLs), and removes the .collector-pid file.
 	Spawn(binPath, sessionID, projectDir string) (port int, cleanup func(), err error)
 }
+
+// SpawnFn is the function signature used by RetrySpawn and the watchdog to
+// start a single collector child process. requestedPort=0 lets the kernel
+// auto-assign a port; non-zero reuses the given port (used by the watchdog
+// to keep the harness's exporter endpoint stable across respawns).
+type SpawnFn func(binPath, sessionID, projectDir string, requestedPort int) (int, *os.Process, error)
 
 // ProcessCollectorOpts configures a ProcessCollector.
 type ProcessCollectorOpts struct {
@@ -39,7 +46,7 @@ type ProcessCollectorOpts struct {
 
 	// SpawnFn overrides the default spawn function. Nil means use DefaultSpawnFn.
 	// Primarily for tests.
-	SpawnFn func(binPath, sessionID, projectDir string) (int, *os.Process, error)
+	SpawnFn SpawnFn
 
 	// WatchdogIntervalEnv is the env-var name used to override the watchdog
 	// poll interval. Empty string defaults to "HTMLGRAPH_OTEL_WATCHDOG_INTERVAL".
@@ -63,7 +70,10 @@ func NewProcessCollector(opts ProcessCollectorOpts) *ProcessCollector {
 }
 
 // Spawn starts the collector, retries up to 3 times with backoff, writes the
-// PID file, starts the watchdog, and returns the port and cleanup func.
+// PID file, starts the watchdog, and returns the port and cleanup func. The
+// watchdog respawns on the same port so the harness's OTLP exporter endpoint
+// remains valid across collector restarts.
+//
 // On failure it writes a FATAL line to Stderr and returns a non-nil error.
 func (c *ProcessCollector) Spawn(binPath, sessionID, projectDir string) (int, func(), error) {
 	spawnFn := c.opts.SpawnFn
@@ -71,29 +81,36 @@ func (c *ProcessCollector) Spawn(binPath, sessionID, projectDir string) (int, fu
 		spawnFn = DefaultSpawnFn
 	}
 
-	port, proc, attempts, err := RetrySpawn(binPath, sessionID, projectDir, 3, spawnFn, c.opts.Stderr)
+	port, proc, attempts, err := RetrySpawn(binPath, sessionID, projectDir, 0, 3, spawnFn, c.opts.Stderr)
 	if err != nil {
 		fmt.Fprintf(c.opts.Stderr, "htmlgraph: FATAL: collector spawn failed after %d attempts: %v\n", attempts, err)
 		return 0, nil, err
 	}
 
 	WriteCollectorPID(projectDir, sessionID, proc.Pid)
-	stopWatchdog := c.startWatchdog(proc, binPath, sessionID, projectDir)
-	baseCleanup := RegisterCleanup(proc, projectDir, sessionID)
-	cleanup := func() { stopWatchdog(); baseCleanup() }
+	procPtr := newProcPointer(proc)
+	startReaper(procPtr.Load(), projectDir, sessionID)
 
+	stopWatchdog := StartWatchdog(procPtr, port, binPath, sessionID, projectDir, c.opts.Stderr, spawnFn, c.opts.WatchdogIntervalEnv)
+	cleanup := makeCleanup(procPtr, projectDir, sessionID, stopWatchdog)
 	return port, cleanup, nil
 }
 
-// DefaultSpawnFn starts an otel-collect child process, waits for its handshake
-// line ("htmlgraph-otel-ready port=<N>"), and returns the port and process.
-// The child is started in its own process group (Setpgid) so it can be
-// independently signalled.
-func DefaultSpawnFn(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+// DefaultSpawnFn starts an otel-collect child process and waits for its
+// handshake line ("htmlgraph-otel-ready port=<N>"). When requestedPort is 0,
+// the kernel auto-assigns a port; when non-zero, the collector binds the
+// requested port (used by the watchdog to preserve endpoint identity across
+// respawns). The child is started in its own process group (Setpgid) so it
+// can be independently signalled.
+func DefaultSpawnFn(binPath, sessionID, projectDir string, requestedPort int) (int, *os.Process, error) {
+	listen := "127.0.0.1:0"
+	if requestedPort > 0 {
+		listen = fmt.Sprintf("127.0.0.1:%d", requestedPort)
+	}
 	cmd := exec.Command(binPath, "otel-collect",
 		"--session-id", sessionID,
 		"--project-dir", projectDir,
-		"--listen", "127.0.0.1:0",
+		"--listen", listen,
 	)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Stderr = os.Stderr
@@ -143,19 +160,19 @@ func readHandshake(scanner *bufio.Scanner) (int, error) {
 }
 
 // RetrySpawn attempts to spawn the collector up to maxAttempts times.
-// Backoff delays between attempts: 100ms, 300ms, 700ms.
-// Writes a warning line to warnW after each non-final failure.
-// Returns port, process, number of attempts, and any final error.
+// requestedPort is forwarded to spawnFn (0 = auto-assign). Backoff delays
+// between attempts: 100ms, 300ms, 700ms. Writes a warning line to warnW
+// after each non-final failure. Returns port, process, attempts, error.
 func RetrySpawn(
 	binPath, sessionID, projectDir string,
-	maxAttempts int,
-	spawnFn func(string, string, string) (int, *os.Process, error),
+	requestedPort, maxAttempts int,
+	spawnFn SpawnFn,
 	warnW io.Writer,
 ) (int, *os.Process, int, error) {
 	backoff := []time.Duration{100 * time.Millisecond, 300 * time.Millisecond, 700 * time.Millisecond}
 	var lastErr error
 	for i := 0; i < maxAttempts; i++ {
-		port, proc, err := spawnFn(binPath, sessionID, projectDir)
+		port, proc, err := spawnFn(binPath, sessionID, projectDir, requestedPort)
 		if err == nil {
 			return port, proc, i + 1, nil
 		}
@@ -181,78 +198,156 @@ func WatchdogInterval(envKey string) time.Duration {
 	return 15 * time.Second
 }
 
-// StartWatchdog launches a goroutine that polls the collector process every
-// WatchdogInterval(envKey). On process death it calls RetrySpawn and updates
-// the current process. Returns a stop func that terminates the goroutine.
+// StartWatchdog launches a goroutine that polls procPtr.Load() every
+// WatchdogInterval(envKey). On process death it calls RetrySpawn with
+// originalPort to keep the harness's exporter endpoint stable, updates
+// procPtr to the new process, writes the new PID file, and starts a reaper
+// for the new process.
+//
+// The returned stop function is blocking: it closes the done channel and
+// waits for the goroutine to exit before returning. Callers can therefore
+// rely on procPtr being stable after stop() returns.
 func StartWatchdog(
-	initialProc *os.Process,
+	procPtr *atomic.Pointer[os.Process],
+	originalPort int,
 	binPath, sessionID, projectDir string,
 	warnW io.Writer,
-	spawnFn func(string, string, string) (int, *os.Process, error),
+	spawnFn SpawnFn,
 	envKey string,
 ) func() {
 	done := make(chan struct{})
+	stopped := make(chan struct{})
 
 	go func() {
+		defer close(stopped)
 		ticker := time.NewTicker(WatchdogInterval(envKey))
 		defer ticker.Stop()
-		currentProc := initialProc
 
 		for {
 			select {
 			case <-done:
 				return
 			case <-ticker.C:
-				if err := currentProc.Signal(syscall.Signal(0)); err == nil {
-					continue // process still alive
+				current := procPtr.Load()
+				if current == nil {
+					continue
 				}
-				fmt.Fprintf(warnW, "htmlgraph: warning: collector died (pid=%d), respawning...\n", currentProc.Pid)
-				port, newProc, _, spawnErr := RetrySpawn(binPath, sessionID, projectDir, 3, spawnFn, warnW)
+				if err := current.Signal(syscall.Signal(0)); err == nil {
+					continue
+				}
+				fmt.Fprintf(warnW, "htmlgraph: warning: collector died (pid=%d), respawning on port %d...\n", current.Pid, originalPort)
+				_, newProc, _, spawnErr := RetrySpawn(binPath, sessionID, projectDir, originalPort, 3, spawnFn, warnW)
 				if spawnErr != nil {
 					fmt.Fprintf(warnW, "htmlgraph: FATAL: collector respawn failed: %v\n", spawnErr)
 					return
 				}
 				WriteCollectorPID(projectDir, sessionID, newProc.Pid)
-				fmt.Fprintf(warnW, "htmlgraph: info: collector respawned (pid=%d port=%d)\n", newProc.Pid, port)
-				currentProc = newProc
+				startReaper(newProc, projectDir, sessionID)
+				procPtr.Store(newProc)
+				fmt.Fprintf(warnW, "htmlgraph: info: collector respawned (pid=%d port=%d)\n", newProc.Pid, originalPort)
 			}
 		}
 	}()
 
-	return func() { close(done) }
-}
-
-// startWatchdog is the method form of StartWatchdog, using opts from the receiver.
-func (c *ProcessCollector) startWatchdog(initialProc *os.Process, binPath, sessionID, projectDir string) func() {
-	spawnFn := c.opts.SpawnFn
-	if spawnFn == nil {
-		spawnFn = DefaultSpawnFn
-	}
-	return StartWatchdog(initialProc, binPath, sessionID, projectDir, c.opts.Stderr, spawnFn, c.opts.WatchdogIntervalEnv)
-}
-
-// RegisterCleanup returns a cleanup function that SIGTERMs the process, waits
-// up to 3s, then SIGKILLs, and removes the .collector-pid file.
-func RegisterCleanup(proc *os.Process, projectDir, sessionID string) func() {
-	go func() { _, _ = proc.Wait() }()
-
 	return func() {
-		_ = proc.Signal(syscall.SIGTERM)
+		close(done)
+		<-stopped
+	}
+}
+
+// makeCleanup returns a function that stops the watchdog (waiting for it to
+// exit), then SIGTERMs the *current* process tracked by procPtr and waits up
+// to 3s before SIGKILL. PID file removal is handled by the per-process
+// reaper goroutine started in startReaper, which conditionally removes the
+// file only when its own PID still matches the file's contents.
+func makeCleanup(
+	procPtr *atomic.Pointer[os.Process],
+	projectDir, sessionID string,
+	stopWatchdog func(),
+) func() {
+	return func() {
+		stopWatchdog() // blocks until watchdog goroutine exits
+		current := procPtr.Load()
+		if current == nil {
+			return
+		}
+		_ = current.Signal(syscall.SIGTERM)
 		deadline := time.Now().Add(3 * time.Second)
 		for time.Now().Before(deadline) {
-			if err := proc.Signal(syscall.Signal(0)); err != nil {
-				RemoveCollectorPID(projectDir, sessionID)
-				return // process exited
+			if err := current.Signal(syscall.Signal(0)); err != nil {
+				return // process exited; its reaper will remove the PID file
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
-		_ = proc.Kill()
-		RemoveCollectorPID(projectDir, sessionID)
+		_ = current.Kill()
 	}
+}
+
+// startReaper spawns a goroutine that waits for proc to exit and then
+// removes .collector-pid only if it still references this PID. This makes
+// independent collector exit (idle timeout, OOM) self-cleaning while
+// remaining safe across watchdog respawns: an old reaper firing after the
+// watchdog has rotated the PID file will see the new PID and leave the
+// file alone.
+func startReaper(proc *os.Process, projectDir, sessionID string) {
+	go func() {
+		_, _ = proc.Wait()
+		removeCollectorPIDIfMatches(projectDir, sessionID, proc.Pid)
+	}()
+}
+
+// RegisterCleanup is preserved for backwards compatibility with the shim in
+// cmd/htmlgraph/claude_otel_collect_spawn.go. It composes a single-process
+// reaper and cleanup. New code should call ProcessCollector.Spawn instead.
+//
+// Deprecated: prefer ProcessCollector.Spawn — RegisterCleanup cannot track
+// watchdog-respawned processes.
+func RegisterCleanup(proc *os.Process, projectDir, sessionID string) func() {
+	procPtr := newProcPointer(proc)
+	startReaper(proc, projectDir, sessionID)
+	return makeCleanup(procPtr, projectDir, sessionID, func() {})
+}
+
+// newProcPointer constructs an atomic.Pointer[os.Process] storing proc.
+func newProcPointer(proc *os.Process) *atomic.Pointer[os.Process] {
+	var p atomic.Pointer[os.Process]
+	p.Store(proc)
+	return &p
+}
+
+// removeCollectorPIDIfMatches removes the .collector-pid file only when its
+// contents match the given PID. Used by the per-process reaper to avoid
+// deleting a fresher PID written by the watchdog after a respawn.
+func removeCollectorPIDIfMatches(projectDir, sessionID string, pid int) {
+	pidPath := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID, ".collector-pid")
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		return
+	}
+	got, err := strconv.Atoi(string(bytesTrimSpace(data)))
+	if err != nil || got != pid {
+		return
+	}
+	_ = os.Remove(pidPath)
+}
+
+// bytesTrimSpace trims trailing whitespace without depending on the strings
+// package or copying the slice.
+func bytesTrimSpace(b []byte) []byte {
+	for len(b) > 0 && (b[len(b)-1] == '\n' || b[len(b)-1] == '\r' || b[len(b)-1] == ' ' || b[len(b)-1] == '\t') {
+		b = b[:len(b)-1]
+	}
+	for len(b) > 0 && (b[0] == '\n' || b[0] == '\r' || b[0] == ' ' || b[0] == '\t') {
+		b = b[1:]
+	}
+	return b
 }
 
 // RemoveCollectorPID removes the .collector-pid file for a session.
 // Best-effort: missing file or unreadable directory is not an error.
+//
+// Unlike removeCollectorPIDIfMatches, this is unconditional. Used by direct
+// shim callers; the reaper path uses the conditional variant.
 func RemoveCollectorPID(projectDir, sessionID string) {
 	pidPath := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID, ".collector-pid")
 	_ = os.Remove(pidPath)

--- a/internal/otel/collector/lifecycle.go
+++ b/internal/otel/collector/lifecycle.go
@@ -1,0 +1,268 @@
+// Package collector provides the CollectorLifecycle interface and its
+// ProcessCollector implementation for spawning, monitoring, and cleaning up
+// htmlgraph otel-collect child processes.
+//
+// Future launchers (Codex, Gemini) call Spawn directly without duplicating
+// retry/watchdog/cleanup machinery.
+package collector
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+// Lifecycle is the minimal interface for spawning a per-session OTel collector.
+type Lifecycle interface {
+	// Spawn starts an otel-collect process for the given session and returns
+	// the port it is listening on plus a cleanup function. The cleanup function
+	// stops the watchdog goroutine, SIGTERMs the process (waits up to 3s, then
+	// SIGKILLs), and removes the .collector-pid file.
+	Spawn(binPath, sessionID, projectDir string) (port int, cleanup func(), err error)
+}
+
+// ProcessCollectorOpts configures a ProcessCollector.
+type ProcessCollectorOpts struct {
+	// Stderr is where warning/info/FATAL lines are written. Defaults to os.Stderr.
+	Stderr io.Writer
+
+	// StrictMode is reserved for callers that want Spawn errors to be fatal;
+	// the ProcessCollector itself does not call os.Exit — that decision belongs
+	// to the caller.
+	StrictMode bool
+
+	// SpawnFn overrides the default spawn function. Nil means use DefaultSpawnFn.
+	// Primarily for tests.
+	SpawnFn func(binPath, sessionID, projectDir string) (int, *os.Process, error)
+
+	// WatchdogIntervalEnv is the env-var name used to override the watchdog
+	// poll interval. Empty string defaults to "HTMLGRAPH_OTEL_WATCHDOG_INTERVAL".
+	WatchdogIntervalEnv string
+}
+
+// ProcessCollector implements Lifecycle by managing a real os.Process.
+type ProcessCollector struct {
+	opts ProcessCollectorOpts
+}
+
+// NewProcessCollector returns a new ProcessCollector configured by opts.
+func NewProcessCollector(opts ProcessCollectorOpts) *ProcessCollector {
+	if opts.Stderr == nil {
+		opts.Stderr = os.Stderr
+	}
+	if opts.WatchdogIntervalEnv == "" {
+		opts.WatchdogIntervalEnv = "HTMLGRAPH_OTEL_WATCHDOG_INTERVAL"
+	}
+	return &ProcessCollector{opts: opts}
+}
+
+// Spawn starts the collector, retries up to 3 times with backoff, writes the
+// PID file, starts the watchdog, and returns the port and cleanup func.
+// On failure it writes a FATAL line to Stderr and returns a non-nil error.
+func (c *ProcessCollector) Spawn(binPath, sessionID, projectDir string) (int, func(), error) {
+	spawnFn := c.opts.SpawnFn
+	if spawnFn == nil {
+		spawnFn = DefaultSpawnFn
+	}
+
+	port, proc, attempts, err := RetrySpawn(binPath, sessionID, projectDir, 3, spawnFn, c.opts.Stderr)
+	if err != nil {
+		fmt.Fprintf(c.opts.Stderr, "htmlgraph: FATAL: collector spawn failed after %d attempts: %v\n", attempts, err)
+		return 0, nil, err
+	}
+
+	WriteCollectorPID(projectDir, sessionID, proc.Pid)
+	stopWatchdog := c.startWatchdog(proc, binPath, sessionID, projectDir)
+	baseCleanup := RegisterCleanup(proc, projectDir, sessionID)
+	cleanup := func() { stopWatchdog(); baseCleanup() }
+
+	return port, cleanup, nil
+}
+
+// DefaultSpawnFn starts an otel-collect child process, waits for its handshake
+// line ("htmlgraph-otel-ready port=<N>"), and returns the port and process.
+// The child is started in its own process group (Setpgid) so it can be
+// independently signalled.
+func DefaultSpawnFn(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+	cmd := exec.Command(binPath, "otel-collect",
+		"--session-id", sessionID,
+		"--project-dir", projectDir,
+		"--listen", "127.0.0.1:0",
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Stderr = os.Stderr
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return 0, nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return 0, nil, fmt.Errorf("start otel-collect: %w", err)
+	}
+
+	port, err := readHandshake(bufio.NewScanner(stdout))
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		return 0, nil, err
+	}
+	return port, cmd.Process, nil
+}
+
+// readHandshake scans stdout for the handshake line within 3s.
+func readHandshake(scanner *bufio.Scanner) (int, error) {
+	type result struct {
+		port int
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		for scanner.Scan() {
+			line := scanner.Text()
+			var p int
+			if _, err := fmt.Sscanf(line, "htmlgraph-otel-ready port=%d", &p); err == nil {
+				ch <- result{port: p}
+				return
+			}
+		}
+		ch <- result{err: fmt.Errorf("otel-collect: handshake not found (stdout closed)")}
+	}()
+
+	select {
+	case r := <-ch:
+		return r.port, r.err
+	case <-time.After(3 * time.Second):
+		return 0, fmt.Errorf("otel-collect: handshake timeout (3s)")
+	}
+}
+
+// RetrySpawn attempts to spawn the collector up to maxAttempts times.
+// Backoff delays between attempts: 100ms, 300ms, 700ms.
+// Writes a warning line to warnW after each non-final failure.
+// Returns port, process, number of attempts, and any final error.
+func RetrySpawn(
+	binPath, sessionID, projectDir string,
+	maxAttempts int,
+	spawnFn func(string, string, string) (int, *os.Process, error),
+	warnW io.Writer,
+) (int, *os.Process, int, error) {
+	backoff := []time.Duration{100 * time.Millisecond, 300 * time.Millisecond, 700 * time.Millisecond}
+	var lastErr error
+	for i := 0; i < maxAttempts; i++ {
+		port, proc, err := spawnFn(binPath, sessionID, projectDir)
+		if err == nil {
+			return port, proc, i + 1, nil
+		}
+		lastErr = err
+		if i < maxAttempts-1 {
+			fmt.Fprintf(warnW, "htmlgraph: warning: collector spawn attempt %d/%d failed: %v\n", i+1, maxAttempts, err)
+			if i < len(backoff) {
+				time.Sleep(backoff[i])
+			}
+		}
+	}
+	return 0, nil, maxAttempts, lastErr
+}
+
+// WatchdogInterval returns the polling interval for the collector watchdog.
+// The env var name is configurable.
+func WatchdogInterval(envKey string) time.Duration {
+	if v := os.Getenv(envKey); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 15 * time.Second
+}
+
+// StartWatchdog launches a goroutine that polls the collector process every
+// WatchdogInterval(envKey). On process death it calls RetrySpawn and updates
+// the current process. Returns a stop func that terminates the goroutine.
+func StartWatchdog(
+	initialProc *os.Process,
+	binPath, sessionID, projectDir string,
+	warnW io.Writer,
+	spawnFn func(string, string, string) (int, *os.Process, error),
+	envKey string,
+) func() {
+	done := make(chan struct{})
+
+	go func() {
+		ticker := time.NewTicker(WatchdogInterval(envKey))
+		defer ticker.Stop()
+		currentProc := initialProc
+
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				if err := currentProc.Signal(syscall.Signal(0)); err == nil {
+					continue // process still alive
+				}
+				fmt.Fprintf(warnW, "htmlgraph: warning: collector died (pid=%d), respawning...\n", currentProc.Pid)
+				port, newProc, _, spawnErr := RetrySpawn(binPath, sessionID, projectDir, 3, spawnFn, warnW)
+				if spawnErr != nil {
+					fmt.Fprintf(warnW, "htmlgraph: FATAL: collector respawn failed: %v\n", spawnErr)
+					return
+				}
+				WriteCollectorPID(projectDir, sessionID, newProc.Pid)
+				fmt.Fprintf(warnW, "htmlgraph: info: collector respawned (pid=%d port=%d)\n", newProc.Pid, port)
+				currentProc = newProc
+			}
+		}
+	}()
+
+	return func() { close(done) }
+}
+
+// startWatchdog is the method form of StartWatchdog, using opts from the receiver.
+func (c *ProcessCollector) startWatchdog(initialProc *os.Process, binPath, sessionID, projectDir string) func() {
+	spawnFn := c.opts.SpawnFn
+	if spawnFn == nil {
+		spawnFn = DefaultSpawnFn
+	}
+	return StartWatchdog(initialProc, binPath, sessionID, projectDir, c.opts.Stderr, spawnFn, c.opts.WatchdogIntervalEnv)
+}
+
+// RegisterCleanup returns a cleanup function that SIGTERMs the process, waits
+// up to 3s, then SIGKILLs, and removes the .collector-pid file.
+func RegisterCleanup(proc *os.Process, projectDir, sessionID string) func() {
+	go func() { _, _ = proc.Wait() }()
+
+	return func() {
+		_ = proc.Signal(syscall.SIGTERM)
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			if err := proc.Signal(syscall.Signal(0)); err != nil {
+				RemoveCollectorPID(projectDir, sessionID)
+				return // process exited
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		_ = proc.Kill()
+		RemoveCollectorPID(projectDir, sessionID)
+	}
+}
+
+// RemoveCollectorPID removes the .collector-pid file for a session.
+// Best-effort: missing file or unreadable directory is not an error.
+func RemoveCollectorPID(projectDir, sessionID string) {
+	pidPath := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID, ".collector-pid")
+	_ = os.Remove(pidPath)
+}
+
+// WriteCollectorPID writes the collector PID to the session directory.
+// Best-effort: errors are silently ignored.
+func WriteCollectorPID(projectDir, sessionID string, pid int) {
+	sessDir := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID)
+	_ = os.MkdirAll(sessDir, 0o755)
+	pidPath := filepath.Join(sessDir, ".collector-pid")
+	_ = os.WriteFile(pidPath, []byte(strconv.Itoa(pid)+"\n"), 0o644)
+}

--- a/internal/otel/collector/lifecycle.go
+++ b/internal/otel/collector/lifecycle.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -257,9 +258,11 @@ func StartWatchdog(
 
 // makeCleanup returns a function that stops the watchdog (waiting for it to
 // exit), then SIGTERMs the *current* process tracked by procPtr and waits up
-// to 3s before SIGKILL. PID file removal is handled by the per-process
-// reaper goroutine started in startReaper, which conditionally removes the
-// file only when its own PID still matches the file's contents.
+// to 3s before SIGKILL. After the kill path completes, cleanup itself calls
+// removeCollectorPIDIfMatches so the PID file is gone synchronously by
+// return time — the per-process reaper still does the same removal
+// asynchronously (idempotent), but cleanup callers should not have to
+// observe a brief stale window.
 func makeCleanup(
 	procPtr *atomic.Pointer[os.Process],
 	projectDir, sessionID string,
@@ -275,11 +278,13 @@ func makeCleanup(
 		deadline := time.Now().Add(3 * time.Second)
 		for time.Now().Before(deadline) {
 			if err := current.Signal(syscall.Signal(0)); err != nil {
-				return // process exited; its reaper will remove the PID file
+				removeCollectorPIDIfMatches(projectDir, sessionID, current.Pid)
+				return // process exited
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
 		_ = current.Kill()
+		removeCollectorPIDIfMatches(projectDir, sessionID, current.Pid)
 	}
 }
 
@@ -316,31 +321,105 @@ func newProcPointer(proc *os.Process) *atomic.Pointer[os.Process] {
 }
 
 // removeCollectorPIDIfMatches removes the .collector-pid file only when its
-// contents match the given PID. Used by the per-process reaper to avoid
-// deleting a fresher PID written by the watchdog after a respawn.
+// recorded PID matches the given pid. Used by the per-process reaper and by
+// makeCleanup to avoid deleting a fresher PID written by the watchdog after
+// a respawn.
 func removeCollectorPIDIfMatches(projectDir, sessionID string, pid int) {
 	pidPath := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID, ".collector-pid")
-	data, err := os.ReadFile(pidPath)
-	if err != nil {
-		return
-	}
-	got, err := strconv.Atoi(string(bytesTrimSpace(data)))
+	got, _, _, err := readCollectorPIDFile(pidPath)
 	if err != nil || got != pid {
 		return
 	}
 	_ = os.Remove(pidPath)
 }
 
-// bytesTrimSpace trims trailing whitespace without depending on the strings
-// package or copying the slice.
-func bytesTrimSpace(b []byte) []byte {
-	for len(b) > 0 && (b[len(b)-1] == '\n' || b[len(b)-1] == '\r' || b[len(b)-1] == ' ' || b[len(b)-1] == '\t') {
-		b = b[:len(b)-1]
+// readCollectorPIDFile parses a .collector-pid file. The file format is:
+//
+//	<pid>
+//	<starttime>     (optional second line — Linux clock-tick start time)
+//
+// Returns pid, starttime, hasStart=true when both lines parsed, or
+// hasStart=false for legacy single-line files.
+func readCollectorPIDFile(pidPath string) (pid int, starttime uint64, hasStart bool, err error) {
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		return 0, 0, false, err
 	}
-	for len(b) > 0 && (b[0] == '\n' || b[0] == '\r' || b[0] == ' ' || b[0] == '\t') {
-		b = b[1:]
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) == "" {
+		return 0, 0, false, fmt.Errorf("empty PID file: %s", pidPath)
 	}
-	return b
+	pid, err = strconv.Atoi(strings.TrimSpace(lines[0]))
+	if err != nil {
+		return 0, 0, false, fmt.Errorf("parse pid %q: %w", lines[0], err)
+	}
+	if len(lines) >= 2 {
+		if st, perr := strconv.ParseUint(strings.TrimSpace(lines[1]), 10, 64); perr == nil {
+			return pid, st, true, nil
+		}
+	}
+	return pid, 0, false, nil
+}
+
+// readProcStartTime returns the process start time from /proc/<pid>/stat
+// field 22 (clock ticks since boot). Returns ok=false on non-Linux systems
+// or when the proc entry is unreadable. Used for PID-reuse detection.
+func readProcStartTime(pid int) (uint64, bool) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, false
+	}
+	s := string(data)
+	// Field 2 (comm) is wrapped in parens and may itself contain spaces or
+	// parens. Split after the LAST closing paren.
+	idx := strings.LastIndex(s, ")")
+	if idx < 0 || idx+1 >= len(s) {
+		return 0, false
+	}
+	fields := strings.Fields(s[idx+1:])
+	// Index 0 here corresponds to field 3 (state); field 22 (starttime) is
+	// at index 19 of this slice.
+	if len(fields) < 20 {
+		return 0, false
+	}
+	st, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return st, true
+}
+
+// IsCollectorAlive verifies the recorded collector PID is alive AND that
+// its process start time matches the value recorded at write-time, when
+// available. The start-time check protects against PID reuse on
+// long-running CI workers; on platforms where /proc is unavailable or
+// when the PID file predates the start-time format, the check falls back
+// to the PID-only Signal(0) probe.
+//
+// sessDir is the absolute path to the session directory (typically
+// <project>/.htmlgraph/sessions/<sid>) — the function looks for
+// .collector-pid inside it. Returns (alive=false, pid=0) when the file
+// is missing or unreadable.
+func IsCollectorAlive(sessDir string) (alive bool, pid int) {
+	pid, recordedStart, hasStart, err := readCollectorPIDFile(filepath.Join(sessDir, ".collector-pid"))
+	if err != nil {
+		return false, 0
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false, pid
+	}
+	if proc.Signal(syscall.Signal(0)) != nil {
+		return false, pid
+	}
+	if !hasStart {
+		return true, pid // legacy file or non-Linux at write-time
+	}
+	actualStart, ok := readProcStartTime(pid)
+	if !ok {
+		return true, pid // /proc unavailable at read-time (non-Linux)
+	}
+	return actualStart == recordedStart, pid
 }
 
 // RemoveCollectorPID removes the .collector-pid file for a session.
@@ -354,10 +433,19 @@ func RemoveCollectorPID(projectDir, sessionID string) {
 }
 
 // WriteCollectorPID writes the collector PID to the session directory.
+// On Linux, also appends the process start time (clock ticks from
+// /proc/<pid>/stat field 22) on a second line so future liveness checks
+// can detect PID reuse. On non-Linux or when /proc is unreadable, only
+// the PID is written; consumers must tolerate single-line files.
+//
 // Best-effort: errors are silently ignored.
 func WriteCollectorPID(projectDir, sessionID string, pid int) {
 	sessDir := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID)
 	_ = os.MkdirAll(sessDir, 0o755)
 	pidPath := filepath.Join(sessDir, ".collector-pid")
-	_ = os.WriteFile(pidPath, []byte(strconv.Itoa(pid)+"\n"), 0o644)
+	content := strconv.Itoa(pid) + "\n"
+	if start, ok := readProcStartTime(pid); ok {
+		content += strconv.FormatUint(start, 10) + "\n"
+	}
+	_ = os.WriteFile(pidPath, []byte(content), 0o644)
 }

--- a/internal/otel/collector/lifecycle.go
+++ b/internal/otel/collector/lifecycle.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -263,28 +264,35 @@ func StartWatchdog(
 // return time — the per-process reaper still does the same removal
 // asynchronously (idempotent), but cleanup callers should not have to
 // observe a brief stale window.
+//
+// The returned function is wrapped in sync.Once so callers may safely
+// invoke it multiple times — for example, both via `defer cleanup()` and
+// via an explicit pre-os.Exit call (since os.Exit bypasses defers).
 func makeCleanup(
 	procPtr *atomic.Pointer[os.Process],
 	projectDir, sessionID string,
 	stopWatchdog func(),
 ) func() {
+	var once sync.Once
 	return func() {
-		stopWatchdog() // blocks until watchdog goroutine exits
-		current := procPtr.Load()
-		if current == nil {
-			return
-		}
-		_ = current.Signal(syscall.SIGTERM)
-		deadline := time.Now().Add(3 * time.Second)
-		for time.Now().Before(deadline) {
-			if err := current.Signal(syscall.Signal(0)); err != nil {
-				removeCollectorPIDIfMatches(projectDir, sessionID, current.Pid)
-				return // process exited
+		once.Do(func() {
+			stopWatchdog() // blocks until watchdog goroutine exits
+			current := procPtr.Load()
+			if current == nil {
+				return
 			}
-			time.Sleep(100 * time.Millisecond)
-		}
-		_ = current.Kill()
-		removeCollectorPIDIfMatches(projectDir, sessionID, current.Pid)
+			_ = current.Signal(syscall.SIGTERM)
+			deadline := time.Now().Add(3 * time.Second)
+			for time.Now().Before(deadline) {
+				if err := current.Signal(syscall.Signal(0)); err != nil {
+					removeCollectorPIDIfMatches(projectDir, sessionID, current.Pid)
+					return // process exited
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+			_ = current.Kill()
+			removeCollectorPIDIfMatches(projectDir, sessionID, current.Pid)
+		})
 	}
 }
 

--- a/internal/otel/collector/lifecycle.go
+++ b/internal/otel/collector/lifecycle.go
@@ -333,13 +333,21 @@ func removeCollectorPIDIfMatches(projectDir, sessionID string, pid int) {
 	_ = os.Remove(pidPath)
 }
 
-// readCollectorPIDFile parses a .collector-pid file. The file format is:
+// ReadCollectorPIDFile parses a .collector-pid file. The file format is:
 //
 //	<pid>
 //	<starttime>     (optional second line — Linux clock-tick start time)
 //
 // Returns pid, starttime, hasStart=true when both lines parsed, or
-// hasStart=false for legacy single-line files.
+// hasStart=false for legacy single-line files. Exported so callers
+// outside this package (e.g. cmd/htmlgraph status surfaces) can parse
+// the PID file consistently with the writer.
+func ReadCollectorPIDFile(pidPath string) (pid int, starttime uint64, hasStart bool, err error) {
+	return readCollectorPIDFile(pidPath)
+}
+
+// readCollectorPIDFile is the internal implementation used by
+// removeCollectorPIDIfMatches and IsCollectorAlive.
 func readCollectorPIDFile(pidPath string) (pid int, starttime uint64, hasStart bool, err error) {
 	data, err := os.ReadFile(pidPath)
 	if err != nil {

--- a/internal/otel/collector/lifecycle_test.go
+++ b/internal/otel/collector/lifecycle_test.go
@@ -55,6 +55,33 @@ func TestProcessCollector_Spawn_Success(t *testing.T) {
 	cleanup()
 }
 
+// TestProcessCollector_Spawn_CleanupIdempotent verifies that calling the
+// returned cleanup multiple times is safe — required because os.Exit in
+// the launcher bypasses deferred cleanups, so the launcher calls cleanup
+// explicitly before os.Exit while still leaving the deferred call in
+// place for non-os.Exit paths.
+func TestProcessCollector_Spawn_CleanupIdempotent(t *testing.T) {
+	var buf bytes.Buffer
+	lc := collector.NewProcessCollector(collector.ProcessCollectorOpts{
+		Stderr: &buf,
+		SpawnFn: func(binPath, sessionID, projectDir string, requestedPort int) (int, *os.Process, error) {
+			return 7777, startSleepProc(t), nil
+		},
+	})
+
+	_, cleanup, err := lc.Spawn("/fake/bin", "test-sess-idempotent", t.TempDir())
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("cleanup should be non-nil on success")
+	}
+
+	// Call cleanup twice — second call must be a no-op, not panic.
+	cleanup()
+	cleanup()
+}
+
 // TestProcessCollector_Spawn_RetriesOnTransientFailure verifies that when the
 // fake SpawnFn fails on the first 2 calls and succeeds on the 3rd, Spawn
 // returns success and stderr has captured 2 warning lines.

--- a/internal/otel/collector/lifecycle_test.go
+++ b/internal/otel/collector/lifecycle_test.go
@@ -1,0 +1,125 @@
+package collector_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/shakestzd/htmlgraph/internal/otel/collector"
+)
+
+// startSleepProc starts a long-lived /bin/sh sleep process for test injection.
+func startSleepProc(t *testing.T) *os.Process {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", "-c", "sleep 60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep proc: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() })
+	return cmd.Process
+}
+
+// TestProcessCollector_Spawn_Success injects a fake SpawnFn returning
+// (port=12345, a real sleep process, nil). Asserts port=12345 and cleanup is
+// non-nil. Calls cleanup and asserts no panic.
+func TestProcessCollector_Spawn_Success(t *testing.T) {
+	var buf bytes.Buffer
+	lc := collector.NewProcessCollector(collector.ProcessCollectorOpts{
+		Stderr: &buf,
+		SpawnFn: func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+			return 12345, startSleepProc(t), nil
+		},
+	})
+
+	projectDir := t.TempDir()
+	port, cleanup, err := lc.Spawn("/fake/bin", "test-sess-success", projectDir)
+	if err != nil {
+		t.Fatalf("Spawn returned unexpected error: %v", err)
+	}
+	if port != 12345 {
+		t.Errorf("port = %d, want 12345", port)
+	}
+	if cleanup == nil {
+		t.Fatal("cleanup should be non-nil on success")
+	}
+
+	// cleanup must not panic
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("cleanup panicked: %v", r)
+		}
+	}()
+	cleanup()
+}
+
+// TestProcessCollector_Spawn_RetriesOnTransientFailure verifies that when the
+// fake SpawnFn fails on the first 2 calls and succeeds on the 3rd, Spawn
+// returns success and stderr has captured 2 warning lines.
+func TestProcessCollector_Spawn_RetriesOnTransientFailure(t *testing.T) {
+	var buf bytes.Buffer
+	callCount := 0
+
+	lc := collector.NewProcessCollector(collector.ProcessCollectorOpts{
+		Stderr: &buf,
+		SpawnFn: func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+			callCount++
+			if callCount < 3 {
+				return 0, nil, fmt.Errorf("transient error attempt %d", callCount)
+			}
+			return 9001, startSleepProc(t), nil
+		},
+	})
+
+	projectDir := t.TempDir()
+	port, cleanup, err := lc.Spawn("/fake/bin", "test-sess-retry", projectDir)
+	if err != nil {
+		t.Fatalf("expected success on 3rd attempt, got: %v", err)
+	}
+	if port != 9001 {
+		t.Errorf("port = %d, want 9001", port)
+	}
+	if cleanup != nil {
+		cleanup()
+	}
+
+	stderr := buf.String()
+	warnCount := strings.Count(stderr, "htmlgraph: warning: collector spawn attempt")
+	if warnCount != 2 {
+		t.Errorf("expected 2 warning lines, got %d; stderr=%q", warnCount, stderr)
+	}
+}
+
+// TestProcessCollector_Spawn_FailsAfterMaxRetries verifies that when all
+// spawn attempts fail, Spawn returns a non-nil error and stderr has a FATAL line.
+func TestProcessCollector_Spawn_FailsAfterMaxRetries(t *testing.T) {
+	var buf bytes.Buffer
+	callCount := 0
+
+	lc := collector.NewProcessCollector(collector.ProcessCollectorOpts{
+		Stderr: &buf,
+		SpawnFn: func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+			callCount++
+			return 0, nil, fmt.Errorf("persistent failure attempt %d", callCount)
+		},
+	})
+
+	projectDir := t.TempDir()
+	port, cleanup, err := lc.Spawn("/fake/bin", "test-sess-allfail", projectDir)
+	if err == nil {
+		t.Fatal("expected error when all spawn attempts fail, got nil")
+	}
+	if port != 0 {
+		t.Errorf("port = %d, want 0 on failure", port)
+	}
+	if cleanup != nil {
+		t.Error("cleanup should be nil on failure")
+	}
+
+	stderr := buf.String()
+	if !strings.Contains(stderr, "FATAL") {
+		t.Errorf("expected FATAL line in stderr, got: %q", stderr)
+	}
+}

--- a/internal/otel/collector/lifecycle_test.go
+++ b/internal/otel/collector/lifecycle_test.go
@@ -29,7 +29,7 @@ func TestProcessCollector_Spawn_Success(t *testing.T) {
 	var buf bytes.Buffer
 	lc := collector.NewProcessCollector(collector.ProcessCollectorOpts{
 		Stderr: &buf,
-		SpawnFn: func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+		SpawnFn: func(binPath, sessionID, projectDir string, requestedPort int) (int, *os.Process, error) {
 			return 12345, startSleepProc(t), nil
 		},
 	})
@@ -64,7 +64,7 @@ func TestProcessCollector_Spawn_RetriesOnTransientFailure(t *testing.T) {
 
 	lc := collector.NewProcessCollector(collector.ProcessCollectorOpts{
 		Stderr: &buf,
-		SpawnFn: func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+		SpawnFn: func(binPath, sessionID, projectDir string, requestedPort int) (int, *os.Process, error) {
 			callCount++
 			if callCount < 3 {
 				return 0, nil, fmt.Errorf("transient error attempt %d", callCount)
@@ -100,7 +100,7 @@ func TestProcessCollector_Spawn_FailsAfterMaxRetries(t *testing.T) {
 
 	lc := collector.NewProcessCollector(collector.ProcessCollectorOpts{
 		Stderr: &buf,
-		SpawnFn: func(binPath, sessionID, projectDir string) (int, *os.Process, error) {
+		SpawnFn: func(binPath, sessionID, projectDir string, requestedPort int) (int, *os.Process, error) {
 			callCount++
 			return 0, nil, fmt.Errorf("persistent failure attempt %d", callCount)
 		},

--- a/internal/otel/receiver/receiver.go
+++ b/internal/otel/receiver/receiver.go
@@ -97,6 +97,8 @@ type Receiver struct {
 func New(cfg Config, s sink.SignalSink) (*Receiver, error) {
 	r := &Receiver{cfg: cfg, sink: s, registry: adapter.NewRegistry()}
 	r.registry.Register(adapter.NewClaudeAdapter())
+	r.registry.Register(adapter.NewCodexAdapter())
+	r.registry.Register(adapter.NewGeminiAdapter())
 
 	if !cfg.Enabled {
 		return r, nil

--- a/internal/otel/signal.go
+++ b/internal/otel/signal.go
@@ -110,6 +110,21 @@ func (t TokenCounts) Total() int64 {
 // SignalID must be stable across retries so duplicate OTLP exports don't
 // double-count. Convention: the receiver derives it from a hash of
 // (resource, scope, name, timestamp, sorted attributes).
+//
+// Canonical attribute mapping by harness (all adapters must populate
+// Harness, SessionID, and CanonicalName on every signal):
+//
+//	Claude  service.name=claude-code   session.id      → SessionID
+//	Codex   service.name=codex-cli     conversation.id → SessionID
+//	Gemini  service.name=gemini-cli    session.id      → SessionID
+//
+//	PromptID sources:
+//	  Claude  prompt.id (signal attr)
+//	  Codex   gen_ai.prompt_id (signal attr); synthesized from conversation.id+seq when absent
+//	  Gemini  gen_ai.prompt_id (signal attr)
+//
+// SessionID falls back to the resource-level attribute when absent from
+// the signal-level attributes (cardinality-controlled metrics omit it).
 type UnifiedSignal struct {
 	// identity
 	Harness        Harness

--- a/internal/otel/signal.go
+++ b/internal/otel/signal.go
@@ -120,7 +120,10 @@ func (t TokenCounts) Total() int64 {
 //
 //	PromptID sources:
 //	  Claude  prompt.id (signal attr)
-//	  Codex   gen_ai.prompt_id (signal attr); synthesized from conversation.id+seq when absent
+//	  Codex   gen_ai.prompt_id (signal attr); empty when absent — Codex does
+//	          not emit a stable per-prompt ID on every signal, so callers
+//	          needing prompt-level correlation must group by
+//	          (SessionID, Timestamp window).
 //	  Gemini  gen_ai.prompt_id (signal attr)
 //
 // SessionID falls back to the resource-level attribute when absent from
@@ -137,7 +140,7 @@ type UnifiedSignal struct {
 
 	// correlation (normalized across harnesses)
 	SessionID  string // Claude session.id | Codex conversation_id | Gemini session.id
-	PromptID   string // Claude prompt.id | Codex synthesized | Gemini prompt_id
+	PromptID   string // Claude prompt.id | Codex gen_ai.prompt_id (empty when absent) | Gemini gen_ai.prompt_id
 	TraceID    string // W3C hex, unmodified
 	SpanID     string
 	ParentSpan string


### PR DESCRIPTION
## Summary

Hardens the per-session OTel collector that was introduced in plan-1cd284e0 and extends it to Codex CLI and Gemini CLI. Motivating incident: bug-28a9d7a7 (collector silently timed out at handshake, no operator-visible signal).

The work was split from the meta-feature `feat-ac7532be` into 11 child features dispatched through `htmlgraph:execute` with explicit `blocked_by` edges, plus several roborev-driven follow-up fixes. All quality gates (`go build && go vet && go test`) pass on every commit.

## What this branch delivers

**Collector lifecycle, extracted and hardened** (`internal/otel/collector/lifecycle.go`)
- New `Lifecycle` interface with a single concrete `ProcessCollector` implementation. All three harness launchers go through it.
- Retry with 100/300/700ms backoff (RESILIENCE-2).
- Fail-loud spawn gated on \`HTMLGRAPH_OTEL_STRICT=1\` (RESILIENCE-1).
- Watchdog goroutine that respawns on the **same port** so the harness's OTLP endpoint stays valid across restarts; configurable via \`HTMLGRAPH_OTEL_WATCHDOG_INTERVAL\` (RESILIENCE-3 + roborev fix).
- Cleanup tracking via \`atomic.Pointer[*os.Process]\` so the launcher's cleanup terminates whichever collector the watchdog has rotated to (roborev fix).
- Per-process reaper goroutines that conditionally remove \`.collector-pid\` only when the file's contents still match the reaped PID — race-safe across watchdog respawns and idle exits (roborev fix).
- \`sync.Once\`-wrapped cleanup so deferred + explicit + signal-handler invocations are all safe (roborev fix).
- Process-identity check via \`/proc/<pid>/stat\` start-time so PID reuse on long-running CI workers is detected (roborev fix).

**Multi-harness support**
- New \`internal/otel/adapter/codex.go\` and \`internal/otel/adapter/gemini.go\` adapters mapping \`service.name=codex-cli\`/\`gemini-cli\` and their respective session attributes (\`conversation.id\` / \`session.id\`) into \`UnifiedSignal\` (SCHEMA-1).
- Both adapters registered in the per-session collector mux and the global receiver (roborev fix).
- \`internal/otel/adapter/conformance_test.go\` parameterizes 20 tests across all three adapters covering Identify / Adapt / cross-rejection / resource fallback.
- Canonical attribute mapping table documented in the \`UnifiedSignal\` doc comment.

**Harness launchers** (\`htmlgraph claude/codex/gemini\`)
- \`cmd/htmlgraph/codex_launch.go\` and \`cmd/htmlgraph/gemini_launch.go\` spawn per-session collectors and inject \`OTEL_EXPORTER_OTLP_ENDPOINT\` / \`GEMINI_TELEMETRY_*\` env vars (CODEX-1, GEMINI-1).
- New \`cmd/htmlgraph/launch_run.go:runHarnessWithCleanup\` centralizes the run-with-cleanup pattern: \`signal.Notify\` for SIGINT/SIGTERM, child reap, cleanup invocation, and signal re-raise for 128+signum POSIX exit semantics — including the case where the child is signal-killed before the parent observes the signal (roborev fix).

**Operator surface**
- \`GET /api/otel/status\` endpoint and \`Collector health:\` block in \`htmlgraph status\` showing pid / port / alive / uptime per session (STATUS-1).
- Path-traversal validation on the \`?session=\` query parameter (roborev fix).

**Tests**
- \`cmd/htmlgraph/multiharness_test.go\` end-to-end POSTs Codex / Gemini / Claude payloads through the per-session collector mux and verifies harness routing into the NDJSON sink (TEST-2).
- \`internal/otel/collector/lifecycle_test.go\` covers spawn / retry / cleanup-idempotency at the lifecycle boundary.
- \`cmd/htmlgraph/launch_run_test.go\` covers the launch-helper including the child-signaled regression test from roborev job 102.

**Documentation**
- \`docs/adr-001-harness-agnostic-collector.md\` captures the cross-cutting decisions: \`Lifecycle\` interface choice, launcher-vs-hook spawn tradeoff, canonical attribute mapping, resilience model, future work, implementation history.

## Roborev review history

This branch went through five roborev branch reviews (jobs 82, 91, 96, 98, 100, 102), each of which surfaced findings that were addressed in the subsequent commits. The remaining LOW findings in the latest review are both on \`.htmlgraph/plans/plan-4458a4f0.yaml\` — out of this branch's scope (a separate plan owned by a different feature).

## Implementation history

| Wave | Feature | Slice | Commit |
|------|---------|-------|--------|
| 1 | feat-75426991 | SCHEMA-1 — canonical attrs + Codex/Gemini adapters | \`ad7b335a\` |
| 1 | feat-dcf3d618 | RESILIENCE-1 — fail-loud spawn | \`e6815d7e\` |
| 1 | feat-1c3ebad9 | STATUS-1 — collector health surface | \`4f09f824\` |
| — | feat-ac7532be | Wave 1 roborev fixes | \`54b34896\` |
| 2 | feat-6286f19f | RESILIENCE-2 — retry with backoff | \`49d6d12a\` |
| 3 | feat-7b195a56 | RESILIENCE-3 — watchdog respawn | \`08878da2\` |
| 4 | feat-35519ac2 | REFACTOR-1 — extract \`CollectorLifecycle\` | \`1cd3a153\`, \`65641657\` |
| — | feat-e195d658 | TEST-1 — closed without dispatch (covered by existing tests) | — |
| 5 | feat-9104fb56 | CODEX-1 — Codex launcher | \`a7d5e91d\` |
| 5 | feat-7b094d00 | GEMINI-1 — Gemini launcher | \`c5a174a7\` |
| 6 | feat-c6b3d956 | TEST-2 — multi-harness ingestion test | \`600918ac\` |
| 7 | feat-bc3c0067 | DOC-1 — ADR | \`6baef7b1\` |
| — | feat-ac7532be | Branch-review fixes (port-stable respawn, cleanup tracking, PID identity, signal handling, etc.) | \`196fd016\`, \`29329c18\`, \`2bdf62f2\`, \`dc185548\`, \`99fe015f\`, \`7305a296\` |

The branch also includes earlier plan-artifact commits from \`plan-4458a4f0\` and \`plan-81a924f6\` that were already on \`trk-cb36e595\` before this work began.

## Test plan

- [ ] \`go build ./...\` passes
- [ ] \`go vet ./...\` passes (project pre-commit hook ran on every commit)
- [ ] \`go test ./...\` passes
- [ ] \`htmlgraph claude\` continues to spawn its per-session collector and shows \`alive=true\` in \`htmlgraph status\`
- [ ] \`htmlgraph codex\` spawns a per-session collector and emits Codex OTel through it (manual; depends on local \`codex\` install)
- [ ] \`htmlgraph gemini\` spawns a per-session collector and emits Gemini OTel through it (manual; depends on local \`gemini\` install)
- [ ] Watchdog respawn preserves the port — kill the collector mid-session, verify \`htmlgraph status\` reflects the new PID on the same port and OTel traffic resumes
- [ ] Ctrl-C the launcher; verify the per-session collector is reaped and \`.collector-pid\` is removed
- [ ] \`/api/otel/status\` returns valid JSON for an active session and 400 for a path-traversal attempt