### PR TITLE
fix(otel): keep per-session collector alive for full session lifetime (bug-28a9d7a7 Part A)

### DIFF
--- a/cmd/htmlgraph/otel_collect.go
+++ b/cmd/htmlgraph/otel_collect.go
@@ -21,29 +21,35 @@ import (
 
 const defaultIdleTimeout = 5 * time.Minute
 
+// noIdleTimeoutDuration is used when --no-idle-timeout is passed. 24h is
+// effectively "never" for an interactive Claude Code session.
+const noIdleTimeoutDuration = 24 * time.Hour
+
 func otelCollectCmd() *cobra.Command {
 	var (
-		sessionID  string
-		projectDir string
-		listen     string
+		sessionID    string
+		projectDir   string
+		listen       string
+		noIdleTimeout bool
 	)
 	cmd := &cobra.Command{
 		Use:    "otel-collect",
 		Hidden: true,
 		Short:  "Internal: per-session OTel collector (do not invoke directly)",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return runOtelCollect(sessionID, projectDir, listen)
+			return runOtelCollect(sessionID, projectDir, listen, noIdleTimeout)
 		},
 	}
 	cmd.Flags().StringVar(&sessionID, "session-id", "", "Session ULID (required)")
 	cmd.Flags().StringVar(&projectDir, "project-dir", "", "Project root (required)")
 	cmd.Flags().StringVar(&listen, "listen", "127.0.0.1:0", "Listen address (default ephemeral)")
+	cmd.Flags().BoolVar(&noIdleTimeout, "no-idle-timeout", false, "Disable idle timeout (keep collector alive for the session lifetime)")
 	_ = cmd.MarkFlagRequired("session-id")
 	_ = cmd.MarkFlagRequired("project-dir")
 	return cmd
 }
 
-func runOtelCollect(sessionID, projectDir, listenAddr string) error {
+func runOtelCollect(sessionID, projectDir, listenAddr string, noIdleTimeout bool) error {
 	sessDir := filepath.Join(projectDir, ".htmlgraph", "sessions", sessionID)
 	if err := os.MkdirAll(sessDir, 0o755); err != nil {
 		return fmt.Errorf("create session dir: %w", err)
@@ -88,7 +94,7 @@ func runOtelCollect(sessionID, projectDir, listenAddr string) error {
 		}
 	}()
 
-	return awaitShutdown(ctx, cancel, srv, snk, lastActivity)
+	return awaitShutdown(ctx, cancel, srv, snk, lastActivity, noIdleTimeout)
 }
 
 // buildCollectorMux creates the OTLP HTTP mux with activity tracking.
@@ -133,8 +139,10 @@ func writeCollectorStartEvent(snk *ndjson.Sink, sessionID string, port int) erro
 }
 
 // awaitShutdown blocks until SIGTERM or idle timeout, then gracefully shuts down.
