### PR TITLE
docs: correct SQLite read-index path in AGENTS.md (bug-4d3c3139)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Local-first observability and coordination platform for AI-assisted development.
 | Layer | Role |
 |-------|------|
 | `.htmlgraph/*.html` | Canonical store — single source of truth |
-| SQLite (`.htmlgraph/htmlgraph.db`) | Read index for queries and dashboard |
+| SQLite (`~/.cache/htmlgraph/<path-hash>/htmlgraph.db`) | Per-user read index for queries and dashboard (derived; not committed) |
 | Go binary (`htmlgraph`) | CLI + hook handler |
 
 ## For AI Agents


### PR DESCRIPTION
The architecture table described the read-index DB at
`.htmlgraph/htmlgraph.db`, but that path was retired when the cache-dir
migration moved it to `~/.cache/htmlgraph/<path-hash>/htmlgraph.db`
(see internal/storage/dbpath.go which uses os.UserCacheDir(); the
LegacyProjectDBPaths helper still handles the in-tree location for
migration). The stale doc surfaced during a debugging session — when
the local DB went missing, the architecture text pointed at a path
that no longer existed.

CLAUDE.md inherits this section via @AGENTS.md, so a single edit fixes
both surfaces.

Bug: bug-4d3c3139
