### PR TITLE
chore(htmlgraph): capture work-item records from parallel YOLO session

### DIFF
--- a/.htmlgraph/bugs/bug-28a9d7a7.html
+++ b/.htmlgraph/bugs/bug-28a9d7a7.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="high"
              data-created="2026-04-26T12:39:31.284862"
-             data-updated="2026-04-26T18:41:12.858039" data-agent-assigned="claude-code" data-track-id="trk-c4615ad2">
+             data-updated="2026-04-29T15:23:48.655047" data-agent-assigned="claude-code" data-track-id="trk-c4615ad2">
 
         <header>
             <h1>Session OTel collector dies mid-session and is duplicated by _serve-child receiver</h1>
@@ -24,6 +24,12 @@
         </header>
 
         <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-c4615ad2.html" data-relationship="part_of" data-since="2026-04-26T12:39:31.292788">trk-c4615ad2</a></li>
+                </ul>
+            </section>
             <section data-edge-type="relates_to">
                 <h3>Relates To:</h3>
                 <ul>
@@ -43,12 +49,6 @@
                     <li><a href="bug-4697c62c.html" data-relationship="caused_by" data-since="2026-04-26T12:39:31.289337">bug-4697c62c</a></li>
                 </ul>
             </section>
-            <section data-edge-type="part_of">
-                <h3>Part Of:</h3>
-                <ul>
-                    <li><a href="trk-c4615ad2.html" data-relationship="part_of" data-since="2026-04-26T12:39:31.292788">trk-c4615ad2</a></li>
-                </ul>
-            </section>
         </nav>
 
         <section data-steps>
@@ -65,6 +65,7 @@
                 <li data-completed="false" data-step-id="step-bug-28a9d7a7-8">⏳ Step 9: Quality gates. Run in order, fix any failure before proceeding: (a) go build ./... (b) go vet ./... (c) go test -count=1 -timeout 180s ./... (d) go test -count=3 -timeout 120s -run &#39;TestPlanLifecycle_NoSlices|TestAutocommitPlan&#39; ./cmd/htmlgraph/ — regression guard against the bug-de827cbf hang.</li>
                 <li data-completed="false" data-step-id="step-bug-28a9d7a7-9">⏳ Step 10: Stage only the files touched in steps 2 and 4-8 (use git add with explicit paths, not git add -A — the working tree contains many unrelated modifications). Commit with message: &#39;refactor(otel): remove orphaned server-based receiver, keep session-scoped collector (bug-28a9d7a7)&#39;. Body should explain that the runtime path was already removed and this commit deletes the dead code &#43; stale comments. Do NOT push. Do NOT use --no-verify. Do NOT add Co-Authored-By lines.</li>
                 <li data-completed="false" data-step-id="step-bug-28a9d7a7-10">⏳ SCOPE CHANGE 2026-04-26: User chose Option C (durable refactor — collector and indexer share one canonical writer) over the minimal rip-out. Additionally, phase 2 of OTel migration aims to reduce/eliminate SQLite dependence. Steps 1-10 above are SUPERSEDED — do not execute as written. New plan pending; will be tracked under a new feature scoped to the OTel track (trk-c4615ad2). This bug remains in-progress as the trigger but execution will move to the new feature once planned.</li>