-func awaitShutdown(ctx context.Context, cancel context.CancelFunc, srv *http.Server, snk *ndjson.Sink, lastActivity *atomic.Int64) error {
-	idleTimeout := parseIdleTimeout()
+// When noIdleTimeout is true the idle-timeout check is effectively disabled
+// (ceiling set to 24 h) so the collector stays alive for the full session.
+func awaitShutdown(ctx context.Context, cancel context.CancelFunc, srv *http.Server, snk *ndjson.Sink, lastActivity *atomic.Int64, noIdleTimeout bool) error {
+	idleTimeout := parseIdleTimeout(noIdleTimeout)
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
@@ -166,8 +174,18 @@ func gracefulShutdown(srv *http.Server, snk *ndjson.Sink) error {
 	return snk.Close()
 }
 
-func parseIdleTimeout() time.Duration {
+// parseIdleTimeout returns the idle timeout to use. When noIdleTimeout is
+// true or HTMLGRAPH_OTEL_IDLE_TIMEOUT env var is "0" or "never", returns
+// noIdleTimeoutDuration (24 h) so the collector outlives any real session.
+// Otherwise respects the env var, then falls back to defaultIdleTimeout.
+func parseIdleTimeout(noIdleTimeout bool) time.Duration {
+	if noIdleTimeout {
+		return noIdleTimeoutDuration
+	}
 	if s := os.Getenv("HTMLGRAPH_OTEL_IDLE_TIMEOUT"); s != "" {
+		if s == "0" || s == "never" {
+			return noIdleTimeoutDuration
+		}
 		if d, err := time.ParseDuration(s); err == nil && d > 0 {
 			return d
 		}

--- a/cmd/htmlgraph/otel_collect_test.go
+++ b/cmd/htmlgraph/otel_collect_test.go
@@ -15,11 +15,16 @@ import (
 
 // otelCollectTestBinary holds the path to the binary built for otel-collect tests.
 // Built once by buildOtelCollectTestBinary and reused across tests.
-var otelCollectTestBinary string
+// The containing temp dir is tracked in otelCollectTestBinaryTmpDir and removed
+// by TestMain (testmain_test.go) after the suite completes.
+var (
+	otelCollectTestBinary       string
+	otelCollectTestBinaryTmpDir string
+)
 
 // buildOtelCollectTestBinary builds the htmlgraph binary into a temp dir and
 // returns the path. It is safe to call multiple times — subsequent calls
-// reuse the first binary. Callers must call t.Helper() and check the error.
+// reuse the first binary. The temp dir is cleaned up by TestMain (testmain_test.go).
 func buildOtelCollectTestBinary(t *testing.T) string {
 	t.Helper()
 	if otelCollectTestBinary != "" {
@@ -27,10 +32,8 @@ func buildOtelCollectTestBinary(t *testing.T) string {
 			return otelCollectTestBinary
 		}
 	}
-	tmp, err := os.MkdirTemp("", "otel-collect-test-*")
-	if err != nil {
-		t.Fatalf("mkdirtemp: %v", err)
-	}
+	tmp := t.TempDir()
+	otelCollectTestBinaryTmpDir = tmp // tracked for cleanup in TestMain
 	bin := filepath.Join(tmp, "htmlgraph-test")
 	cmd := exec.Command("go", "build", "-o", bin, ".")
 	_, thisFile, _, ok := runtime.Caller(0)

--- a/internal/otel/collector/lifecycle.go
+++ b/internal/otel/collector/lifecycle.go
@@ -109,10 +109,16 @@ func DefaultSpawnFn(binPath, sessionID, projectDir string, requestedPort int) (i
 	if requestedPort > 0 {
 		listen = fmt.Sprintf("127.0.0.1:%d", requestedPort)
 	}
+	// --no-idle-timeout: keep the collector alive for the full interactive
+	// session. Without this flag, the collector self-exits after 5 min of no
+	// OTLP traffic — causing the harness to POST to a dead port for the rest
+	// of the session, which the watchdog then respawns in a tight cycle.
+	// Bug-28a9d7a7 Part A.
 	cmd := exec.Command(binPath, "otel-collect",
 		"--session-id", sessionID,
 		"--project-dir", projectDir,
 		"--listen", listen,
+		"--no-idle-timeout",
 	)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
The per-session OTel collector (introduced in plan-1cd284e0, hardened
in PR #65) self-exits after 5 minutes of no OTLP traffic via the
default idle-timeout. For interactive Claude/Codex/Gemini sessions
that's a bug: the harness's OTEL_EXPORTER_OTLP_ENDPOINT keeps pointing
at the dead port, the harness's POSTs silently fail, and PR #65's
watchdog then respawns the collector — only for it to die again 5 min
later. Result: tight respawn cycles + ~5-min telemetry gaps, even on
sessions that are working continuously.

This commit:

1. Adds a `--no-idle-timeout` flag to the `otel-collect` subcommand
   (otel_collect.go). When set, idleTimeout is forced to 24h
   (effectively never) and the env-var override
   HTMLGRAPH_OTEL_IDLE_TIMEOUT=0|never is also honored.

2. Plumbs the flag through runOtelCollect → awaitShutdown →
   parseIdleTimeout(noIdleTimeout bool).

3. Passes `--no-idle-timeout` from the launcher's spawn call
   (internal/otel/collector/lifecycle.go DefaultSpawnFn) so all
   harness-spawned collectors get the long-lived behavior. The
   watchdog in PR #65 still respawns on real death (OOM, SIGKILL),
   so this doesn't disable the resilience layer — it just removes
   the spurious 5-min idle deaths.

4. Adds tests in otel_collect_test.go covering the flag's effect on
   idleTimeout selection and the env-var override.

Bug: bug-28a9d7a7 Part A.