+                <li data-completed="false" data-step-id="step-bug-28a9d7a7-11">⏳ FINDING 1 — Collector never started for pid 58306: spawnCollector failed silently at startup (non-fatal path), leaving no session dir under .htmlgraph/sessions/ newer than 06:00; the 06:34 session has zero .collector-pid file and pid 31202 (the 06:00 session&#39;s collector) is already dead. Root guard at claude.go:500 checks opts.ProjectRoot != &#39;&#39; and !isExplicitlyDisabled(HTMLGRAPH_OTEL_ENABLED) — both pass for --dev mode — so spawn was attempted but spawnCollector returned otelEnvOverrides{} (zero-value) on failure, silently skipping the collector without any user-visible error beyond a stderr warning.</li>
             </ol>
         </section>
 

--- a/.htmlgraph/bugs/bug-4d3c3139.html
+++ b/.htmlgraph/bugs/bug-4d3c3139.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Stale docs: DB path moved from .htmlgraph/ to user cache</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-4d3c3139"
+             data-type="bug"
+             data-status="done"
+             data-priority="medium"
+             data-created="2026-04-29T14:57:51.979144"
+             data-updated="2026-04-29T14:58:00.57508" data-agent-assigned="claude-code" data-track-id="trk-0677c709">
+
+        <header>
+            <h1>Stale docs: DB path moved from .htmlgraph/ to user cache</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-0677c709.html" data-relationship="part_of" data-since="2026-04-29T14:57:51.984691">trk-0677c709</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>AGENTS.md and CLAUDE.md still show SQLite at .htmlgraph/htmlgraph.db; actual implementation in internal/storage/dbpath.go uses os.UserCacheDir()</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/bugs/bug-ccf8b887.html
+++ b/.htmlgraph/bugs/bug-ccf8b887.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Address PR #62 review feedback (registry hardening &#43; indexer removal)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-ccf8b887"
+             data-type="bug"
+             data-status="done"
+             data-priority="high"
+             data-created="2026-04-29T03:40:05.453146"
+             data-updated="2026-04-29T03:43:28.688959" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+
+        <header>
+            <h1>Address PR #62 review feedback (registry hardening &#43; indexer removal)</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-high">High Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="caused_by">
+                <h3>Caused By:</h3>
+                <ul>
+                    <li><a href="bug-cc41e3d2.html" data-relationship="caused_by" data-since="2026-04-29T03:40:05.463931">bug-cc41e3d2</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T03:40:05.470586">trk-cb36e595</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Review of PR #62 raised the following actionable items:
+
+1. SCOPE: PR bundles registry hardening (bug-cc41e3d2) AND NDJSON indexer removal (bug-28a9d7a7). Split into two PRs OR update PR title/summary to disclose the indexer removal.
+
+2. TITLE: 'concurrent writes' is overstated — no locking/CAS added, last-writer-wins still possible. Either add file locking OR soften the title. Also drop 'atomic write via temp-file+rename' from summary since that pre-existed.
+
+3. BUG: TestMain in worktree_helpers_test.go has 'defer os.RemoveAll' followed by 'os.Exit' — defers do NOT run after os.Exit. Fix: move cleanup before os.Exit so xdg-data/xdg-config tempdirs do not leak in /tmp.
+
+4. CONTRACT: registry.Save() now silently calls Prune(). Either rename to SaveAndPrune/Compact, OR beef up the godoc so the side-effect is unmissable.
+
+5. MIGRATION: DefaultPath() switch to honor XDG_DATA_HOME orphans existing registries when XDG_DATA_HOME points away from the legacy ~/.local/share path. Add legacy-path fallback + auto-migrate on next save.
+
+6. NIT: serve_parent runServeServer startup Load+Save rewrites the file even when nothing changed. Stat-then-skip if no pruning needed.
+
+7. NIT: withRegistryAtAndStale in projects_test.go re-implements the registry JSON format by hand. Schema drift will silently break it. Use a test-only helper on the registry package instead.
+
+8. TESTS: indexer removal in serve_child has no test asserting /api/indexer/status now 404s or that callers do not regress.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/bugs/bug-ff6a3286.html
+++ b/.htmlgraph/bugs/bug-ff6a3286.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Strip host paths at work-item HTML render time instead of allowlisting at commit gate</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-ff6a3286"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-04-29T00:11:20.284783"
+             data-updated="2026-04-29T00:11:20.293854" data-agent-assigned="claude-code" data-track-id="trk-0677c709">
+
+        <header>
+            <h1>Strip host paths at work-item HTML render time instead of allowlisting at commit gate</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-0677c709.html" data-relationship="part_of" data-since="2026-04-29T00:11:20.293691">trk-0677c709</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Commit 1aefbe08 widened scripts/host-paths-allowlist-patterns.conf from .htmlgraph/bugs/bug-7eda6bc4.html plus tracks/** to all .htmlgraph/{bugs,features,spikes,plans}/** because the work-item HTML rendered during a coordination session contained literal host paths from diagnostic output (Test tempdir paths, devcontainer absolute paths, user home references). The existing check-host-paths pre-commit gate flagged the sync commit; the workaround was an allowlist expansion. That is a precedent-extending workaround, not a fix.
+
+Real fix: scrub host paths at the render layer so they never land in committed HTML, regardless of what session events produced them. The gate then stays narrow and meaningful.
+
+Implementation surface (verify exact paths):
+- Template rendering for bugs/features/spikes/plans/tracks (likely internal/workitem and internal/plantmpl). Add a path-redaction pass over rendered description and event text fields before writing the HTML.
+- Replace absolute paths matching the gate's patterns (workspaces, home, Users, tmp, private/var) with either basenames, relative paths, or a redacted token.
+- Preserve readability: do NOT replace paths that are obviously documentation references like example tokens; only target paths that look real (have user-specific prefixes).
+- Update the existing host-path check pre-commit gate to be the safety net it was originally meant to be, not the routine fence we currently allowlist around.
+
+Acceptance:
+- Recreate a work-item that includes a session log with host paths in descriptions or event text. Render it. Inspect the HTML. No matches for the gate patterns.
+- Narrow scripts/host-paths-allowlist-patterns.conf back to the original narrow set (bug-7eda6bc4.html plus tracks/**). Commit a fresh state-sync commit. Pre-commit gate passes without allowlist help.
+
+Background: this would not have surfaced without the cumulative session activity that landed lots of diagnostic output into work-item bodies. Other contributors could hit this too; it is a launch-readiness concern even though the immediate symptom is masked.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-09024fb0.html
+++ b/.htmlgraph/features/feat-09024fb0.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Draft v2 plan-system follow-up plans (compression&#43;autocommit &#43; logic tree)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-09024fb0"
+             data-type="feature"
+             data-status="done"
+             data-priority="high"
+             data-created="2026-04-29T10:22:08.567876"
+             data-updated="2026-04-29T10:28:34.345237" data-agent-assigned="claude-code">
+
+        <header>
+            <h1>Draft v2 plan-system follow-up plans (compression&#43;autocommit &#43; logic tree)</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-high">High Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="c2fe2500-e4d2-4ac8-a26a-e834bd9fe2f1.html" data-relationship="implemented_in" data-since="2026-04-29T10:24:02.888692">session c2fe2500-e4d2-4ac8-a26a-e834bd9fe2f1</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Draft two v2-format plans:
+
+PLAN A — auto-commit hardening + per-slice compression: closes review gaps in the v2 system (approve/reject not auto-committed, locking missing, slice status/answers SQLite-only, plan render uncommitted, dashboard lacks per-slice Q/C view).
+
+PLAN B — logic-tree decomposition: integrates Conn & McLean Bulletproof Problem Solving steps 2-3 (disaggregate, prioritize) on top of the compressed schema. Depends on PLAN A.
+
+Plans are drafts for human review — do NOT finalize-yaml. Just create-yaml + add-slice-yaml + add-question-yaml.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-1c3ebad9.html
+++ b/.htmlgraph/features/feat-1c3ebad9.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Expose collector health via htmlgraph status &#43; /api/otel/status (STATUS-1)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-1c3ebad9"
+             data-type="feature"
+             data-status="done"
+             data-priority="medium"
+             data-created="2026-04-29T18:50:29.43393"
+             data-updated="2026-04-29T19:08:59.185527" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+
+        <header>
+            <h1>Expose collector health via htmlgraph status &#43; /api/otel/status (STATUS-1)</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-1cd284e0.html" data-relationship="planned_in" data-since="2026-04-29T18:50:29.437243">plan-1cd284e0</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T18:50:29.440192">trk-cb36e595</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="relates_to">
+                <h3>Relates To:</h3>
+                <ul>
+                    <li><a href="feat-ac7532be.html" data-relationship="relates_to" data-since="2026-04-29T18:50:50.020238">Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="c5ae568f-1904-41e6-a072-55afc0755865.html" data-relationship="implemented_in" data-since="2026-04-29T18:54:38.677991">session c5ae568f-1904-41e6-a072-55afc0755865</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Add cmd/htmlgraph/api_collector_status.go with CollectorStatus struct that reads .htmlgraph/sessions//.collector-pid, probes PID with Signal(0), reads events.ndjson for collector_start event (port + pid), returns JSON {pid, port, alive, uptime_s, last_activity_ms, signals_ingested}. Wire to GET /api/otel/status in api_otel.go. Update htmlgraph status text formatter with Collector: line. Acceptance: htmlgraph status while session active shows 'Collector: pid= port= alive=true'; after session end shows 'alive=false last_seen='. Refs: writeCollectorPID claude_otel_collect_spawn.go:151-155, writeCollectorStartEvent otel_collect.go:119-136, parent feat-ac7532be.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-35519ac2.html
+++ b/.htmlgraph/features/feat-35519ac2.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Extract CollectorLifecycle interface to internal/otel/collector (REFACTOR-1)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-35519ac2"
+             data-type="feature"
+             data-status="done"
+             data-priority="high"
+             data-created="2026-04-29T18:50:29.468042"
+             data-updated="2026-04-29T20:17:34.347685" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+
+        <header>
+            <h1>Extract CollectorLifecycle interface to internal/otel/collector (REFACTOR-1)</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-high">High Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-1cd284e0.html" data-relationship="planned_in" data-since="2026-04-29T18:50:29.471863">plan-1cd284e0</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T18:50:29.474235">trk-cb36e595</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-7b195a56.html" data-relationship="blocked_by" data-since="2026-04-29T18:50:49.567255">Watchdog respawns dead session collector (RESILIENCE-3)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="relates_to">
+                <h3>Relates To:</h3>
+                <ul>
+                    <li><a href="feat-ac7532be.html" data-relationship="relates_to" data-since="2026-04-29T18:50:50.04686">Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="c5ae568f-1904-41e6-a072-55afc0755865.html" data-relationship="implemented_in" data-since="2026-04-29T20:11:46.892087">session c5ae568f-1904-41e6-a072-55afc0755865</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Create internal/otel/collector/lifecycle.go with type CollectorLifecycle interface { Spawn(binPath, sessionID, projectDir string) (port int, cleanup func(), err error); Status() CollectorStatus }. Concrete ProcessCollector wraps spawnCollector, retrySpawnCollector, writeCollectorPID, registerCollectorCleanup, watchdog goroutine. cmd/htmlgraph/claude.go launchClaude switches to CollectorLifecycle.Spawn() with zero behavior change. Pattern: follow internal/otel/adapter/adapter.go:105-121 interface+registry approach. Keep lifecycle.go under 200 lines. Acceptance: go build ./... passes; existing Claude spawn integration test passes unmodified. Refs: parent feat-ac7532be.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-3cf79e0b.html
+++ b/.htmlgraph/features/feat-3cf79e0b.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Address PR #62 review feedback (registry hardening &#43; indexer removal)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-3cf79e0b"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="high"
+             data-created="2026-04-29T03:43:22.274887"
+             data-updated="2026-04-29T06:57:10.768161" data-agent-assigned="claude-code">
+
+        <header>
+            <h1>Address PR #62 review feedback (registry hardening &#43; indexer removal)</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-high">High Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="implements">
+                <h3>Implements:</h3>
+                <ul>
+                    <li><a href="bug-ccf8b887.html" data-relationship="implements" data-since="2026-04-29T03:43:28.64612">Address PR #62 review feedback (registry hardening &#43; indexer removal)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="8ef0905c-77f1-4349-8e61-8380555d170c.html" data-relationship="implemented_in" data-since="2026-04-29T04:00:01.670691">session 8ef0905c-77f1-4349-8e61-8380555d170c</a></li>
+                    <li><a href="c2fe2500-e4d2-4ac8-a26a-e834bd9fe2f1.html" data-relationship="implemented_in" data-since="2026-04-29T06:57:10.767899">session c2fe2500-e4d2-4ac8-a26a-e834bd9fe2f1</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-steps>
+            <h3>Implementation Steps</h3>
+            <ol>
+                <li data-completed="true" data-step-id="step-feat-3cf79e0b-0" data-agent="claude-code">✅ Split out indexer-removal hunk to separate PR [task:1]</li>
+                <li data-completed="true" data-step-id="step-feat-3cf79e0b-1" data-agent="claude-code">✅ Fix TestMain defer-after-os.Exit leak [task:2]</li>
+                <li data-completed="true" data-step-id="step-feat-3cf79e0b-2" data-agent="claude-code">✅ Soften PR title — drop concurrent writes [task:3]</li>
+                <li data-completed="true" data-step-id="step-feat-3cf79e0b-3" data-agent="claude-code">✅ Document Save() Prune side-effect or rename [task:4]</li>
+                <li data-completed="true" data-step-id="step-feat-3cf79e0b-4" data-agent="claude-code">✅ Add legacy-path fallback in DefaultPath [task:5]</li>
+                <li data-completed="true" data-step-id="step-feat-3cf79e0b-5" data-agent="claude-code">✅ serve_parent stat-then-skip &#43; reconcile DefaultPath [task:6]</li>
+                <li data-completed="true" data-step-id="step-feat-3cf79e0b-6" data-agent="claude-code">✅ Refactor withRegistryAtAndStale helper [task:7]</li>
+                <li data-completed="true" data-step-id="step-feat-3cf79e0b-7" data-agent="claude-code">✅ Run quality gates and push [task:8]</li>
+            </ol>
+        </section>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Implements the fixes from the PR #62 review (see bug-ccf8b887 for the full issue list).
+
+Concrete actions, in priority order:
+
+1. (🔴) Update PR #62 title/summary to disclose the indexer removal (bug-28a9d7a7), OR split it into a second PR. Preferred: split — file a new PR for the indexer removal so the change is reviewable in isolation.
+
+2. (🟡) Fix TestMain defer-after-os.Exit leak in cmd/htmlgraph/worktree_helpers_test.go (lines ~469-484). Move os.RemoveAll calls before os.Exit(code).
+
+3. (🟡) Soften PR #62 title — drop 'concurrent writes' (no locking added) OR actually add file-level locking (flock) around Save(). Drop 'atomic write via temp-file+rename' from summary since that pre-existed.
+
+4. (🟡) Either rename registry.Save() to SaveAndPrune()/Compact() to reflect new semantics, OR beef up the godoc to make the Prune() side-effect impossible to miss.
+
+5. (🟡) Add legacy-path fallback in registry.DefaultPath(): if XDG path does not exist but ~/.local/share/htmlgraph/projects.json does, read from legacy and migrate on next save. Cover with a test.
+
+6. (🟢) serve_parent runServeServer startup auto-prune: stat-then-skip rewrite if no entries pruned. Also reconcile registry.DefaultPath() call vs defaultRegistryPath package var.
+
+7. (🟢) Refactor withRegistryAtAndStale in cmd/htmlgraph/projects_test.go to either use a registry-package test helper OR marshal []registry.Entry directly via json.MarshalIndent instead of hand-writing the JSON format.
+
+8. (🟢) Add a regression test asserting /api/indexer/status now 404s after the indexer removal in serve_child.go.
+
+After fixes: run go build ./... && go vet ./... && go test ./... — all must pass. Push to the PR #62 branch (or a new branch for the split-out indexer PR).</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-6286f19f.html
+++ b/.htmlgraph/features/feat-6286f19f.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Retry OTel collector spawn with exponential backoff (RESILIENCE-2)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-6286f19f"
+             data-type="feature"
+             data-status="done"
+             data-priority="high"
+             data-created="2026-04-29T18:50:29.357346"
+             data-updated="2026-04-29T20:05:09.617401" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+
+        <header>
+            <h1>Retry OTel collector spawn with exponential backoff (RESILIENCE-2)</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-high">High Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="c5ae568f-1904-41e6-a072-55afc0755865.html" data-relationship="implemented_in" data-since="2026-04-29T20:02:20.764914">session c5ae568f-1904-41e6-a072-55afc0755865</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T18:50:29.364987">trk-cb36e595</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-1cd284e0.html" data-relationship="planned_in" data-since="2026-04-29T18:50:29.362549">plan-1cd284e0</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-dcf3d618.html" data-relationship="blocked_by" data-since="2026-04-29T18:50:49.500818">Fail-loud OTel collector spawn failure (RESILIENCE-1)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="relates_to">
+                <h3>Relates To:</h3>
+                <ul>
+                    <li><a href="feat-ac7532be.html" data-relationship="relates_to" data-since="2026-04-29T18:50:49.956521">Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Extract retrySpawnCollector(binPath, sessionID, projectDir string, maxAttempts int) in cmd/htmlgraph/claude_otel_collect_spawn.go that loops over spawnCollector() with backoff: attempt 1 = 100ms, 2 = 300ms, 3 = 700ms. Log each retry to stderr. 3s handshake timeout per attempt unchanged. Total worst-case ~13s. If all retries fail, fall through to fail-loud path from RESILIENCE-1. Acceptance: unit test with binPath script that fails first 2 invocations and succeeds on 3rd verifies spawnSessionCollector returns valid port + 2 warning lines on stderr. Refs: bug-28a9d7a7, parent feat-ac7532be.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-75426991.html
+++ b/.htmlgraph/features/feat-75426991.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Canonical attribute set &#43; Codex/Gemini adapter conformance (SCHEMA-1)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-75426991"
+             data-type="feature"
+             data-status="done"
+             data-priority="high"
+             data-created="2026-04-29T18:50:29.615532"
+             data-updated="2026-04-29T19:08:59.226467" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+
+        <header>
+            <h1>Canonical attribute set &#43; Codex/Gemini adapter conformance (SCHEMA-1)</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-high">High Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T18:50:29.626152">trk-cb36e595</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="c5ae568f-1904-41e6-a072-55afc0755865.html" data-relationship="implemented_in" data-since="2026-04-29T18:55:07.141975">session c5ae568f-1904-41e6-a072-55afc0755865</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="relates_to">
+                <h3>Relates To:</h3>
+                <ul>
+                    <li><a href="feat-ac7532be.html" data-relationship="relates_to" data-since="2026-04-29T18:50:50.118506">Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-1cd284e0.html" data-relationship="planned_in" data-since="2026-04-29T18:50:29.621092">plan-1cd284e0</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Define canonical UnifiedSignal attrs (Harness, SessionID, PromptID) in internal/otel/signal.go. Add internal/otel/adapter/codex.go (service.name=codex-cli, conversation.id->SessionID) and gemini.go (service.name=gemini-cli, session.id->SessionID). For spans/logs without session.id at signal level, fall back to resource-level (pattern from internal/otel/adapter/claude.go:242-249 baseSignal). Document attribute mapping table in signal.go doc comment. Add adapter conformance test verifying all 3 adapters populate Harness, SessionID, CanonicalName across metric/log/span paths. Acceptance: go test ./internal/otel/... includes TestAdapterConformance passing for all 3 adapters. Refs: internal/otel/signal.go:124, parent feat-ac7532be.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-7b094d00.html
+++ b/.htmlgraph/features/feat-7b094d00.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Per-session collector spawn for Gemini CLI (GEMINI-1)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-7b094d00"
+             data-type="feature"
+             data-status="done"
+             data-priority="medium"
+             data-created="2026-04-29T18:50:29.573082"
+             data-updated="2026-04-29T21:07:04.493431" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+
+        <header>
+            <h1>Per-session collector spawn for Gemini CLI (GEMINI-1)</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-35519ac2.html" data-relationship="blocked_by" data-since="2026-04-29T18:50:49.634374">Extract CollectorLifecycle interface to internal/otel/collector (REFACTOR-1)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="relates_to">
+                <h3>Relates To:</h3>
+                <ul>
+                    <li><a href="feat-ac7532be.html" data-relationship="relates_to" data-since="2026-04-29T18:50:50.095418">Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-1cd284e0.html" data-relationship="planned_in" data-since="2026-04-29T18:50:29.580532">plan-1cd284e0</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T18:50:29.584106">trk-cb36e595</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="c5ae568f-1904-41e6-a072-55afc0755865.html" data-relationship="implemented_in" data-since="2026-04-29T21:04:02.528776">session c5ae568f-1904-41e6-a072-55afc0755865</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Add cmd/htmlgraph/gemini_launch.go: htmlgraph gemini launcher that spawns per-session collector and passes GEMINI_TELEMETRY_ENABLED=true, GEMINI_TELEMETRY_USE_COLLECTOR=true, GEMINI_TELEMETRY_OTLP_ENDPOINT=http://127.0.0.1:, GEMINI_TELEMETRY_OTLP_PROTOCOL=http to gemini child. session.id on signals matches Claude pattern. Use CollectorLifecycle interface from REFACTOR-1. Acceptance: gemini session with telemetry enabled generates .htmlgraph/sessions//events.ndjson with harness=gemini_cli signals + session.id. Refs: google-gemini.github.io/gemini-cli/docs/cli/telemetry.html, internal/otel/signal.go:31 HarnessGemini, parent feat-ac7532be.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-7b195a56.html
+++ b/.htmlgraph/features/feat-7b195a56.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Watchdog respawns dead session collector (RESILIENCE-3)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-7b195a56"
+             data-type="feature"
+             data-status="done"
+             data-priority="high"
+             data-created="2026-04-29T18:50:29.399247"
+             data-updated="2026-04-29T20:10:08.865578" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+
+        <header>
+            <h1>Watchdog respawns dead session collector (RESILIENCE-3)</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-high">High Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="c5ae568f-1904-41e6-a072-55afc0755865.html" data-relationship="implemented_in" data-since="2026-04-29T20:06:43.806872">session c5ae568f-1904-41e6-a072-55afc0755865</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-1cd284e0.html" data-relationship="planned_in" data-since="2026-04-29T18:50:29.404545">plan-1cd284e0</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T18:50:29.407061">trk-cb36e595</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-6286f19f.html" data-relationship="blocked_by" data-since="2026-04-29T18:50:49.533747">Retry OTel collector spawn with exponential backoff (RESILIENCE-2)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="relates_to">
+                <h3>Relates To:</h3>
+                <ul>
+                    <li><a href="feat-ac7532be.html" data-relationship="relates_to" data-since="2026-04-29T18:50:49.988439">Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Add collectorWatchdog goroutine in cmd/htmlgraph/claude_otel_collect_spawn.go that polls proc.Signal(0) every 15s (HTMLGRAPH_OTEL_WATCHDOG_INTERVAL configurable). On non-nil error, call retrySpawnCollector with same sessionID and log new port; OTel traffic gap during respawn is acceptable for v1 (simpler path). Watchdog terminates when session cleanup function is called. Acceptance: integration test spawns collector, SIGKILLs it, waits 20s, verifies new .collector-pid file appears with live PID. Refs: registerCollectorCleanup pattern in claude_otel_collect_spawn.go:132-146, parent feat-ac7532be.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-9104fb56.html
+++ b/.htmlgraph/features/feat-9104fb56.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Per-session collector spawn for Codex CLI (CODEX-1)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-9104fb56"
+             data-type="feature"
+             data-status="done"
+             data-priority="medium"
+             data-created="2026-04-29T18:50:29.512233"
+             data-updated="2026-04-29T21:01:18.993924" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+
+        <header>
+            <h1>Per-session collector spawn for Codex CLI (CODEX-1)</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="c5ae568f-1904-41e6-a072-55afc0755865.html" data-relationship="implemented_in" data-since="2026-04-29T20:56:41.551128">session c5ae568f-1904-41e6-a072-55afc0755865</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-1cd284e0.html" data-relationship="planned_in" data-since="2026-04-29T18:50:29.515908">plan-1cd284e0</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T18:50:29.519682">trk-cb36e595</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-35519ac2.html" data-relationship="blocked_by" data-since="2026-04-29T18:50:49.600857">Extract CollectorLifecycle interface to internal/otel/collector (REFACTOR-1)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="relates_to">
+                <h3>Relates To:</h3>
+                <ul>
+                    <li><a href="feat-ac7532be.html" data-relationship="relates_to" data-since="2026-04-29T18:50:50.06862">Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Add cmd/htmlgraph/codex_launch.go: htmlgraph codex launcher analogous to htmlgraph claude that spawns per-session collector via CollectorLifecycle and passes OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1: to codex child process. Codex CLI emits OTel via ~/.codex/config.toml [otel] section (PR openai/codex#2103). service.name=codex-cli, conversation.id is session identifier. HarnessCodex constant exists in internal/otel/signal.go:30. Acceptance: htmlgraph codex with test session generates .htmlgraph/sessions//events.ndjson with harness=codex signals. Refs: github.com/openai/codex/pull/2103, developers.openai.com/codex/config-reference, parent feat-ac7532be.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-ac7532be.html
+++ b/.htmlgraph/features/feat-ac7532be.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-ac7532be"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="medium"
+             data-created="2026-04-29T16:43:57.363196"
+             data-updated="2026-04-30T06:30:41.292016" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+
+        <header>
+            <h1>Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T16:43:57.370454">trk-cb36e595</a></li>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T18:17:14.020614">Multi-Project Hardening — per-project process isolation</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="c5ae568f-1904-41e6-a072-55afc0755865.html" data-relationship="implemented_in" data-since="2026-04-29T20:00:14.019222">session c5ae568f-1904-41e6-a072-55afc0755865</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implements">
+                <h3>Implements:</h3>
+                <ul>
+                    <li><a href="plan-1cd284e0.html" data-relationship="implements" data-since="2026-04-29T18:17:16.793309">Plan: Per-session OTel collector with NDJSON ingest &#43; SQLite as derived index</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="relates_to">
+                <h3>Relates To:</h3>
+                <ul>
+                    <li><a href="bug-28a9d7a7.html" data-relationship="relates_to" data-since="2026-04-29T18:17:16.757745">Session OTel collector dies mid-session and is duplicated by _serve-child receiver</a></li>
+                    <li><a href="bug-e8b8900b.html" data-relationship="relates_to" data-since="2026-04-29T18:17:16.824175">Parallel Claude Code sessions in same project merge into one session after ingest</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-steps>
+            <h3>Implementation Steps</h3>
+            <ol>
+                <li data-completed="false" data-step-id="step-feat-ac7532be-0">⏳ **Scope:** cmd/htmlgraph/claude_otel_collect_spawn.go — spawnSessionCollector()
+**Goal:** Replace silent-failure return (lines 114-116) with a fatal log &#43; non-zero exit path so operators can detect spawn failures immediately instead of discovering them in post-session analysis.
+**Approach:** After the spawnCollector() error path, emit a structured stderr line: `htmlgraph: FATAL: collector spawn failed after all retries: &lt;err&gt;`. Remove the silent `otelEnvOverrides{}` return for the primary code path; keep silent-fail only when HTMLGRAPH_OTEL_ENABLED is explicitly false or binary path resolution fails (soft precondition errors). This aligns with the bug-28a9d7a7 finding that handshake timeout at pid 58306 produced zero operator-visible signal. Implementation: promote the warning to a `log.Fatal` equivalent gated on `HTMLGRAPH_OTEL_STRICT=1` (opt-in initially, becomes default in next major). Reference: bug-28a9d7a7 FINDING 1; claude_otel_collect_spawn.go:114-116.
+**Acceptance:** Running `htmlgraph claude` in a project where the binary path is intentionally broken produces a non-zero exit and the FATAL line on stderr rather than a silent start.
+**Refs:** bug-28a9d7a7, plan-1cd284e0, trk-cb36e595</li>
+                <li data-completed="false" data-step-id="step-feat-ac7532be-1">⏳ **Scope:** cmd/htmlgraph/claude_otel_collect_spawn.go — spawnSessionCollector() and spawnCollector()
+**Goal:** Retry collector spawn up to 3 times with 100ms / 300ms / 700ms exponential backoff before giving up, narrowing the silent-failure window from one attempt to four.
+**Approach:** Extract a retrySpawnCollector(binPath, sessionID, projectDir string, maxAttempts int) function that loops over spawnCollector() calls, sleeping between attempts. Use attempt-indexed backoff: attempt 1 = 100ms, 2 = 300ms, 3 = 700ms. Log each retry attempt to stderr at warning level. The 3s handshake timeout per attempt (readCollectorHandshake) remains unchanged — total worst-case wall time 4 * 3s &#43; 1.1s backoff ≈ 13s, acceptable for session startup. If all retries fail, fall through to the fail-loud path from RESILIENCE-1. Rationale: transient port contention or process scheduling delays are the most likely cause of the pid 58306 incident (bug-28a9d7a7). Reference: otel_collect_spawn.go readCollectorHandshake:67-90; standard exponential backoff as used in net/http DefaultTransport.
+**Acceptance:** Unit test that injects a binPath pointing to a script that fails the first 2 invocations and succeeds on the 3rd verifies that spawnSessionCollector() returns a valid port and that 2 warning lines appear on stderr.
+**Refs:** bug-28a9d7a7, cmd/htmlgraph/claude_otel_collect_spawn.go:67-90</li>
+                <li data-completed="false" data-step-id="step-feat-ac7532be-2">⏳ **Scope:** cmd/htmlgraph/claude_otel_collect_spawn.go — new collectorWatchdog goroutine in spawnSessionCollector()
+**Goal:** Detect mid-session collector death and automatically respawn so telemetry gaps are minimized even when the process crashes or is killed by OOM after startup.
+**Approach:** After the initial successful spawn, launch a watchdog goroutine that polls `proc.Signal(0)` every 15s (configurable via HTMLGRAPH_OTEL_WATCHDOG_INTERVAL). On non-nil error (process gone), call retrySpawnCollector() again with the same sessionID and update the otelEnvOverrides.CollectorPort atomically so subsequent OTLP payloads from the harness target the new port — requires also updating the child process env of the running claude process, which is not possible post-fork. Instead, the watchdog should write the new port to a well-known file (.htmlgraph/sessions/&lt;sid&gt;/.collector-port) and expose it via a localhost redirect endpoint on the original port. Simpler alternative: the watchdog respawns and logs the new port; OTel traffic is lost during the gap but restarts clean. Choose simpler path for v1. Watchdog terminates when the session cleanup function is called. Reference: registerCollectorCleanup:132-146 (claude_otel_collect_spawn.go) for the existing reaper pattern; Go signal(0) liveness check as used in process managers like supervisord.
+**Acceptance:** Integration test: spawn collector, kill it with SIGKILL, wait 20s, verify a new .collector-pid file appears in the session dir and the new PID is live.
+**Refs:** cmd/htmlgraph/claude_otel_collect_spawn.go:132-146, plan-1cd284e0</li>
+                <li data-completed="false" data-step-id="step-feat-ac7532be-3">⏳ **Scope:** cmd/htmlgraph/api_otel.go (or new cmd/htmlgraph/api_collector_status.go) &#43; htmlgraph status CLI handler
+**Goal:** Expose live collector health — PID, port, uptime, signal counts, last-activity timestamp — in `htmlgraph status` output and the /api/otel/status JSON endpoint.
+**Approach:** The collector PID is already written to .htmlgraph/sessions/&lt;sid&gt;/.collector-pid (claude_otel_collect_spawn.go:152-155). Add a CollectorStatus struct that reads this file, probes the PID with Signal(0), reads .htmlgraph/sessions/&lt;sid&gt;/events.ndjson for the collector_start event (which embeds port &#43; pid), and returns JSON: {&#34;pid&#34;:N,&#34;port&#34;:N,&#34;alive&#34;:true/false,&#34;uptime_s&#34;:N,&#34;last_activity_ms&#34;:N,&#34;signals_ingested&#34;:N}. Wire it to GET /api/otel/status in api_otel.go. Update the `htmlgraph status` text formatter to include a Collector: line. Reference: writeCollectorPID (claude_otel_collect_spawn.go:151-155), writeCollectorStartEvent (otel_collect.go:119-136) for attribute names (pid, port, htmlgraph_sid).
+**Acceptance:** `htmlgraph status` while a session is active shows &#34;Collector: pid=&lt;N&gt; port=&lt;N&gt; alive=true&#34;. `htmlgraph status` after session end shows &#34;Collector: alive=false last_seen=&lt;ts&gt;&#34;.
+**Refs:** cmd/htmlgraph/claude_otel_collect_spawn.go:151-155, cmd/htmlgraph/otel_collect.go:119-136, cmd/htmlgraph/api_otel.go</li>
+                <li data-completed="false" data-step-id="step-feat-ac7532be-4">⏳ **Scope:** cmd/htmlgraph/claude_otel_collect_spawn.go → new internal/otel/collector/lifecycle.go
+**Goal:** Extract a CollectorLifecycle interface &#43; concrete implementation from claude_otel_collect_spawn.go so the same spawn/retry/watchdog/cleanup code can be called from a future codexLaunch() or geminiLaunch() entrypoint without duplicating the logic.
+**Approach:** Define an interface: type CollectorLifecycle interface { Spawn(binPath, sessionID, projectDir string) (port int, cleanup func(), err error); Status() CollectorStatus }. The concrete ProcessCollector implementation wraps spawnCollector, retrySpawnCollector, writeCollectorPID, registerCollectorCleanup, and the watchdog goroutine. The claude.go launchClaude() caller switches to CollectorLifecycle.Spawn() with zero behavior change. Future harness launchers call the same interface. This also makes unit testing the lifecycle much easier — inject a fake Spawner that returns ports on demand. Reference: Adapter interface pattern already established in internal/otel/adapter/adapter.go:105-121 — follow the same Go interface &#43; registry approach. File size: keep lifecycle.go under 200 lines; move helper functions in.
+**Acceptance:** go build ./... passes after refactor; existing integration test for Claude spawn path continues to pass without modification (behavioral identity).
+**Refs:** internal/otel/adapter/adapter.go:105-121, cmd/htmlgraph/claude_otel_collect_spawn.go, cmd/htmlgraph/claude.go:499-505</li>
+                <li data-completed="false" data-step-id="step-feat-ac7532be-5">⏳ **Scope:** new cmd/htmlgraph/codex_launch.go (or similar) &#43; packages/codex-marketplace
+**Goal:** Wire per-session collector spawn into the Codex CLI launch path, mirroring what claude.go does for Claude Code sessions.
+**Approach:** Codex CLI (openai/codex) natively emits OTel over OTLP HTTP when configured via ~/.codex/config.toml [otel] section (PR openai/codex#2103, merged). The session identifier is conversation.id on all events; service.name = &#34;codex-cli&#34;. The collector adapter for Codex (HarnessCodex = &#34;codex&#34; in internal/otel/signal.go:30) already exists. The integration needs: (1) a `htmlgraph codex` launcher command analogous to `htmlgraph claude` that spawns a per-session collector and passes OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:&lt;port&gt; to the codex child process — note Codex uses its own OTEL_* or [otel] config, not GEMINI_TELEMETRY_* — confirm via codex config docs at https://developers.openai.com/codex/config-reference; (2) hook the existing SessionStart hook to read HTMLGRAPH_OTEL_PORT from env if the codex harness is detected. Alternatively, expose the collector spawn as a hook so the SessionStart hook handler for codex calls `htmlgraph otel-spawn --harness codex --session-id &lt;id&gt;` and writes the port back to the session dir. Design decision between the two approaches is a key open question (see open questions in feature description). Reference: Codex PR openai/codex#2103 for attribute names; packages/codex-marketplace hooks.json SessionStart event; internal/otel/signal.go:30 HarnessCodex.
+**Acceptance:** Running `htmlgraph codex` (or the hook-based path) with a test Codex session generates .htmlgraph/sessions/&lt;sid&gt;/events.ndjson with harness=codex signals.
+**Refs:** https://github.com/openai/codex/pull/2103, https://developers.openai.com/codex/config-reference, packages/codex-marketplace/.agents/plugins/htmlgraph/hooks.json, internal/otel/signal.go:30</li>
+                <li data-completed="false" data-step-id="step-feat-ac7532be-6">⏳ **Scope:** new cmd/htmlgraph/gemini_launch.go (or hook path) &#43; packages/gemini-extension
+**Goal:** Wire per-session collector spawn into the Gemini CLI launch path.
+**Approach:** Gemini CLI has first-class OTel support with distinct env vars: GEMINI_TELEMETRY_ENABLED=true, GEMINI_TELEMETRY_USE_COLLECTOR=true, GEMINI_TELEMETRY_OTLP_ENDPOINT=http://127.0.0.1:&lt;port&gt;, GEMINI_TELEMETRY_OTLP_PROTOCOL=http (ref: https://google-gemini.github.io/gemini-cli/docs/cli/telemetry.html). Session ID is session.id on all signals, identical to Claude Code (making the HarnessGemini adapter straightforward). Gemini also exposes GEMINI_SESSION_ID as an env var to hooks (SessionStart hook receives the ID), which means the SessionStart hook handler can call `htmlgraph otel-spawn --harness gemini --session-id $GEMINI_SESSION_ID` and write the port to the session dir — enabling a pure-hook approach without a `htmlgraph gemini` launcher binary. The Gemini extension hooks.json already has a SessionStart hook (packages/gemini-extension/hooks/hooks.json:3). Proposed approach: augment the hook handler `htmlgraph hook session-start` to detect harness (GEMINI_SESSION_ID present → gemini) and spawn the collector, writing port to .htmlgraph/sessions/&lt;sid&gt;/.collector-port. Then add a BeforeAgent hook that reads the port file and injects GEMINI_TELEMETRY_OTLP_ENDPOINT — but Gemini hooks cannot mutate child env, so the launcher approach may still be needed. Research needed: can Gemini CLI read GEMINI_TELEMETRY_OTLP_ENDPOINT from environment at launch? If yes, `htmlgraph gemini` launcher is the cleanest path.
+**Acceptance:** Gemini session with GEMINI_TELEMETRY_ENABLED=true generates .htmlgraph/sessions/&lt;sid&gt;/events.ndjson with harness=gemini_cli signals including session.id.
+**Refs:** https://google-gemini.github.io/gemini-cli/docs/cli/telemetry.html, packages/gemini-extension/hooks/hooks.json, internal/otel/signal.go:31 HarnessGemini</li>
+                <li data-completed="false" data-step-id="step-feat-ac7532be-7">⏳ **Scope:** internal/otel/signal.go, internal/otel/adapter/claude.go, internal/otel/adapter/ (new codex.go &#43; gemini.go)
+**Goal:** Define and enforce a canonical attribute set that all harness adapters populate, so cross-harness dashboard queries work without harness-specific special-casing.
+**Approach:** Canonical required attributes on every UnifiedSignal: Harness (already set), SessionID (already set per-harness), PromptID (Claude: prompt.id; Codex: synthesize from conversation.id &#43; event sequence number; Gemini: gen_ai.prompt_id). For spans/logs that do not carry session.id at the signal level, fall back to the resource-level session.id (already done for Claude in claude.go baseSignal:246-249 — same pattern needed for Codex conversation.id and Gemini session.id fallback). Document the attribute mapping table in a doc comment in signal.go: Claude session.id → SessionID | Codex conversation.id → SessionID | Gemini session.id → SessionID. service.name discrimination: claude-code → HarnessClaude; codex-cli or codex → HarnessCodex (confirm exact value from PR openai/codex#2103, which sets service.name = &#34;codex-cli&#34;); gemini-cli → HarnessGemini (confirm from https://google-gemini.github.io/gemini-cli/docs/cli/telemetry.html). The collector handler (otel_collect_handler.go:76-90) already routes through the adapter registry; no change needed there. Write an adapter conformance test that verifies all three adapters populate Harness, SessionID, and CanonicalName on every signal type.
+**Acceptance:** `go test ./internal/otel/...` includes a TestAdapterConformance that passes for all three adapters across metric/log/span paths.
+**Refs:** internal/otel/signal.go:124, internal/otel/adapter/claude.go:242-249, https://github.com/openai/codex/pull/2103, https://google-gemini.github.io/gemini-cli/docs/cli/telemetry.html</li>
+                <li data-completed="false" data-step-id="step-feat-ac7532be-8">⏳ **Scope:** cmd/htmlgraph/otel_collect_test.go &#43; new cmd/htmlgraph/collector_watchdog_test.go
+**Goal:** Integration test that verifies the watchdog detects collector death and respawns within 20s, with no data races.
+**Approach:** The test binary pattern is already established: otel_collect_test.go uses binPath injection to test spawnCollector() against real child processes. Extend with TestWatchdogRespawn: (1) spawn a collector; (2) record the first PID from .collector-pid; (3) SIGKILL the collector; (4) poll .collector-pid every 500ms for up to 20s; (5) assert new PID != old PID and new process is alive. Run with -race to catch the atomic port-update path introduced in RESILIENCE-3. Also test TestHandshakeTimeout: inject a fake binary that sleeps 5s before printing the handshake line and assert spawnCollector returns the timeout error in under 4s. Reference: existing TestSpawnCollector pattern in cmd/htmlgraph/otel_collect_test.go.
+**Acceptance:** `go test -race ./cmd/htmlgraph/ -run TestWatchdog` passes; `go test -race ./cmd/htmlgraph/ -run TestHandshakeTimeout` passes in under 5s.
+**Refs:** cmd/htmlgraph/otel_collect_test.go, cmd/htmlgraph/claude_otel_collect_spawn.go:66-91</li>
+                <li data-completed="false" data-step-id="step-feat-ac7532be-9">⏳ **Scope:** cmd/htmlgraph/otel_collect_test.go or new cmd/htmlgraph/multiharness_test.go
+**Goal:** Integration test that verifies the per-session collector correctly ingests and routes signals from all three harness dialects.
+**Approach:** The collectorHandler uses buildCollectorMux → adapter.NewRegistry() → reg.Register(adapter.NewClaudeAdapter()). Currently only ClaudeAdapter is registered (otel_collect.go:103). Once CodexAdapter and GeminiAdapter exist (SCHEMA step), register all three and test: (1) POST /v1/logs with a fake Codex log body (service.name=codex-cli, conversation.id=&lt;id&gt;); assert ndjson sink contains a signal with Harness=codex and SessionID=&lt;id&gt;. (2) POST /v1/metrics with a fake Gemini metrics body (service.name=gemini-cli, session.id=&lt;sid&gt;); assert HarnessGemini and SessionID. (3) POST /v1/traces with a Claude trace body; assert HarnessClaude still works. Use the protobuf builders already imported in otel_collect_handler.go. Reference: otel_collect.go:101-116 for registry construction; internal/otel/adapter/claude_test.go for payload construction patterns.
+**Acceptance:** `go test ./cmd/htmlgraph/ -run TestMultiHarnessIngestion` passes with all three harness assertions verified.
+**Refs:** cmd/htmlgraph/otel_collect.go:101-116, internal/otel/adapter/claude_test.go</li>
+                <li data-completed="false" data-step-id="step-feat-ac7532be-10">⏳ **Scope:** .htmlgraph/plans/ (new ADR section) &#43; plan-1cd284e0 status update
+**Goal:** Document the harness-agnostic collector interface design as an ADR so future contributors understand the spawn-vs-hook tradeoff and the canonical attribute mapping.
+**Approach:** Create a new plan (or append a decision record section to plan-1cd284e0 via `htmlgraph plan add-question`) capturing: (1) ADR-001: CollectorLifecycle interface — why an extracted Go interface is preferred over per-harness duplicated spawn code; (2) ADR-002: Launcher vs hook-based spawn for Codex/Gemini — tradeoffs: launcher gives pre-fork env injection (clean, deterministic port), hook-based requires writing port to disk and polling (racy), but launcher requires users to replace `codex` / `gemini` invocations with `htmlgraph codex` / `htmlgraph gemini`; (3) Canonical attribute table from SCHEMA step; (4) Reference to bug-28a9d7a7 as the motivating incident and plan-1cd284e0 as the prior session-scoped design. The plan should link feat-ac7532be as the implementation target. Update plan-1cd284e0 status to &#34;extended&#34; with a forward-reference to the new ADR plan.
+**Acceptance:** `htmlgraph plan show &lt;new-plan-id&gt;` displays all three ADR sections; plan-1cd284e0 has a link to feat-ac7532be.
+**Refs:** plan-1cd284e0, bug-28a9d7a7, feat-ac7532be, commits 6430031c 2039aa0b 49de4919</li>
+            </ol>
+        </section>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>META-FEATURE — split into 11 child features for parallel dispatch on 2026-04-29.
+
+Original scope: harden per-session OTel collector spawn path (fail-loud, retry, watchdog) and extend capture pipeline to Codex CLI and Gemini CLI sessions.
+
+Children (linked via relates_to):
+- feat-dcf3d618  RESILIENCE-1: Fail-loud OTel collector spawn failure
+- feat-6286f19f  RESILIENCE-2: Retry OTel collector spawn with exponential backoff
+- feat-7b195a56  RESILIENCE-3: Watchdog respawns dead session collector
+- feat-1c3ebad9  STATUS-1: Expose collector health via htmlgraph status + /api/otel/status
+- feat-35519ac2  REFACTOR-1: Extract CollectorLifecycle interface to internal/otel/collector
+- feat-9104fb56  CODEX-1: Per-session collector spawn for Codex CLI
+- feat-7b094d00  GEMINI-1: Per-session collector spawn for Gemini CLI
+- feat-75426991  SCHEMA-1: Canonical attribute set + Codex/Gemini adapter conformance
+- feat-e195d658  TEST-1: Watchdog and handshake-timeout integration tests
+- feat-c6b3d956  TEST-2: Multi-harness collector ingestion integration test
+- feat-bc3c0067  DOC-1: ADR — harness-agnostic collector lifecycle + canonical attrs
+
+Dispatch order (blocked_by graph):
+- Wave 1 (parallel): RESILIENCE-1, STATUS-1, SCHEMA-1
+- Wave 2: RESILIENCE-2 (after RESILIENCE-1)
+- Wave 3: RESILIENCE-3 (after RESILIENCE-2)
+- Wave 4: REFACTOR-1, TEST-1 (after RESILIENCE-3)
+- Wave 5 (parallel): CODEX-1, GEMINI-1 (after REFACTOR-1)
+- Wave 6: TEST-2 (after SCHEMA-1, CODEX-1, GEMINI-1)
+- Wave 7: DOC-1 (after all)
+
+This parent stays open as a tracking record; complete it once all children are done.
+
+Refs: bug-28a9d7a7 (motivating incident), plan-1cd284e0, trk-cb36e595.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-bc3c0067.html
+++ b/.htmlgraph/features/feat-bc3c0067.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>ADR: harness-agnostic collector lifecycle &#43; canonical attrs (DOC-1)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-bc3c0067"
+             data-type="feature"
+             data-status="done"
+             data-priority="low"
+             data-created="2026-04-29T18:50:29.765802"
+             data-updated="2026-04-29T22:00:50.981495" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+
+        <header>
+            <h1>ADR: harness-agnostic collector lifecycle &#43; canonical attrs (DOC-1)</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-low">Low Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="relates_to">
+                <h3>Relates To:</h3>
+                <ul>
+                    <li><a href="feat-ac7532be.html" data-relationship="relates_to" data-since="2026-04-29T18:50:50.184781">Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-35519ac2.html" data-relationship="blocked_by" data-since="2026-04-29T18:50:49.789297">Extract CollectorLifecycle interface to internal/otel/collector (REFACTOR-1)</a></li>
+                    <li><a href="feat-75426991.html" data-relationship="blocked_by" data-since="2026-04-29T18:50:49.821903">Canonical attribute set &#43; Codex/Gemini adapter conformance (SCHEMA-1)</a></li>
+                    <li><a href="feat-e195d658.html" data-relationship="blocked_by" data-since="2026-04-29T18:50:49.851033">Watchdog and handshake-timeout integration tests (TEST-1)</a></li>
+                    <li><a href="feat-c6b3d956.html" data-relationship="blocked_by" data-since="2026-04-29T18:50:49.885285">Multi-harness collector ingestion integration test (TEST-2)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-1cd284e0.html" data-relationship="planned_in" data-since="2026-04-29T18:50:29.770612">plan-1cd284e0</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="c5ae568f-1904-41e6-a072-55afc0755865.html" data-relationship="implemented_in" data-since="2026-04-29T21:27:09.238152">session c5ae568f-1904-41e6-a072-55afc0755865</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T18:50:29.774666">trk-cb36e595</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Document the harness-agnostic collector design as ADR. New plan or appended decision record on plan-1cd284e0 capturing: ADR-001 CollectorLifecycle interface (extracted Go interface preferred over per-harness duplicated spawn code); ADR-002 Launcher vs hook-based spawn for Codex/Gemini (launcher gives pre-fork env injection — clean, deterministic — vs hook-based which requires writing port to disk and polling, racy); canonical attribute table from SCHEMA-1; reference to bug-28a9d7a7 motivating incident, plan-1cd284e0 prior session-scoped design. Update plan-1cd284e0 status with forward-reference to new ADR plan. Acceptance: htmlgraph plan show  displays all 3 ADR sections; plan-1cd284e0 has link to feat-ac7532be. Refs: parent feat-ac7532be.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-c6b3d956.html
+++ b/.htmlgraph/features/feat-c6b3d956.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Multi-harness collector ingestion integration test (TEST-2)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-c6b3d956"
+             data-type="feature"
+             data-status="done"
+             data-priority="medium"
+             data-created="2026-04-29T18:50:29.712109"
+             data-updated="2026-04-29T21:11:38.468007" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+
+        <header>
+            <h1>Multi-harness collector ingestion integration test (TEST-2)</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="relates_to">
+                <h3>Relates To:</h3>
+                <ul>
+                    <li><a href="feat-ac7532be.html" data-relationship="relates_to" data-since="2026-04-29T18:50:50.162985">Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="c5ae568f-1904-41e6-a072-55afc0755865.html" data-relationship="implemented_in" data-since="2026-04-29T21:08:37.52328">session c5ae568f-1904-41e6-a072-55afc0755865</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-1cd284e0.html" data-relationship="planned_in" data-since="2026-04-29T18:50:29.716864">plan-1cd284e0</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-75426991.html" data-relationship="blocked_by" data-since="2026-04-29T18:50:49.689354">Canonical attribute set &#43; Codex/Gemini adapter conformance (SCHEMA-1)</a></li>
+                    <li><a href="feat-9104fb56.html" data-relationship="blocked_by" data-since="2026-04-29T18:50:49.712873">Per-session collector spawn for Codex CLI (CODEX-1)</a></li>
+                    <li><a href="feat-7b094d00.html" data-relationship="blocked_by" data-since="2026-04-29T18:50:49.739227">Per-session collector spawn for Gemini CLI (GEMINI-1)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T18:50:29.71982">trk-cb36e595</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Add cmd/htmlgraph/multiharness_test.go: TestMultiHarnessIngestion. Register all 3 adapters (Claude, Codex, Gemini) via reg.Register in test setup. POST /v1/logs with Codex log body (service.name=codex-cli, conversation.id=) — assert ndjson has Harness=codex SessionID=. POST /v1/metrics with Gemini metrics (service.name=gemini-cli, session.id=) — assert HarnessGemini SessionID. POST /v1/traces with Claude trace — assert HarnessClaude. Use protobuf builders from otel_collect_handler.go. Pattern: internal/otel/adapter/claude_test.go payload construction. Acceptance: go test ./cmd/htmlgraph/ -run TestMultiHarnessIngestion passes all 3 assertions. Refs: cmd/htmlgraph/otel_collect.go:101-116, parent feat-ac7532be.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-dcf3d618.html
+++ b/.htmlgraph/features/feat-dcf3d618.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Fail-loud OTel collector spawn failure (RESILIENCE-1)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-dcf3d618"
+             data-type="feature"
+             data-status="done"
+             data-priority="high"
+             data-created="2026-04-29T18:49:24.182303"
+             data-updated="2026-04-29T19:08:59.134602" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+
+        <header>
+            <h1>Fail-loud OTel collector spawn failure (RESILIENCE-1)</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-high">High Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="c5ae568f-1904-41e6-a072-55afc0755865.html" data-relationship="implemented_in" data-since="2026-04-29T18:54:10.353952">session c5ae568f-1904-41e6-a072-55afc0755865</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T18:49:24.19559">trk-cb36e595</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-1cd284e0.html" data-relationship="planned_in" data-since="2026-04-29T18:49:24.191995">plan-1cd284e0</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="relates_to">
+                <h3>Relates To:</h3>
+                <ul>
+                    <li><a href="feat-ac7532be.html" data-relationship="relates_to" data-since="2026-04-29T18:50:49.924063">Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Replace silent-failure return in cmd/htmlgraph/claude_otel_collect_spawn.go:114-116 with a fatal log + non-zero exit gated on HTMLGRAPH_OTEL_STRICT=1. Emit structured stderr line 'htmlgraph: FATAL: collector spawn failed after all retries: '. Keep silent-fail only when HTMLGRAPH_OTEL_ENABLED=false or binary path resolution fails. Acceptance: htmlgraph claude with broken binary path produces non-zero exit + FATAL line on stderr. Refs: bug-28a9d7a7 FINDING 1, parent feat-ac7532be.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-e195d658.html
+++ b/.htmlgraph/features/feat-e195d658.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Watchdog and handshake-timeout integration tests (TEST-1)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-e195d658"
+             data-type="feature"
+             data-status="done"
+             data-priority="medium"
+             data-created="2026-04-29T18:50:29.660961"
+             data-updated="2026-04-29T20:55:52.631513" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+
+        <header>
+            <h1>Watchdog and handshake-timeout integration tests (TEST-1)</h1>
+            <div class="metadata">
+                <span class="badge status-done">Done</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-29T18:50:29.671236">trk-cb36e595</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-7b195a56.html" data-relationship="blocked_by" data-since="2026-04-29T18:50:49.662323">Watchdog respawns dead session collector (RESILIENCE-3)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="relates_to">
+                <h3>Relates To:</h3>
+                <ul>
+                    <li><a href="feat-ac7532be.html" data-relationship="relates_to" data-since="2026-04-29T18:50:50.141395">Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-1cd284e0.html" data-relationship="planned_in" data-since="2026-04-29T18:50:29.667997">plan-1cd284e0</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Closed without dispatch: coverage already provided by existing tests after Waves 2-3 landed.
+
+- TestSpawnCollector_HandshakeTimeout (cmd/htmlgraph/) covers the handshake-timeout path.
+- TestWatchdog_RespawnsOnDeath, TestWatchdog_StopsCleanlyWhenLive, TestWatchdog_IntervalEnvOverride
+  (cmd/htmlgraph/) and TestProcessCollector_Spawn_* (internal/otel/collector/) cover the watchdog
+  goroutine logic and lifecycle interface.
+
+The proposed real-subprocess TestWatchdogRespawn would have provided regression insurance against
+silent wiring bugs (e.g. forgetting to call writeCollectorPID on respawn) but the watchdog code
+path is small enough (<50 LOC) to be code-review-reviewable, and we have no evidence of a wiring
+bug class that warrants the ongoing flake-rerun cost.
+
+Decision recorded 2026-04-29 with user.
+
+Original scope: Watchdog and handshake-timeout integration tests.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/tracks/trk-0677c709.html
+++ b/.htmlgraph/tracks/trk-0677c709.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="high"
              data-created="2026-04-10T22:30:29.647944"
-             data-updated="2026-04-28T17:23:05.690141" data-agent-assigned="claude-code">
+             data-updated="2026-04-29T14:57:51.989151" data-agent-assigned="claude-code">
 
         <header>
             <h1>Launch Readiness — close pitch/reality gaps before LinkedIn launch</h1>
@@ -90,6 +90,8 @@
                     <li><a href="bug-0ac5ad08.html" data-relationship="contains" data-since="2026-04-27T23:30:20.176827">OTel collector loses in-flight events on host sleep / abrupt shutdown</a></li>
                     <li><a href="bug-cc41e3d2.html" data-relationship="contains" data-since="2026-04-28T03:16:12.379373">Cache eviction must also prune entries whose project path no longer exists</a></li>
                     <li><a href="bug-727e4901.html" data-relationship="contains" data-since="2026-04-28T17:23:05.686394">Auto-clean legacy SQLite DB instead of warning forever</a></li>
+                    <li><a href="bug-ff6a3286.html" data-relationship="contains" data-since="2026-04-29T00:11:20.293691">Strip host paths at work-item HTML render time instead of allowlisting at commit gate</a></li>
+                    <li><a href="bug-4d3c3139.html" data-relationship="contains" data-since="2026-04-29T14:57:51.984691">Stale docs: DB path moved from .htmlgraph/ to user cache</a></li>
                 </ul>
             </section>
             <section data-edge-type="implemented_in">

--- a/.htmlgraph/tracks/trk-cb36e595.html
+++ b/.htmlgraph/tracks/trk-cb36e595.html
@@ -13,7 +13,7 @@
              data-status="todo"
              data-priority="high"
              data-created="2026-04-09T20:45:55.987414"
-             data-updated="2026-04-25T23:31:35.674251" data-agent-assigned="claude-code">
+             data-updated="2026-04-29T18:50:29.779914" data-agent-assigned="claude-code">
 
         <header>
             <h1>Multi-Project Hardening — per-project process isolation</h1>
@@ -35,6 +35,19 @@
                     <li><a href="bug-a52d5bf9.html" data-relationship="contains" data-since="2026-04-10T08:14:54.784918">Session ingest writes rows with empty project_dir, pollutes every project DB</a></li>
                     <li><a href="feat-e7670adb.html" data-relationship="contains" data-since="2026-04-10T09:17:12.930051">Plan: Session HTML canonical store via live-append</a></li>
                     <li><a href="bug-f0eff9b7.html" data-relationship="contains" data-since="2026-04-25T23:31:35.669933">Host registry accumulates thousands of ghost projects</a></li>
+                    <li><a href="bug-ccf8b887.html" data-relationship="contains" data-since="2026-04-29T03:40:05.470586">Address PR #62 review feedback (registry hardening &#43; indexer removal)</a></li>
+                    <li><a href="feat-ac7532be.html" data-relationship="contains" data-since="2026-04-29T16:43:57.370454">Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</a></li>
+                    <li><a href="feat-dcf3d618.html" data-relationship="contains" data-since="2026-04-29T18:49:24.19559">Fail-loud OTel collector spawn failure (RESILIENCE-1)</a></li>
+                    <li><a href="feat-6286f19f.html" data-relationship="contains" data-since="2026-04-29T18:50:29.364987">Retry OTel collector spawn with exponential backoff (RESILIENCE-2)</a></li>
+                    <li><a href="feat-7b195a56.html" data-relationship="contains" data-since="2026-04-29T18:50:29.407061">Watchdog respawns dead session collector (RESILIENCE-3)</a></li>
+                    <li><a href="feat-1c3ebad9.html" data-relationship="contains" data-since="2026-04-29T18:50:29.440192">Expose collector health via htmlgraph status &#43; /api/otel/status (STATUS-1)</a></li>
+                    <li><a href="feat-35519ac2.html" data-relationship="contains" data-since="2026-04-29T18:50:29.474235">Extract CollectorLifecycle interface to internal/otel/collector (REFACTOR-1)</a></li>
+                    <li><a href="feat-9104fb56.html" data-relationship="contains" data-since="2026-04-29T18:50:29.519682">Per-session collector spawn for Codex CLI (CODEX-1)</a></li>
+                    <li><a href="feat-7b094d00.html" data-relationship="contains" data-since="2026-04-29T18:50:29.584106">Per-session collector spawn for Gemini CLI (GEMINI-1)</a></li>
+                    <li><a href="feat-75426991.html" data-relationship="contains" data-since="2026-04-29T18:50:29.626152">Canonical attribute set &#43; Codex/Gemini adapter conformance (SCHEMA-1)</a></li>
+                    <li><a href="feat-e195d658.html" data-relationship="contains" data-since="2026-04-29T18:50:29.671236">Watchdog and handshake-timeout integration tests (TEST-1)</a></li>
+                    <li><a href="feat-c6b3d956.html" data-relationship="contains" data-since="2026-04-29T18:50:29.71982">Multi-harness collector ingestion integration test (TEST-2)</a></li>
+                    <li><a href="feat-bc3c0067.html" data-relationship="contains" data-since="2026-04-29T18:50:29.774666">ADR: harness-agnostic collector lifecycle &#43; canonical attrs (DOC-1)</a></li>
                 </ul>
             </section>
         </nav>


### PR DESCRIPTION
The YOLO session that implemented PR #65 ran its orchestrator on local
main while subagents worked in a worktree on the trk-cb36e595 branch.
Code commits landed on the branch (and shipped via PR #65), but the
htmlgraph CLI calls that created/updated work items wrote to .htmlgraph/
on local main and were never committed.

This commit captures those orphaned work-item records.

PR #65 child features (11):
- feat-1c3ebad9 STATUS-1, feat-dcf3d618 RESILIENCE-1,
- feat-6286f19f RESILIENCE-2, feat-7b195a56 RESILIENCE-3,
- feat-35519ac2 REFACTOR-1, feat-9104fb56 CODEX-1,
- feat-7b094d00 GEMINI-1, feat-75426991 SCHEMA-1,
- feat-c6b3d956 TEST-2, feat-e195d658 TEST-1, feat-bc3c0067 DOC-1

Parent + follow-ups:
- feat-ac7532be parent
- feat-09024fb0 v2 plan-system follow-up
- feat-3cf79e0b PR #62 follow-up

Bugs: bug-4d3c3139 (DB-path docs, done), bug-ccf8b887 (PR #62 follow-up,
done), bug-ff6a3286 (host-path stripping, todo), bug-28a9d7a7
(FINDING 1 added during diagnosis).

Track auto-updates: trk-cb36e595 (OTel), trk-0677c709.
