### PR TITLE
trk-08dcbb33: htmlgraph migrate-tracks — backfill feature track attribution (feat-d9c66e16)

### DIFF
--- a/cmd/htmlgraph/main.go
+++ b/cmd/htmlgraph/main.go
@@ -229,6 +229,10 @@ func buildRoot() *cobra.Command {
 	migrate.GroupID = "data"
 	root.AddCommand(migrate)
 
+	migrateTracks := migrateTracksCmd()
+	migrateTracks.GroupID = "data"
+	root.AddCommand(migrateTracks)
+
 	cleanup := cleanupCmd()
 	cleanup.GroupID = "data"
 	root.AddCommand(cleanup)

--- a/cmd/htmlgraph/migrate_tracks.go
+++ b/cmd/htmlgraph/migrate_tracks.go
@@ -69,7 +69,7 @@ Examples:
 				return err
 			}
 			printProjectHeaderIfDifferent(hgDir)
-			return runMigrateTracks(context.Background(), hgDir, opts, os.Stdout)
+			return runMigrateTracks(context.Background(), hgDir, opts, os.Stdout, os.Stderr)
 		},
 	}
 	cmd.Flags().StringVar(&opts.rulesPath, "rules", "", "path to rules YAML (required)")
@@ -86,7 +86,11 @@ Examples:
 // runMigrateTracks executes the classifier against the project at hgDir and
 // emits text/json output to out. When opts.write is true, applies confident
 // moves and records them in a manifest file under .htmlgraph/migrations/.
-func runMigrateTracks(ctx context.Context, hgDir string, opts migrateTracksOpts, out io.Writer) error {
+//
+// `out` is the primary output stream (decision table or JSON array).
+// `status` is the human status stream — sent there so JSON mode keeps `out`
+// pure-JSON-parseable. Pass io.Discard to suppress status entirely.
+func runMigrateTracks(ctx context.Context, hgDir string, opts migrateTracksOpts, out, status io.Writer) error {
 	if opts.rulesPath == "" {
 		return fmt.Errorf("--rules is required")
 	}
@@ -141,6 +145,15 @@ func runMigrateTracks(ctx context.Context, hgDir string, opts migrateTracksOpts,
 		}
 	}
 
+	// Validate proposed tracks BEFORE writing or even printing in --write
+	// mode. A typo'd track_id in the rules file should fail loudly up-front
+	// rather than partially applying and leaving the store in a torn state.
+	if opts.write {
+		if err := validateProposedTracks(p, decisions); err != nil {
+			return err
+		}
+	}
+
 	// Emit decisions in requested format.
 	switch opts.format {
 	case "json":
@@ -157,22 +170,45 @@ func runMigrateTracks(ctx context.Context, hgDir string, opts migrateTracksOpts,
 		return nil
 	}
 
-	// Apply confident moves and write the manifest.
+	// Apply confident moves and write the manifest. Status messages go to
+	// `status` (stderr) so JSON mode keeps `out` pure-JSON.
 	applyErrs := applyDecisions(p, decisions)
 	if writeErr := writeManifest(manifestPath, opts.rulesPath, decisions); writeErr != nil {
 		return fmt.Errorf("write manifest: %w (also had %d apply errors)", writeErr, len(applyErrs))
 	}
 	if len(applyErrs) > 0 {
-		fmt.Fprintf(out, "\nWARNING: %d apply errors:\n", len(applyErrs))
+		fmt.Fprintf(status, "\nWARNING: %d apply errors:\n", len(applyErrs))
 		for _, e := range applyErrs {
-			fmt.Fprintf(out, "  %v\n", e)
+			fmt.Fprintf(status, "  %v\n", e)
 		}
-		return fmt.Errorf("%d features failed to migrate (see manifest at %s)",
+		return fmt.Errorf("%d items failed to migrate (see manifest at %s)",
 			len(applyErrs), manifestPath)
 	}
-	fmt.Fprintf(out, "\nManifest written: %s\n", manifestPath)
-	fmt.Fprintln(out, "Run `htmlgraph reindex --full` to refresh the SQLite read index "+
+	fmt.Fprintf(status, "\nManifest written: %s\n", manifestPath)
+	fmt.Fprintln(status, "Run `htmlgraph reindex --full` to refresh the SQLite read index "+
 		"so blame/code-areas reflect the new attribution.")
+	return nil
+}
+
+// validateProposedTracks checks that every confident decision targets a track
+// that actually exists in the project. Returns the first missing track as an
+// error so the caller can abort BEFORE mutating any state.
+func validateProposedTracks(p *workitem.Project, decisions []migrate.Decision) error {
+	seen := map[string]bool{}
+	for _, d := range decisions {
+		if d.Reason != "confident" {
+			continue
+		}
+		if seen[d.ProposedTrack] {
+			continue
+		}
+		seen[d.ProposedTrack] = true
+		if _, err := p.Tracks.Get(d.ProposedTrack); err != nil {
+			return fmt.Errorf("rules reference unknown track %q (proposed for %s): %w — "+
+				"check docs/track-attribution-rules.yaml for typos",
+				d.ProposedTrack, d.FeatureID, err)
+		}
+	}
 	return nil
 }
 
@@ -232,20 +268,29 @@ func writeJSON(w io.Writer, decisions []migrate.Decision) error {
 }
 
 // applyDecisions performs the actual re-attribution for confident decisions.
-// Skips ambiguous, no-change, no-attribution, and no-match. Returns the list
-// of errors encountered (one per failed feature) without aborting on first
-// failure — partial progress is recorded in the manifest.
+// Skips ambiguous, no-change, no-attribution, and no-match. Dispatches to the
+// correct collection (features vs bugs) based on Decision.ItemType so a
+// confident bug move edits p.Bugs, not p.Features. Returns errors per item
+// without aborting on first failure — partial progress is recorded in the
+// manifest.
 func applyDecisions(p *workitem.Project, decisions []migrate.Decision) []error {
 	var errs []error
 	for _, d := range decisions {
 		if d.Reason != "confident" {
 			continue
 		}
-		if err := p.Features.Edit(d.FeatureID).SetTrack(d.ProposedTrack).Save(); err != nil {
+		switch d.ItemType {
+		case "feature", "bug":
+		default:
+			errs = append(errs, fmt.Errorf("%s: unsupported item_type %q", d.FeatureID, d.ItemType))
+			continue
+		}
+		col := collectionFor(p, d.ItemType)
+		if err := col.Edit(d.FeatureID).SetTrack(d.ProposedTrack).Save(); err != nil {
 			errs = append(errs, fmt.Errorf("%s: SetTrack: %w", d.FeatureID, err))
 			continue
 		}
-		if err := moveTrackEdges(p, d.FeatureID, "feature", d.ProposedTrack); err != nil {
+		if err := moveTrackEdges(p, d.FeatureID, d.ItemType, d.ProposedTrack); err != nil {
 			errs = append(errs, fmt.Errorf("%s: moveTrackEdges: %w", d.FeatureID, err))
 		}
 	}

--- a/cmd/htmlgraph/migrate_tracks.go
+++ b/cmd/htmlgraph/migrate_tracks.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/shakestzd/htmlgraph/internal/migrate"
+	"github.com/shakestzd/htmlgraph/internal/workitem"
+	"github.com/spf13/cobra"
+)
+
+// migrateTracksOpts holds the parsed CLI flags for `htmlgraph migrate-tracks`.
+type migrateTracksOpts struct {
+	rulesPath string
+	dryRun    bool
+	write     bool
+	types     string  // comma-separated: features, bugs
+	threshold float64 // dominant-share floor (0..1)
+	format    string  // text | json
+	force     bool    // overwrite existing manifest
+}
+
+// migrateTracksCmd returns the cobra command for `htmlgraph migrate-tracks`.
+func migrateTracksCmd() *cobra.Command {
+	opts := migrateTracksOpts{
+		dryRun:    true,
+		types:     "features",
+		threshold: 0.6,
+		format:    "text",
+	}
+	cmd := &cobra.Command{
+		Use:   "migrate-tracks",
+		Short: "Backfill feature track attribution via path-glob rules",
+		Long: `Walks every feature, examines its feature_files paths, and proposes
+re-attribution to the value-aligned track whose code surface dominates.
+
+Modes:
+  --dry-run (default)  print proposed moves; do not modify state
+  --write              apply moves and write a manifest for audit/rollback
+
+Rules: a YAML catalog of {glob, track_id, priority}. Higher priority wins
+on overlap. Globs support * (single segment) and ** (across boundaries).
+
+Decisions are emitted in five categories:
+  confident       — dominant track exceeds threshold; safe to move
+  ambiguous       — files matched but no track exceeds threshold
+  no-attribution  — feature has zero feature_files rows
+  no-match        — feature has files but none match any rule
+  no-change       — current track is already the dominant track
+
+Examples:
+  htmlgraph migrate-tracks --rules docs/track-attribution-rules.yaml
+  htmlgraph migrate-tracks --rules rules.yaml --write
+  htmlgraph migrate-tracks --rules rules.yaml --format json
+  htmlgraph migrate-tracks --rules rules.yaml --types features,bugs`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if opts.write {
+				opts.dryRun = false
+			}
+			hgDir, err := findHtmlgraphDir()
+			if err != nil {
+				return err
+			}
+			printProjectHeaderIfDifferent(hgDir)
+			return runMigrateTracks(context.Background(), hgDir, opts, os.Stdout)
+		},
+	}
+	cmd.Flags().StringVar(&opts.rulesPath, "rules", "", "path to rules YAML (required)")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", true, "preview without writing changes (default)")
+	cmd.Flags().BoolVar(&opts.write, "write", false, "apply moves and write manifest")
+	cmd.Flags().StringVar(&opts.types, "types", "features", "comma-separated work-item types: features, bugs")
+	cmd.Flags().Float64Var(&opts.threshold, "ambiguity-threshold", 0.6, "minimum dominant-track share (0..1)")
+	cmd.Flags().StringVar(&opts.format, "format", "text", "output format: text or json")
+	cmd.Flags().BoolVar(&opts.force, "force", false, "overwrite existing manifest in --write mode")
+	_ = cmd.MarkFlagRequired("rules")
+	return cmd
+}
+
+// runMigrateTracks executes the classifier against the project at hgDir and
+// emits text/json output to out. When opts.write is true, applies confident
+// moves and records them in a manifest file under .htmlgraph/migrations/.
+func runMigrateTracks(ctx context.Context, hgDir string, opts migrateTracksOpts, out io.Writer) error {
+	if opts.rulesPath == "" {
+		return fmt.Errorf("--rules is required")
+	}
+	if opts.write && opts.dryRun {
+		// `--write` overrides the default dry-run.
+		opts.dryRun = false
+	}
+	if opts.threshold < 0 || opts.threshold > 1 {
+		return fmt.Errorf("--ambiguity-threshold must be between 0 and 1, got %v", opts.threshold)
+	}
+
+	types, err := parseTypesFlag(opts.types)
+	if err != nil {
+		return err
+	}
+
+	rules, err := migrate.LoadRules(opts.rulesPath)
+	if err != nil {
+		return err
+	}
+	if len(rules.Rules) == 0 {
+		return fmt.Errorf("rules file %s contains no rules", opts.rulesPath)
+	}
+
+	p, err := workitem.Open(hgDir, "htmlgraph-cli")
+	if err != nil {
+		return fmt.Errorf("open project: %w", err)
+	}
+	defer p.Close()
+
+	decisions, err := migrate.ClassifyAll(p.DB, hgDir, rules, opts.threshold, types)
+	if err != nil {
+		return err
+	}
+	migrate.SortDecisions(decisions)
+
+	// Resolve manifest path up-front so write mode fails fast on collision.
+	var manifestPath string
+	if opts.write {
+		manifestPath = filepath.Join(hgDir, "migrations",
+			fmt.Sprintf("track-backfill-%d.json", time.Now().Unix()))
+		if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+			return fmt.Errorf("create migrations dir: %w", err)
+		}
+		// Refuse overwrite without --force. Since the path is unique-by-second,
+		// a same-second collision is rare; but if any track-backfill-*.json
+		// exists and --force is not set, treat that as "manifest already present".
+		matches, _ := filepath.Glob(filepath.Join(filepath.Dir(manifestPath), "track-backfill-*.json"))
+		if len(matches) > 0 && !opts.force {
+			return fmt.Errorf("existing manifest(s) present in %s — re-run with --force to overwrite",
+				filepath.Dir(manifestPath))
+		}
+	}
+
+	// Emit decisions in requested format.
+	switch opts.format {
+	case "json":
+		if err := writeJSON(out, decisions); err != nil {
+			return err
+		}
+	case "text", "":
+		writeText(out, decisions)
+	default:
+		return fmt.Errorf("unknown --format %q (use text or json)", opts.format)
+	}
+
+	if !opts.write {
+		return nil
+	}
+
+	// Apply confident moves and write the manifest.
+	applyErrs := applyDecisions(p, decisions)
+	if writeErr := writeManifest(manifestPath, opts.rulesPath, decisions); writeErr != nil {
+		return fmt.Errorf("write manifest: %w (also had %d apply errors)", writeErr, len(applyErrs))
+	}
+	if len(applyErrs) > 0 {
+		fmt.Fprintf(out, "\nWARNING: %d apply errors:\n", len(applyErrs))
+		for _, e := range applyErrs {
+			fmt.Fprintf(out, "  %v\n", e)
+		}
+		return fmt.Errorf("%d features failed to migrate (see manifest at %s)",
+			len(applyErrs), manifestPath)
+	}
+	fmt.Fprintf(out, "\nManifest written: %s\n", manifestPath)
+	fmt.Fprintln(out, "Run `htmlgraph reindex --full` to refresh the SQLite read index "+
+		"so blame/code-areas reflect the new attribution.")
+	return nil
+}
+
+// parseTypesFlag accepts a comma-separated list and validates each entry.
+func parseTypesFlag(s string) ([]string, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, fmt.Errorf("--types must include at least one of: features, bugs")
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		t := strings.TrimSpace(p)
+		switch t {
+		case "features", "bugs":
+			out = append(out, t)
+		default:
+			return nil, fmt.Errorf("unknown type %q in --types (use features or bugs)", t)
+		}
+	}
+	return out, nil
+}
+
+// writeText emits a tab-aligned table plus a summary line.
+func writeText(w io.Writer, decisions []migrate.Decision) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "FEATURE\tCURRENT\t\tPROPOSED\tCONFIDENCE\tREASON")
+	for _, d := range decisions {
+		conf := fmt.Sprintf("%5.1f%%", d.DominantShare*100)
+		reason := d.Reason
+		if d.Ambiguous {
+			reason = "AMBIGUOUS (below threshold)"
+		}
+		from := d.CurrentTrack
+		if from == "" {
+			from = "-"
+		}
+		to := d.ProposedTrack
+		if to == "" {
+			to = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t→\t%s\t%s\t%s (%d files)\n",
+			d.FeatureID, from, to, conf, reason, d.FileCount)
+	}
+	tw.Flush()
+	s := migrate.Summarize(decisions)
+	fmt.Fprintf(w, "\n%d features classified: %d confident moves, %d ambiguous, %d no-change, %d no-attribution, %d no-match\n",
+		s.Total, s.Confident, s.Ambiguous, s.NoChange, s.NoAttribution, s.NoMatch)
+}
+
+func writeJSON(w io.Writer, decisions []migrate.Decision) error {
+	if decisions == nil {
+		decisions = []migrate.Decision{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(decisions)
+}
+
+// applyDecisions performs the actual re-attribution for confident decisions.
+// Skips ambiguous, no-change, no-attribution, and no-match. Returns the list
+// of errors encountered (one per failed feature) without aborting on first
+// failure — partial progress is recorded in the manifest.
+func applyDecisions(p *workitem.Project, decisions []migrate.Decision) []error {
+	var errs []error
+	for _, d := range decisions {
+		if d.Reason != "confident" {
+			continue
+		}
+		if err := p.Features.Edit(d.FeatureID).SetTrack(d.ProposedTrack).Save(); err != nil {
+			errs = append(errs, fmt.Errorf("%s: SetTrack: %w", d.FeatureID, err))
+			continue
+		}
+		if err := moveTrackEdges(p, d.FeatureID, "feature", d.ProposedTrack); err != nil {
+			errs = append(errs, fmt.Errorf("%s: moveTrackEdges: %w", d.FeatureID, err))
+		}
+	}
+	return errs
+}
+
+// migrationManifest is the on-disk audit record for a single backfill run.
+type migrationManifest struct {
+	GeneratedAt   time.Time          `json:"generated_at"`
+	RulesPath     string             `json:"rules_path"`
+	HtmlgraphTool string             `json:"htmlgraph_tool"` // "migrate-tracks"
+	Decisions     []migrate.Decision `json:"decisions"`
+}
+
+func writeManifest(path, rulesPath string, decisions []migrate.Decision) error {
+	m := migrationManifest{
+		GeneratedAt:   time.Now().UTC(),
+		RulesPath:     rulesPath,
+		HtmlgraphTool: "migrate-tracks",
+		Decisions:     decisions,
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/cmd/htmlgraph/migrate_tracks_test.go
+++ b/cmd/htmlgraph/migrate_tracks_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -138,7 +139,7 @@ func TestMigrateTracksDryRunOutput(t *testing.T) {
 		threshold: 0.6,
 		format:    "text",
 	}
-	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf); err != nil {
+	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf, io.Discard); err != nil {
 		t.Fatalf("runMigrateTracks: %v", err)
 	}
 
@@ -176,7 +177,7 @@ func TestMigrateTracksWriteCreatesManifest(t *testing.T) {
 		threshold: 0.6,
 		format:    "text",
 	}
-	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf); err != nil {
+	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf, io.Discard); err != nil {
 		t.Fatalf("runMigrateTracks: %v", err)
 	}
 
@@ -244,7 +245,7 @@ func TestMigrateTracksWriteRefusesOverwrite(t *testing.T) {
 		format:    "text",
 		// force is FALSE
 	}
-	err := runMigrateTracks(context.Background(), hgDir, opts, &buf)
+	err := runMigrateTracks(context.Background(), hgDir, opts, &buf, io.Discard)
 	if err == nil {
 		t.Fatalf("expected error on existing manifest without --force")
 	}
@@ -255,7 +256,7 @@ func TestMigrateTracksWriteRefusesOverwrite(t *testing.T) {
 	// With --force it should succeed.
 	opts.force = true
 	buf.Reset()
-	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf); err != nil {
+	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf, io.Discard); err != nil {
 		t.Fatalf("runMigrateTracks --force: %v", err)
 	}
 }
@@ -271,7 +272,7 @@ func TestMigrateTracksJSONFormat(t *testing.T) {
 		threshold: 0.6,
 		format:    "json",
 	}
-	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf); err != nil {
+	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf, io.Discard); err != nil {
 		t.Fatalf("runMigrateTracks json: %v", err)
 	}
 	var ds []migrate.Decision
@@ -296,7 +297,7 @@ func TestMigrateTracksAmbiguousSkippedInWrite(t *testing.T) {
 		threshold: 0.6,
 		format:    "text",
 	}
-	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf); err != nil {
+	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf, io.Discard); err != nil {
 		t.Fatalf("runMigrateTracks: %v", err)
 	}
 
@@ -311,6 +312,144 @@ func TestMigrateTracksAmbiguousSkippedInWrite(t *testing.T) {
 	}
 	if feat.TrackID != trkOld {
 		t.Errorf("ambiguous feature should not have moved; track_id = %q, want %q", feat.TrackID, trkOld)
+	}
+}
+
+func TestMigrateTracksBugsWriteEditsBugCollection(t *testing.T) {
+	// Regression: roborev finding — --types bugs --write must edit p.Bugs,
+	// not p.Features. We seed a bug with yolo-dominant files and assert the
+	// canonical store reflects the bug's new track after --write.
+	hgDir, rulesPath := migrateTracksTestEnv(t)
+	trkYolo := os.Getenv("MTT_TRK_YOLO")
+	trkOld := os.Getenv("MTT_TRK_OLD")
+
+	p, err := workitem.Open(hgDir, "test-agent")
+	if err != nil {
+		t.Fatalf("workitem.Open: %v", err)
+	}
+	bg, err := p.Bugs.Create("Bug touching yolo", workitem.BugWithTrack(trkOld))
+	if err != nil {
+		t.Fatalf("Bugs.Create: %v", err)
+	}
+	for _, f := range []string{"cmd/htmlgraph/yolo.go", "cmd/htmlgraph/tmux.go", "cmd/htmlgraph/budget.go", "internal/worktree/manager.go"} {
+		if err := db.UpsertFeatureFile(p.DB, &models.FeatureFile{
+			ID: "ff-bug-" + bg.ID + "-" + f, FeatureID: bg.ID, FilePath: f, Operation: "edit",
+		}); err != nil {
+			t.Fatalf("UpsertFeatureFile: %v", err)
+		}
+	}
+	p.Close()
+
+	var buf bytes.Buffer
+	opts := migrateTracksOpts{
+		rulesPath: rulesPath,
+		write:     true,
+		types:     "bugs",
+		threshold: 0.6,
+		format:    "text",
+	}
+	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf, io.Discard); err != nil {
+		t.Fatalf("runMigrateTracks bugs: %v", err)
+	}
+
+	// Reopen and check: the BUG should be on trkYolo now.
+	p2, err := workitem.Open(hgDir, "test-agent")
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer p2.Close()
+	got, err := p2.Bugs.Get(bg.ID)
+	if err != nil {
+		t.Fatalf("Bugs.Get: %v", err)
+	}
+	if got.TrackID != trkYolo {
+		t.Errorf("bug track_id = %q, want %q", got.TrackID, trkYolo)
+	}
+}
+
+func TestMigrateTracksJSONWriteIsPureJSON(t *testing.T) {
+	// Regression: roborev finding — --format json --write must keep stdout
+	// pure-JSON-parseable. Status (manifest path, reindex hint) goes to
+	// stderr instead of being appended to stdout.
+	hgDir, rulesPath := migrateTracksTestEnv(t)
+
+	var stdout, stderr bytes.Buffer
+	opts := migrateTracksOpts{
+		rulesPath: rulesPath,
+		write:     true,
+		types:     "features",
+		threshold: 0.6,
+		format:    "json",
+	}
+	if err := runMigrateTracks(context.Background(), hgDir, opts, &stdout, &stderr); err != nil {
+		t.Fatalf("runMigrateTracks: %v", err)
+	}
+
+	// Stdout must parse as JSON without trailing junk.
+	var ds []migrate.Decision
+	dec := json.NewDecoder(bytes.NewReader(stdout.Bytes()))
+	if err := dec.Decode(&ds); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n--- stdout ---\n%s", err, stdout.String())
+	}
+	if dec.More() {
+		t.Errorf("stdout has trailing content after JSON decode: %s", stdout.String())
+	}
+	// Stderr should carry the manifest hint.
+	if !strings.Contains(stderr.String(), "Manifest written") {
+		t.Errorf("stderr missing manifest message:\n%s", stderr.String())
+	}
+}
+
+func TestMigrateTracksRejectsUnknownProposedTrack(t *testing.T) {
+	// Regression: roborev finding — a typo'd track_id in the rules file must
+	// fail before any mutation, not after partial application.
+	hgDir, _ := migrateTracksTestEnv(t)
+
+	// Replace the rules file with one that names a non-existent track.
+	badRules := filepath.Join(filepath.Dir(hgDir), "bad-rules.yaml")
+	if err := os.WriteFile(badRules, []byte(
+		"rules:\n"+
+			"  - { glob: \"cmd/htmlgraph/yolo.go\", track_id: \"trk-does-not-exist\", priority: 110 }\n"+
+			"  - { glob: \"cmd/htmlgraph/tmux.go\", track_id: \"trk-does-not-exist\", priority: 110 }\n"+
+			"  - { glob: \"cmd/htmlgraph/budget.go\", track_id: \"trk-does-not-exist\", priority: 110 }\n"+
+			"  - { glob: \"internal/worktree/**\", track_id: \"trk-does-not-exist\", priority: 100 }\n"),
+		0o644); err != nil {
+		t.Fatalf("write bad-rules: %v", err)
+	}
+
+	// Snapshot: featClear is on trkOld before the call.
+	featClear := os.Getenv("MTT_FEAT_CLEAR")
+	trkOld := os.Getenv("MTT_TRK_OLD")
+
+	var buf bytes.Buffer
+	opts := migrateTracksOpts{
+		rulesPath: badRules,
+		write:     true,
+		types:     "features",
+		threshold: 0.6,
+		format:    "text",
+	}
+	err := runMigrateTracks(context.Background(), hgDir, opts, &buf, io.Discard)
+	if err == nil {
+		t.Fatalf("expected error for unknown ProposedTrack, got nil")
+	}
+	if !strings.Contains(err.Error(), "trk-does-not-exist") {
+		t.Errorf("error doesn't name the missing track: %v", err)
+	}
+
+	// And critically: nothing was mutated.
+	p, err := workitem.Open(hgDir, "test-agent")
+	if err != nil {
+		t.Fatalf("workitem.Open: %v", err)
+	}
+	defer p.Close()
+	feat, err := p.Features.Get(featClear)
+	if err != nil {
+		t.Fatalf("Features.Get: %v", err)
+	}
+	if feat.TrackID != trkOld {
+		t.Errorf("featClear was mutated despite validation failure: track_id = %q, want %q",
+			feat.TrackID, trkOld)
 	}
 }
 
@@ -336,7 +475,7 @@ func TestMigrateTracksTypesValidation(t *testing.T) {
 			format:    "text",
 		}
 		var buf bytes.Buffer
-		err := runMigrateTracks(context.Background(), hgDir, opts, &buf)
+		err := runMigrateTracks(context.Background(), hgDir, opts, &buf, io.Discard)
 		if c.ok && err != nil {
 			t.Errorf("types=%q: unexpected error %v", c.types, err)
 		}

--- a/cmd/htmlgraph/migrate_tracks_test.go
+++ b/cmd/htmlgraph/migrate_tracks_test.go
@@ -1,0 +1,347 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shakestzd/htmlgraph/internal/db"
+	"github.com/shakestzd/htmlgraph/internal/migrate"
+	"github.com/shakestzd/htmlgraph/internal/models"
+	"github.com/shakestzd/htmlgraph/internal/workitem"
+)
+
+// migrateTracksTestEnv builds a temp project directory and seeds:
+//   - tracks: trk-old, trk-yolo, trk-plan
+//   - features: featClear (yolo-dominant, currently on trk-old),
+//     featAmbig (split between two tracks),
+//     featOrphan (no feature_files),
+//     featStable (already on its dominant track).
+//
+// Returns the .htmlgraph directory path and a project root for the test.
+func migrateTracksTestEnv(t *testing.T) (hgDir, rulesPath string) {
+	t.Helper()
+	root := t.TempDir()
+	hgDir = filepath.Join(root, ".htmlgraph")
+	if err := os.MkdirAll(hgDir, 0o755); err != nil {
+		t.Fatalf("mkdir .htmlgraph: %v", err)
+	}
+
+	// Force the DB to live inside the project for test isolation.
+	dbPath := filepath.Join(hgDir, "htmlgraph.db")
+	t.Setenv("HTMLGRAPH_DB_PATH", dbPath)
+
+	// Open the project — workitem.Open will use HTMLGRAPH_DB_PATH and create
+	// the DB file. We also use it to write canonical HTML so feature update
+	// works end-to-end.
+	p, err := workitem.Open(hgDir, "test-agent")
+	if err != nil {
+		t.Fatalf("workitem.Open: %v", err)
+	}
+	t.Cleanup(func() { p.Close() })
+
+	tOld, err := p.Tracks.Create("Old Track")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tYolo, err := p.Tracks.Create("Yolo Track")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tPlan, err := p.Tracks.Create("Plan Track")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	featClear, err := p.Features.Create("Clear yolo feature", workitem.FeatWithTrack(tOld.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	featAmbig, err := p.Features.Create("Ambiguous feature", workitem.FeatWithTrack(tOld.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	featOrphan, err := p.Features.Create("Orphan feature", workitem.FeatWithTrack(tOld.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	featStable, err := p.Features.Create("Already correct", workitem.FeatWithTrack(tYolo.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed feature_files in the SQLite read index. We use the same DB the
+	// project uses (env var override), so direct UpsertFeatureFile is fine.
+	now := time.Now().UTC()
+	_ = now
+	upsert := func(featureID, path string) {
+		if err := db.UpsertFeatureFile(p.DB, &models.FeatureFile{
+			ID: "ff-" + featureID + "-" + path, FeatureID: featureID, FilePath: path, Operation: "edit",
+		}); err != nil {
+			t.Fatalf("upsert feature_file: %v", err)
+		}
+	}
+
+	// featClear: 4 yolo files, 0 plan
+	for _, f := range []string{"cmd/htmlgraph/yolo.go", "cmd/htmlgraph/tmux.go", "cmd/htmlgraph/budget.go", "internal/worktree/manager.go"} {
+		upsert(featClear.ID, f)
+	}
+	// featAmbig: 2 plan, 2 yolo (50/50 split)
+	for _, f := range []string{"cmd/htmlgraph/plan_create.go", "cmd/htmlgraph/plan_show.go", "cmd/htmlgraph/yolo.go", "cmd/htmlgraph/tmux.go"} {
+		upsert(featAmbig.ID, f)
+	}
+	// featOrphan: zero feature_files
+	_ = featOrphan
+	// featStable: 3 yolo files; current track is already trk-yolo.
+	for _, f := range []string{"cmd/htmlgraph/yolo.go", "cmd/htmlgraph/tmux.go", "cmd/htmlgraph/launch_run.go"} {
+		upsert(featStable.ID, f)
+	}
+
+	// Save IDs for later assertions.
+	t.Setenv("MTT_FEAT_CLEAR", featClear.ID)
+	t.Setenv("MTT_FEAT_AMBIG", featAmbig.ID)
+	t.Setenv("MTT_FEAT_ORPHAN", featOrphan.ID)
+	t.Setenv("MTT_FEAT_STABLE", featStable.ID)
+	t.Setenv("MTT_TRK_OLD", tOld.ID)
+	t.Setenv("MTT_TRK_YOLO", tYolo.ID)
+	t.Setenv("MTT_TRK_PLAN", tPlan.ID)
+
+	// Write a rules file using the actual track IDs we just created.
+	rulesPath = filepath.Join(root, "rules.yaml")
+	rulesYAML := "rules:\n" +
+		"  - { glob: \"cmd/htmlgraph/yolo.go\",        track_id: \"" + tYolo.ID + "\", priority: 110 }\n" +
+		"  - { glob: \"cmd/htmlgraph/tmux.go\",        track_id: \"" + tYolo.ID + "\", priority: 110 }\n" +
+		"  - { glob: \"cmd/htmlgraph/budget.go\",      track_id: \"" + tYolo.ID + "\", priority: 110 }\n" +
+		"  - { glob: \"cmd/htmlgraph/launch_run.go\",  track_id: \"" + tYolo.ID + "\", priority: 110 }\n" +
+		"  - { glob: \"internal/worktree/**\",         track_id: \"" + tYolo.ID + "\", priority: 100 }\n" +
+		"  - { glob: \"cmd/htmlgraph/plan_*.go\",      track_id: \"" + tPlan.ID + "\", priority: 100 }\n"
+	if err := os.WriteFile(rulesPath, []byte(rulesYAML), 0o644); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+
+	return hgDir, rulesPath
+}
+
+func TestMigrateTracksDryRunOutput(t *testing.T) {
+	hgDir, rulesPath := migrateTracksTestEnv(t)
+
+	var buf bytes.Buffer
+	opts := migrateTracksOpts{
+		rulesPath: rulesPath,
+		dryRun:    true,
+		types:     "features",
+		threshold: 0.6,
+		format:    "text",
+	}
+	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf); err != nil {
+		t.Fatalf("runMigrateTracks: %v", err)
+	}
+
+	out := buf.String()
+	// Headline summary line should be present.
+	if !strings.Contains(out, "features classified:") {
+		t.Errorf("missing summary line:\n%s", out)
+	}
+	// Confident move should be there.
+	if !strings.Contains(out, "confident") {
+		t.Errorf("expected at least one 'confident' decision:\n%s", out)
+	}
+	// Ambiguous label should appear (50/50 case is below 0.6 threshold).
+	if !strings.Contains(strings.ToLower(out), "ambiguous") {
+		t.Errorf("expected an ambiguous decision in output:\n%s", out)
+	}
+
+	// Dry-run must NOT have written a manifest.
+	matches, _ := filepath.Glob(filepath.Join(hgDir, "migrations", "track-backfill-*.json"))
+	if len(matches) != 0 {
+		t.Errorf("dry-run should not write manifests, found: %v", matches)
+	}
+}
+
+func TestMigrateTracksWriteCreatesManifest(t *testing.T) {
+	hgDir, rulesPath := migrateTracksTestEnv(t)
+	featClear := os.Getenv("MTT_FEAT_CLEAR")
+	trkYolo := os.Getenv("MTT_TRK_YOLO")
+
+	var buf bytes.Buffer
+	opts := migrateTracksOpts{
+		rulesPath: rulesPath,
+		write:     true,
+		types:     "features",
+		threshold: 0.6,
+		format:    "text",
+	}
+	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf); err != nil {
+		t.Fatalf("runMigrateTracks: %v", err)
+	}
+
+	// Manifest written?
+	matches, _ := filepath.Glob(filepath.Join(hgDir, "migrations", "track-backfill-*.json"))
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 manifest file, got %d: %v", len(matches), matches)
+	}
+	data, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var manifest struct {
+		Decisions []migrate.Decision `json:"decisions"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	// Confirm featClear was moved.
+	moved := false
+	for _, d := range manifest.Decisions {
+		if d.FeatureID == featClear && d.ProposedTrack == trkYolo {
+			moved = true
+			break
+		}
+	}
+	if !moved {
+		t.Fatalf("featClear (%s) → %s not recorded in manifest:\n%s", featClear, trkYolo, data)
+	}
+
+	// Confirm the canonical store reflects the new track for featClear.
+	p, err := workitem.Open(hgDir, "test-agent")
+	if err != nil {
+		t.Fatalf("workitem.Open after write: %v", err)
+	}
+	defer p.Close()
+	feat, err := p.Features.Get(featClear)
+	if err != nil {
+		t.Fatalf("Features.Get: %v", err)
+	}
+	if feat.TrackID != trkYolo {
+		t.Errorf("featClear track_id = %q, want %q", feat.TrackID, trkYolo)
+	}
+}
+
+func TestMigrateTracksWriteRefusesOverwrite(t *testing.T) {
+	hgDir, rulesPath := migrateTracksTestEnv(t)
+
+	// Pre-create a manifest so the second write call collides.
+	migDir := filepath.Join(hgDir, "migrations")
+	if err := os.MkdirAll(migDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := filepath.Join(migDir, "track-backfill-1234567890.json")
+	if err := os.WriteFile(existing, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	opts := migrateTracksOpts{
+		rulesPath: rulesPath,
+		write:     true,
+		types:     "features",
+		threshold: 0.6,
+		format:    "text",
+		// force is FALSE
+	}
+	err := runMigrateTracks(context.Background(), hgDir, opts, &buf)
+	if err == nil {
+		t.Fatalf("expected error on existing manifest without --force")
+	}
+	if !strings.Contains(err.Error(), "manifest") {
+		t.Errorf("error = %q, want a manifest-collision message", err.Error())
+	}
+
+	// With --force it should succeed.
+	opts.force = true
+	buf.Reset()
+	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf); err != nil {
+		t.Fatalf("runMigrateTracks --force: %v", err)
+	}
+}
+
+func TestMigrateTracksJSONFormat(t *testing.T) {
+	hgDir, rulesPath := migrateTracksTestEnv(t)
+
+	var buf bytes.Buffer
+	opts := migrateTracksOpts{
+		rulesPath: rulesPath,
+		dryRun:    true,
+		types:     "features",
+		threshold: 0.6,
+		format:    "json",
+	}
+	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf); err != nil {
+		t.Fatalf("runMigrateTracks json: %v", err)
+	}
+	var ds []migrate.Decision
+	if err := json.Unmarshal(buf.Bytes(), &ds); err != nil {
+		t.Fatalf("not valid JSON Decision array: %v\n%s", err, buf.String())
+	}
+	if len(ds) == 0 {
+		t.Errorf("expected non-empty decisions array")
+	}
+}
+
+func TestMigrateTracksAmbiguousSkippedInWrite(t *testing.T) {
+	hgDir, rulesPath := migrateTracksTestEnv(t)
+	featAmbig := os.Getenv("MTT_FEAT_AMBIG")
+	trkOld := os.Getenv("MTT_TRK_OLD")
+
+	var buf bytes.Buffer
+	opts := migrateTracksOpts{
+		rulesPath: rulesPath,
+		write:     true,
+		types:     "features",
+		threshold: 0.6,
+		format:    "text",
+	}
+	if err := runMigrateTracks(context.Background(), hgDir, opts, &buf); err != nil {
+		t.Fatalf("runMigrateTracks: %v", err)
+	}
+
+	p, err := workitem.Open(hgDir, "test-agent")
+	if err != nil {
+		t.Fatalf("workitem.Open: %v", err)
+	}
+	defer p.Close()
+	feat, err := p.Features.Get(featAmbig)
+	if err != nil {
+		t.Fatalf("Features.Get: %v", err)
+	}
+	if feat.TrackID != trkOld {
+		t.Errorf("ambiguous feature should not have moved; track_id = %q, want %q", feat.TrackID, trkOld)
+	}
+}
+
+func TestMigrateTracksTypesValidation(t *testing.T) {
+	hgDir, rulesPath := migrateTracksTestEnv(t)
+
+	cases := []struct {
+		types string
+		ok    bool
+	}{
+		{"features", true},
+		{"bugs", true},
+		{"features,bugs", true},
+		{"sessions", false}, // unknown type
+		{"", false},
+	}
+	for _, c := range cases {
+		opts := migrateTracksOpts{
+			rulesPath: rulesPath,
+			dryRun:    true,
+			types:     c.types,
+			threshold: 0.6,
+			format:    "text",
+		}
+		var buf bytes.Buffer
+		err := runMigrateTracks(context.Background(), hgDir, opts, &buf)
+		if c.ok && err != nil {
+			t.Errorf("types=%q: unexpected error %v", c.types, err)
+		}
+		if !c.ok && err == nil {
+			t.Errorf("types=%q: expected error, got none", c.types)
+		}
+	}
+}

--- a/docs/cli/migrate-tracks.md
+++ b/docs/cli/migrate-tracks.md
@@ -1,0 +1,109 @@
+# `htmlgraph migrate-tracks`
+
+Backfill feature track attribution by classifying each feature's `feature_files`
+paths against a YAML rule catalog. Confident moves are applied; ambiguous
+features are flagged for manual review rather than silently re-attributed.
+
+## When to use
+
+After a track reorganization (rename, split, merge), existing features keep
+the track they were created with. `migrate-tracks` walks every feature, looks
+at the file paths it has touched, and proposes re-attribution to the track
+whose code surface dominates.
+
+## Usage
+
+```
+htmlgraph migrate-tracks --rules <yaml> [--dry-run|--write]
+                          [--types features,bugs]
+                          [--ambiguity-threshold 0.6]
+                          [--format text|json] [--force]
+```
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--rules` | (required) | Path to the rule YAML catalog. |
+| `--dry-run` | `true`  | Preview without writing. Default mode. |
+| `--write`   | `false` | Apply moves and write a manifest. |
+| `--types`   | `features` | Comma-separated: `features`, `bugs`. |
+| `--ambiguity-threshold` | `0.6` | Minimum dominant-track share (0..1). |
+| `--format`  | `text` | `text` or `json`. |
+| `--force`   | `false` | Required to overwrite an existing manifest. |
+
+## Rules file format
+
+```yaml
+rules:
+  - { glob: "cmd/htmlgraph/yolo.go",     track_id: "trk-be293476", priority: 110 }
+  - { glob: "internal/blame/**",         track_id: "trk-08dcbb33", priority: 100 }
+  - { glob: "plugin/agents/*.md",        track_id: "trk-2c83a1e2", priority: 100 }
+```
+
+- `glob`: path pattern. `*` matches a single segment; `**` matches across `/` boundaries.
+- `track_id`: target track for files matching the glob.
+- `priority`: higher wins on overlap. Use `>=110` for exact-file rules and
+  `100` for directory-level rules.
+
+Paths captured in `feature_files` may be absolute (when tool hooks ran inside
+a worktree). The classifier normalizes those by stripping the worktree prefix
+(`.../.claude/worktrees/<name>/`) or the longest path-prefix that ends just
+before a recognized top-level repo directory (`cmd/`, `internal/`, `plugin/`,
+etc.) before glob matching.
+
+## Decision categories
+
+| Reason | Action in `--write` mode |
+|--------|--------------------------|
+| `confident`      | Move applied. Dominant share ≥ threshold and current track ≠ proposed. |
+| `ambiguous`      | NOT moved. No track exceeded threshold; flag for human review. |
+| `no-attribution` | NOT moved. Feature has zero `feature_files` rows (orphan in the read index). |
+| `no-match`       | NOT moved. Feature touched files but none matched any rule. |
+| `no-change`      | NOT moved. Current track is already dominant. |
+
+## Manifest
+
+Every `--write` invocation records a manifest at
+`.htmlgraph/migrations/track-backfill-<unix>.json` containing the rules path
+and the full Decision array (every feature considered, including the ones
+left untouched). To roll back a move, edit the feature's track via
+`htmlgraph feature update <id> --track <old-track>`.
+
+To prevent stomping on a prior run, `--write` refuses to proceed if any
+`track-backfill-*.json` file already exists in `.htmlgraph/migrations/`.
+Pass `--force` to override.
+
+## Refresh the read index after `--write`
+
+The migration writes through the canonical HTML store. The SQLite read
+index that powers `htmlgraph blame` and `htmlgraph code-areas` only
+catches up after a full reindex:
+
+```
+htmlgraph reindex --full
+```
+
+The incremental reindex skips files whose `data-track-id` changed but
+whose `data-updated` timestamp didn't, so a `--full` pass is required.
+
+## Smoke tests
+
+Verify the migration landed by running blame on canonical files:
+
+```
+htmlgraph blame cmd/htmlgraph/yolo.go         # expect dominant: trk-be293476 (Yolo Mode)
+htmlgraph blame internal/hooks/yolo_guard.go  # expect dominant: trk-be293476
+htmlgraph blame plugin/agents/sonnet-coder.md # expect dominant: trk-2c83a1e2 (Subagents)
+```
+
+`htmlgraph code-areas --format markdown > docs/code-areas.md` regenerates
+the per-track inventory snapshot that quantifies the rebalance.
+
+## Scope notes
+
+- Bugs are opt-in via `--types bugs` (deferred to a follow-up — features
+  are the dominant work-item type and the highest-impact target for
+  re-attribution).
+- The classifier only operates on work items present in the canonical
+  HTML store. Features that exist in `feature_files` but not in
+  `.htmlgraph/features/*.html` are silently ignored — repairing those
+  orphans is a separate upstream concern.

--- a/docs/code-areas.md
+++ b/docs/code-areas.md
@@ -321,7 +321,7 @@ _depends on local feature_files state that the canonical `.htmlgraph/*.html` doe
 
 ## Track: OTel Integration — telemetry capture, span hierarchy, cost attribution (trk-c4615ad2)
 
-9 features, 62 files, 79 total touches
+8 features, 60 files, 74 total touches
 
 | File | Features | Touches |
 |------|----------|---------|
@@ -330,11 +330,9 @@ _depends on local feature_files state that the canonical `.htmlgraph/*.html` doe
 | cmd/htmlgraph/api_otel.go | 1 | 1 |
 | cmd/htmlgraph/api_tree.go | 1 | 1 |
 | cmd/htmlgraph/api_tree_test.go | 1 | 1 |
-| cmd/htmlgraph/claude.go | 3 | 3 |
-| cmd/htmlgraph/claude_env.go | 3 | 3 |
-| cmd/htmlgraph/claude_env_test.go | 3 | 3 |
-| cmd/htmlgraph/claude_otel_collect_spawn.go | 1 | 1 |
-| cmd/htmlgraph/claude_otel_collect_spawn_test.go | 1 | 1 |
+| cmd/htmlgraph/claude.go | 2 | 2 |
+| cmd/htmlgraph/claude_env.go | 2 | 2 |
+| cmd/htmlgraph/claude_env_test.go | 2 | 2 |
 | cmd/htmlgraph/claude_serve_autostart.go | 2 | 2 |
 | cmd/htmlgraph/dashboard/components/event-tree.js | 2 | 2 |
 | cmd/htmlgraph/dashboard/css/components.css | 1 | 1 |
@@ -437,12 +435,11 @@ _depends on local feature_files state that the canonical `.htmlgraph/*.html` doe
 
 ## Track: Local cockpit — embedded parallel AI sessions in dashboard (trk-cd61bbae)
 
-14 features, 35 files, 58 total touches
+13 features, 29 files, 51 total touches
 
 | File | Features | Touches |
 |------|----------|---------|
 | .githooks/pre-commit | 2 | 2 |
-| cmd/htmlgraph/agent_worktree_test.go | 1 | 1 |
 | cmd/htmlgraph/codex.go | 1 | 1 |
 | cmd/htmlgraph/codex_test.go | 2 | 2 |
 | cmd/htmlgraph/dashboard/css/components.css | 3 | 3 |
@@ -460,10 +457,6 @@ _depends on local feature_files state that the canonical `.htmlgraph/*.html` doe
 | cmd/htmlgraph/terminal_handlers_test.go | 3 | 3 |
 | cmd/htmlgraph/workitem.go | 1 | 1 |
 | cmd/htmlgraph/workitem_test.go | 1 | 1 |
-| cmd/htmlgraph/worktree_helpers.go | 1 | 1 |
-| cmd/htmlgraph/worktree_helpers_test.go | 1 | 1 |
-| cmd/htmlgraph/yolo.go | 1 | 1 |
-| cmd/htmlgraph/yolo_test.go | 1 | 1 |
 | docs/cross-env-path-drift-audit.md | 1 | 1 |
 | internal/db/claim_repo.go | 1 | 1 |
 | internal/hooks/harness.go | 1 | 1 |
@@ -472,9 +465,8 @@ _depends on local feature_files state that the canonical `.htmlgraph/*.html` doe
 | internal/hooks/pretooluse_test.go | 1 | 1 |
 | internal/terminal/terminal.go | 4 | 4 |
 | internal/terminal/terminal_test.go | 3 | 3 |
-| internal/worktree/worktree.go | 3 | 3 |
+| internal/worktree/worktree.go | 2 | 2 |
 | internal/worktree/worktree_internal_test.go | 1 | 1 |
-| internal/worktree/worktree_test.go | 1 | 1 |
 | scripts/stress-launch.sh | 1 | 1 |
 
 ## Track: Launch Readiness — close pitch/reality gaps before LinkedIn launch (trk-0677c709)
@@ -508,6 +500,28 @@ _depends on local feature_files state that the canonical `.htmlgraph/*.html` doe
 | internal/storage/evict.go | 1 | 2 |
 | internal/storage/evict_test.go | 1 | 1 |
 | scripts/devcontainer.sh | 1 | 1 |
+
+## Track: Yolo Mode — autonomous feature execution (trk-be293476)
+
+3 features, 15 files, 15 total touches
+
+| File | Features | Touches |
+|------|----------|---------|
+| cmd/htmlgraph/agent_worktree_test.go | 1 | 1 |
+| cmd/htmlgraph/claude.go | 1 | 1 |
+| cmd/htmlgraph/claude_env.go | 1 | 1 |
+| cmd/htmlgraph/claude_env_test.go | 1 | 1 |
+| cmd/htmlgraph/claude_otel_collect_spawn.go | 1 | 1 |
+| cmd/htmlgraph/claude_otel_collect_spawn_test.go | 1 | 1 |
+| cmd/htmlgraph/worktree_helpers.go | 1 | 1 |
+| cmd/htmlgraph/worktree_helpers_test.go | 1 | 1 |
+| cmd/htmlgraph/yolo.go | 1 | 1 |
+| cmd/htmlgraph/yolo_test.go | 1 | 1 |
+| internal/hooks/pretooluse.go | 1 | 1 |
+| internal/hooks/yolo_guard.go | 1 | 1 |
+| internal/hooks/yolo_guard_test.go | 1 | 1 |
+| internal/worktree/worktree.go | 1 | 1 |
+| internal/worktree/worktree_test.go | 1 | 1 |
 
 ## Track: Plan Mode (trk-a30e8df4)
 
@@ -544,7 +558,7 @@ _depends on local feature_files state that the canonical `.htmlgraph/*.html` doe
 
 ## Track: Workitem Attribution & Lineage (trk-08dcbb33)
 
-3 features, 7 files, 8 total touches
+4 features, 7 files, 9 total touches
 
 | File | Features | Touches |
 |------|----------|---------|
@@ -552,7 +566,7 @@ _depends on local feature_files state that the canonical `.htmlgraph/*.html` doe
 | cmd/htmlgraph/api_otel.go | 1 | 1 |
 | cmd/htmlgraph/dashboard/components/event-tree.js | 1 | 1 |
 | cmd/htmlgraph/dashboard/css/components.css | 1 | 1 |
-| cmd/htmlgraph/main.go | 2 | 2 |
+| cmd/htmlgraph/main.go | 3 | 3 |
 | internal/db/otel_schema.go | 1 | 1 |
 | internal/otel/receiver/writer.go | 1 | 1 |
 
@@ -569,16 +583,6 @@ _depends on local feature_files state that the canonical `.htmlgraph/*.html` doe
 | internal/hooks/session_end.go | 1 | 1 |
 | internal/hooks/transcript_user_prompt.go | 1 | 1 |
 | internal/hooks/transcript_user_prompt_test.go | 1 | 1 |
-
-## Track: Yolo Mode — autonomous feature execution (trk-be293476)
-
-1 features, 3 files, 3 total touches
-
-| File | Features | Touches |
-|------|----------|---------|
-| internal/hooks/pretooluse.go | 1 | 1 |
-| internal/hooks/yolo_guard.go | 1 | 1 |
-| internal/hooks/yolo_guard_test.go | 1 | 1 |
 
 ## Untracked
 

--- a/docs/track-attribution-rules.yaml
+++ b/docs/track-attribution-rules.yaml
@@ -1,0 +1,79 @@
+# Track-attribution rules: file-path globs → value-aligned track IDs.
+#
+# Used by `htmlgraph migrate-tracks` to backfill feature track attribution after
+# the value-aligned track reorganization (Plan Mode rename + creation of
+# Subagents / Yolo Mode / Lineage tracks). Each feature's feature_files rows
+# are matched against these globs; the dominant track (by match count) wins.
+# Higher `priority` rules override lower ones when a path matches multiple.
+#
+# Glob syntax:
+#   *    — matches any sequence within a single path segment (no /)
+#   **   — matches any sequence including / boundaries
+#   /    — path separator
+#
+# Track IDs:
+#   trk-a30e8df4 — Plan Mode
+#   trk-2c83a1e2 — Subagents
+#   trk-be293476 — Yolo Mode
+#   trk-08dcbb33 — Workitem Attribution & Lineage
+rules:
+  # ---- Plan Mode ----
+  - { glob: "cmd/htmlgraph/plan_*.go",            track_id: "trk-a30e8df4", priority: 100 }
+  - { glob: "cmd/htmlgraph/plan.go",              track_id: "trk-a30e8df4", priority: 100 }
+  - { glob: "cmd/htmlgraph/api_plans*.go",        track_id: "trk-a30e8df4", priority: 100 }
+  - { glob: "internal/plantmpl/**",               track_id: "trk-a30e8df4", priority: 100 }
+  - { glob: "internal/planyaml/**",               track_id: "trk-a30e8df4", priority: 100 }
+  - { glob: "internal/planamend/**",              track_id: "trk-a30e8df4", priority: 100 }
+  - { glob: "internal/planchat/**",               track_id: "trk-a30e8df4", priority: 100 }
+  - { glob: "internal/db/plan_*.go",              track_id: "trk-a30e8df4", priority: 100 }
+  - { glob: "plugin/skills/plan/**",              track_id: "trk-a30e8df4", priority: 100 }
+
+  # ---- Subagents ----
+  - { glob: "plugin/agents/*.md",                 track_id: "trk-2c83a1e2", priority: 100 }
+  - { glob: "internal/agent/**",                  track_id: "trk-2c83a1e2", priority: 100 }
+  - { glob: "internal/hooks/subagent_start*.go",  track_id: "trk-2c83a1e2", priority: 110 }
+  - { glob: "internal/hooks/attribution*.go",     track_id: "trk-2c83a1e2", priority: 110 }
+  - { glob: "internal/hooks/task_*.go",           track_id: "trk-2c83a1e2", priority: 110 }
+  - { glob: "internal/hooks/quality_gate*.go",    track_id: "trk-2c83a1e2", priority: 110 }
+  - { glob: "internal/otel/adapter/claude/**",    track_id: "trk-2c83a1e2", priority: 100 }
+  - { glob: "internal/otel/adapter/codex/**",     track_id: "trk-2c83a1e2", priority: 100 }
+  - { glob: "internal/otel/adapter/gemini/**",    track_id: "trk-2c83a1e2", priority: 100 }
+  - { glob: "internal/pricing/**",                track_id: "trk-2c83a1e2", priority: 100 }
+  - { glob: "cmd/htmlgraph/orchestrator*.go",     track_id: "trk-2c83a1e2", priority: 110 }
+  - { glob: "cmd/htmlgraph/agent_*.go",           track_id: "trk-2c83a1e2", priority: 100 }
+
+  # ---- Yolo Mode ----
+  - { glob: "cmd/htmlgraph/yolo*.go",             track_id: "trk-be293476", priority: 110 }
+  - { glob: "cmd/htmlgraph/tmux*.go",             track_id: "trk-be293476", priority: 110 }
+  - { glob: "cmd/htmlgraph/budget*.go",           track_id: "trk-be293476", priority: 110 }
+  - { glob: "cmd/htmlgraph/launch_run*.go",       track_id: "trk-be293476", priority: 110 }
+  - { glob: "cmd/htmlgraph/worktree_helpers*.go", track_id: "trk-be293476", priority: 110 }
+  - { glob: "cmd/htmlgraph/claude.go",            track_id: "trk-be293476", priority: 110 }
+  - { glob: "cmd/htmlgraph/claude_env*.go",       track_id: "trk-be293476", priority: 110 }
+  - { glob: "cmd/htmlgraph/agent_worktree*.go",   track_id: "trk-be293476", priority: 115 }
+  - { glob: "internal/hooks/yolo_guard*.go",      track_id: "trk-be293476", priority: 110 }
+  - { glob: "internal/worktree/**",               track_id: "trk-be293476", priority: 100 }
+
+  # ---- Workitem Attribution & Lineage ----
+  - { glob: "cmd/htmlgraph/lineage*.go",           track_id: "trk-08dcbb33", priority: 100 }
+  - { glob: "cmd/htmlgraph/trace*.go",             track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "cmd/htmlgraph/history*.go",           track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "cmd/htmlgraph/link*.go",              track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "cmd/htmlgraph/graph*.go",             track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "cmd/htmlgraph/blame*.go",             track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "cmd/htmlgraph/code_areas*.go",        track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "cmd/htmlgraph/workitem_edges*.go",    track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "cmd/htmlgraph/api_graph*.go",         track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "cmd/htmlgraph/api_provenance*.go",    track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "cmd/htmlgraph/api_tree*.go",          track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "cmd/htmlgraph/migrate_attribution*.go",track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "cmd/htmlgraph/migrate_tracks*.go",    track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "internal/graph/**",                   track_id: "trk-08dcbb33", priority: 100 }
+  - { glob: "internal/blame/**",                   track_id: "trk-08dcbb33", priority: 100 }
+  - { glob: "internal/migrate/**",                 track_id: "trk-08dcbb33", priority: 100 }
+  - { glob: "internal/db/lineage_repo*.go",        track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "internal/db/edge_repo*.go",           track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "internal/db/feature_files_repo*.go",  track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "internal/models/lineage*.go",         track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "internal/models/node*.go",            track_id: "trk-08dcbb33", priority: 110 }
+  - { glob: "internal/models/feature_file*.go",    track_id: "trk-08dcbb33", priority: 110 }

--- a/internal/blame/areas.go
+++ b/internal/blame/areas.go
@@ -136,8 +136,22 @@ func WalkAreas(ctx context.Context, database *sql.DB, root string, opts WalkOpti
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		// Skip directories that may have been listed as gitlinks (submodules).
-		if info, statErr := os.Stat(filepath.Join(root, rel)); statErr == nil && info.IsDir() {
+		// `git ls-files` can report files that have been deleted from the
+		// working tree but still tracked, plus directories that are gitlinks
+		// (submodules). Stat first so we can distinguish:
+		//   - ENOENT → file was removed; skip so deleted files don't appear
+		//     in the area inventory or get re-attributed via stale
+		//     feature_files rows.
+		//   - other stat errors → propagate; something is genuinely wrong.
+		//   - directory → submodule gitlink, skip.
+		info, statErr := os.Stat(filepath.Join(root, rel))
+		if statErr != nil {
+			if os.IsNotExist(statErr) {
+				continue
+			}
+			return nil, fmt.Errorf("stat %s: %w", rel, statErr)
+		}
+		if info.IsDir() {
 			continue
 		}
 

--- a/internal/blame/areas_test.go
+++ b/internal/blame/areas_test.go
@@ -234,6 +234,53 @@ func TestWalkAreas_ExcludesHtmlgraphDir(t *testing.T) {
 	}
 }
 
+// TestWalkAreas_SkipsDeletedTrackedFiles is a regression test for the
+// roborev finding that `git ls-files` can include tracked files that
+// have been deleted from the working tree, and that a stale feature_files
+// row would re-attribute the file in the area inventory. WalkAreas must
+// skip ENOENT files cleanly (no error, no inventory entry).
+func TestWalkAreas_SkipsDeletedTrackedFiles(t *testing.T) {
+	database := openTestDB(t)
+
+	insertTrack(t, database, "trk-del", "Deleted Track")
+	insertFeature(t, database, "feat-del", "Deleted Feature", "trk-del")
+
+	root := t.TempDir()
+	writeFile(t, root, "kept.go")
+	writeFile(t, root, "ghost.go")
+	gitInit(t, root, "kept.go", "ghost.go")
+
+	// Stale feature_files rows for both — including the file we'll delete.
+	insertFeatureFile(t, database, "ff-del-1", "feat-del", "kept.go")
+	insertFeatureFile(t, database, "ff-del-2", "feat-del", "ghost.go")
+
+	// Delete ghost.go from the working tree but DO NOT git rm it, so it
+	// remains in `git ls-files` output while the file no longer exists.
+	if err := os.Remove(filepath.Join(root, "ghost.go")); err != nil {
+		t.Fatalf("remove ghost.go: %v", err)
+	}
+
+	res, err := blame.WalkAreas(context.Background(), database, root, blame.WalkOptions{
+		IncludeUntracked: boolPtr(true),
+	})
+	if err != nil {
+		t.Fatalf("WalkAreas: %v", err)
+	}
+
+	for _, ta := range res.ByTrack {
+		for _, f := range ta.Files {
+			if f.Path == "ghost.go" {
+				t.Errorf("deleted file ghost.go should not appear in ByTrack inventory: %+v", f)
+			}
+		}
+	}
+	for _, u := range res.Untracked {
+		if u == "ghost.go" {
+			t.Errorf("deleted file ghost.go should not appear in Untracked: %v", res.Untracked)
+		}
+	}
+}
+
 // writeFile creates an empty file at dir/name for walking tests.
 func writeFile(t *testing.T, dir, name string) {
 	t.Helper()

--- a/internal/migrate/tracks.go
+++ b/internal/migrate/tracks.go
@@ -1,0 +1,384 @@
+// Package migrate implements feature track-attribution backfill.
+//
+// The classifier matches each feature's feature_files paths against a glob
+// rule catalog and re-attributes the feature to the value-aligned track whose
+// code surface dominates. Ambiguous features (no clear dominant) are flagged
+// for manual review rather than silently moved.
+package migrate
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/shakestzd/htmlgraph/internal/db"
+	"github.com/shakestzd/htmlgraph/internal/models"
+	"gopkg.in/yaml.v3"
+)
+
+// Rule maps a path glob to a track ID with a precedence priority.
+// Higher Priority wins when a single path matches multiple globs.
+type Rule struct {
+	Glob     string `yaml:"glob"`
+	TrackID  string `yaml:"track_id"`
+	Priority int    `yaml:"priority"`
+}
+
+// RuleSet is the loaded rule catalog from a YAML file.
+type RuleSet struct {
+	Rules []Rule `yaml:"rules"`
+}
+
+// Decision is the per-feature classifier output. Reason values:
+//
+//	"confident"      — dominant track exceeds threshold; safe to move
+//	"ambiguous"      — files matched but no track exceeds threshold
+//	"no-attribution" — feature has zero feature_files rows
+//	"no-match"       — feature has files but none match any rule
+//	"no-change"      — current_track is already the dominant track
+type Decision struct {
+	FeatureID     string  `json:"feature_id"`
+	CurrentTrack  string  `json:"current_track"`
+	ProposedTrack string  `json:"proposed_track"`
+	DominantShare float64 `json:"dominant_share"`
+	FileCount     int     `json:"file_count"`
+	Ambiguous     bool    `json:"ambiguous"`
+	Reason        string  `json:"reason"`
+}
+
+// LoadRules parses a YAML rule catalog from disk.
+func LoadRules(path string) (*RuleSet, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read rules %s: %w", path, err)
+	}
+	var rs RuleSet
+	if err := yaml.Unmarshal(data, &rs); err != nil {
+		return nil, fmt.Errorf("parse rules %s: %w", path, err)
+	}
+	return &rs, nil
+}
+
+// ClassifyFeature applies the rule catalog to a feature's file list and
+// returns the migration Decision. threshold is the minimum dominant-track
+// share (0..1) required to mark a Decision as confident; below it the
+// Decision is flagged ambiguous.
+func ClassifyFeature(rules *RuleSet, files []models.FeatureFile, currentTrack string, threshold float64) Decision {
+	d := Decision{
+		CurrentTrack: currentTrack,
+		FileCount:    len(files),
+	}
+	if len(files) > 0 {
+		d.FeatureID = files[0].FeatureID
+	}
+
+	if len(files) == 0 {
+		d.Reason = "no-attribution"
+		return d
+	}
+
+	counts := map[string]int{}
+	matched := 0
+	for _, f := range files {
+		if track := bestTrackForPath(rules, f.FilePath); track != "" {
+			counts[track]++
+			matched++
+		}
+	}
+
+	if matched == 0 {
+		d.Reason = "no-match"
+		return d
+	}
+
+	dominantTrack, dominantCount := topTrack(counts)
+	share := float64(dominantCount) / float64(len(files))
+	d.ProposedTrack = dominantTrack
+	d.DominantShare = share
+
+	if currentTrack == dominantTrack {
+		d.Reason = "no-change"
+		return d
+	}
+
+	if share < threshold {
+		d.Ambiguous = true
+		d.Reason = "ambiguous"
+		return d
+	}
+	d.Reason = "confident"
+	return d
+}
+
+// ClassifyAll iterates every feature in the project, loads its feature_files
+// rows from the read index, and classifies each.
+func ClassifyAll(database *sql.DB, projectDir string, rules *RuleSet, threshold float64, types []string) ([]Decision, error) {
+	wantFeatures := false
+	wantBugs := false
+	for _, t := range types {
+		switch t {
+		case "features":
+			wantFeatures = true
+		case "bugs":
+			wantBugs = true
+		default:
+			return nil, fmt.Errorf("unknown type %q (use features or bugs)", t)
+		}
+	}
+	if !wantFeatures && !wantBugs {
+		return nil, fmt.Errorf("--types must include at least one of: features, bugs")
+	}
+
+	var decisions []Decision
+	if wantFeatures {
+		ds, err := classifyByType(database, "feature", rules, threshold)
+		if err != nil {
+			return nil, err
+		}
+		decisions = append(decisions, ds...)
+	}
+	if wantBugs {
+		ds, err := classifyByType(database, "bug", rules, threshold)
+		if err != nil {
+			return nil, err
+		}
+		decisions = append(decisions, ds...)
+	}
+	return decisions, nil
+}
+
+// classifyByType loads (id, track_id) for every work item of the given type
+// and runs the classifier against each one's feature_files rows.
+func classifyByType(database *sql.DB, typeName string, rules *RuleSet, threshold float64) ([]Decision, error) {
+	rows, err := database.QueryContext(context.Background(),
+		`SELECT id, COALESCE(track_id, '') FROM features WHERE type = ?`, typeName)
+	if err != nil {
+		return nil, fmt.Errorf("list %ss: %w", typeName, err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	tracks := map[string]string{}
+	for rows.Next() {
+		var id, trackID string
+		if err := rows.Scan(&id, &trackID); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+		tracks[id] = trackID
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]Decision, 0, len(ids))
+	for _, id := range ids {
+		files, err := db.ListFilesByFeature(database, id)
+		if err != nil {
+			return nil, fmt.Errorf("load files for %s: %w", id, err)
+		}
+		d := ClassifyFeature(rules, files, tracks[id], threshold)
+		// ClassifyFeature pulls FeatureID from files[0] when present; ensure
+		// we record the id even when files is empty.
+		d.FeatureID = id
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+// SortDecisions reorders Decisions for human-readable output: ambiguous
+// first (most likely to need review), then by feature ID alphabetically.
+func SortDecisions(ds []Decision) {
+	sort.SliceStable(ds, func(i, j int) bool {
+		ai, aj := ds[i].Ambiguous, ds[j].Ambiguous
+		if ai != aj {
+			return ai && !aj
+		}
+		return ds[i].FeatureID < ds[j].FeatureID
+	})
+}
+
+// Summary aggregates Decisions into headline counts.
+type Summary struct {
+	Total         int
+	Confident     int
+	Ambiguous     int
+	NoChange      int
+	NoAttribution int
+	NoMatch       int
+}
+
+// Summarize counts Decisions by Reason.
+func Summarize(ds []Decision) Summary {
+	s := Summary{Total: len(ds)}
+	for _, d := range ds {
+		switch d.Reason {
+		case "confident":
+			s.Confident++
+		case "ambiguous":
+			s.Ambiguous++
+		case "no-change":
+			s.NoChange++
+		case "no-attribution":
+			s.NoAttribution++
+		case "no-match":
+			s.NoMatch++
+		}
+	}
+	return s
+}
+
+// bestTrackForPath returns the track ID of the highest-priority rule that
+// matches path, or "" if no rule matches. Tries the original path first,
+// then a normalized (repo-relative) variant for paths captured as absolute
+// (e.g. from worktree-aware tool calls).
+func bestTrackForPath(rules *RuleSet, p string) string {
+	candidates := []string{p}
+	if norm := normalizePath(p); norm != p {
+		candidates = append(candidates, norm)
+	}
+	bestPriority := -1 << 30
+	bestTrack := ""
+	for _, r := range rules.Rules {
+		matched := false
+		for _, cand := range candidates {
+			if matchGlob(r.Glob, cand) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		if r.Priority > bestPriority {
+			bestPriority = r.Priority
+			bestTrack = r.TrackID
+		}
+	}
+	return bestTrack
+}
+
+// normalizePath strips the absolute prefix from a path captured by tool
+// hooks running inside a worktree, returning a repo-relative path so glob
+// rules written against repo-relative globs (cmd/htmlgraph/blame.go) still
+// match. Paths already relative are returned unchanged.
+//
+// Strategy:
+//  1. If the path contains "/.claude/worktrees/<name>/", strip up to and
+//     including that segment — this is the canonical worktree prefix layout.
+//  2. Otherwise, find the first occurrence of any top-level repo directory
+//     anchor (cmd/, internal/, plugin/, etc.) and strip everything before it.
+//  3. If neither matches, return the path unchanged.
+func normalizePath(p string) string {
+	if !strings.HasPrefix(p, "/") {
+		return p
+	}
+	if rest, ok := stripWorktreePrefix(p); ok {
+		p = rest
+		if !strings.HasPrefix(p, "/") {
+			return p
+		}
+	}
+	for _, anchor := range repoAnchors {
+		needle := "/" + anchor
+		if idx := strings.Index(p, needle); idx >= 0 {
+			return p[idx+1:]
+		}
+	}
+	return p
+}
+
+// stripWorktreePrefix strips a leading ".../.claude/worktrees/<name>/"
+// segment from p, returning the remainder and true on success. Returns the
+// original path and false when the marker is absent.
+func stripWorktreePrefix(p string) (string, bool) {
+	const marker = "/.claude/worktrees/"
+	idx := strings.Index(p, marker)
+	if idx < 0 {
+		return p, false
+	}
+	tail := p[idx+len(marker):]
+	slash := strings.Index(tail, "/")
+	if slash < 0 {
+		return p, false
+	}
+	return tail[slash+1:], true
+}
+
+// repoAnchors are the top-level directory names that mark the start of a
+// repo-relative path. Order matters only when paths contain multiple — the
+// first match wins, so list more-specific anchors before broader ones.
+var repoAnchors = []string{
+	"cmd/",
+	"internal/",
+	"plugin/",
+	"packages/",
+	"docs/",
+	"scripts/",
+	"web/",
+	".githooks/",
+}
+
+// topTrack returns the track with the highest count. Ties broken by track ID
+// (deterministic).
+func topTrack(counts map[string]int) (string, int) {
+	bestCount := -1
+	bestTrack := ""
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if counts[k] > bestCount {
+			bestCount = counts[k]
+			bestTrack = k
+		}
+	}
+	return bestTrack, bestCount
+}
+
+// matchGlob implements a small subset of glob syntax used by the rule catalog:
+//
+//	*   — matches any sequence of non-/ characters within a single segment
+//	**  — matches any sequence of characters including / boundaries
+//
+// Other characters are matched literally. Use this rather than path.Match,
+// which doesn't support **.
+func matchGlob(pattern, p string) bool {
+	// Fast path: no wildcards.
+	if !strings.ContainsAny(pattern, "*?") {
+		return pattern == p
+	}
+	// Handle ** by splitting on it.
+	if strings.Contains(pattern, "**") {
+		parts := strings.SplitN(pattern, "**", 2)
+		prefix, suffix := parts[0], parts[1]
+		if !strings.HasPrefix(p, prefix) {
+			return false
+		}
+		rest := p[len(prefix):]
+		// suffix may itself contain * patterns — recurse, but only against
+		// the tail of `rest`. Try every possible split point.
+		if suffix == "" {
+			return true
+		}
+		// Walk all suffixes of rest.
+		for i := 0; i <= len(rest); i++ {
+			if matchGlob(suffix, rest[i:]) {
+				return true
+			}
+		}
+		return false
+	}
+	// No **: defer to path.Match which handles * (single segment only).
+	ok, err := path.Match(pattern, p)
+	if err != nil {
+		return false
+	}
+	return ok
+}

--- a/internal/migrate/tracks.go
+++ b/internal/migrate/tracks.go
@@ -42,6 +42,7 @@ type RuleSet struct {
 //	"no-change"      — current_track is already the dominant track
 type Decision struct {
 	FeatureID     string  `json:"feature_id"`
+	ItemType      string  `json:"item_type"` // "feature" | "bug"
 	CurrentTrack  string  `json:"current_track"`
 	ProposedTrack string  `json:"proposed_track"`
 	DominantShare float64 `json:"dominant_share"`
@@ -100,14 +101,17 @@ func ClassifyFeature(rules *RuleSet, files []models.FeatureFile, currentTrack st
 	d.ProposedTrack = dominantTrack
 	d.DominantShare = share
 
-	if currentTrack == dominantTrack {
-		d.Reason = "no-change"
-		return d
-	}
-
+	// Ambiguity check runs first — a low-confidence dominance shouldn't be
+	// reported as settled just because the feature happens to already live on
+	// the dominant track. A 30% share is ambiguous regardless of where the
+	// feature is currently attributed.
 	if share < threshold {
 		d.Ambiguous = true
 		d.Reason = "ambiguous"
+		return d
+	}
+	if currentTrack == dominantTrack {
+		d.Reason = "no-change"
 		return d
 	}
 	d.Reason = "confident"
@@ -185,6 +189,7 @@ func classifyByType(database *sql.DB, typeName string, rules *RuleSet, threshold
 		// ClassifyFeature pulls FeatureID from files[0] when present; ensure
 		// we record the id even when files is empty.
 		d.FeatureID = id
+		d.ItemType = typeName
 		out = append(out, d)
 	}
 	return out, nil

--- a/internal/migrate/tracks_test.go
+++ b/internal/migrate/tracks_test.go
@@ -1,0 +1,228 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shakestzd/htmlgraph/internal/models"
+)
+
+// fakeFiles makes a slice of FeatureFile with the given paths.
+func fakeFiles(featureID string, paths ...string) []models.FeatureFile {
+	out := make([]models.FeatureFile, len(paths))
+	for i, p := range paths {
+		out[i] = models.FeatureFile{
+			ID:        "ff-" + p,
+			FeatureID: featureID,
+			FilePath:  p,
+		}
+	}
+	return out
+}
+
+// testRules returns a small RuleSet covering the four value-aligned tracks.
+func testRules() *RuleSet {
+	return &RuleSet{Rules: []Rule{
+		{Glob: "cmd/htmlgraph/yolo.go", TrackID: "trk-yolo", Priority: 110},
+		{Glob: "cmd/htmlgraph/tmux.go", TrackID: "trk-yolo", Priority: 110},
+		{Glob: "internal/worktree/**", TrackID: "trk-yolo", Priority: 100},
+		{Glob: "cmd/htmlgraph/plan_*.go", TrackID: "trk-plan", Priority: 100},
+		{Glob: "internal/plantmpl/**", TrackID: "trk-plan", Priority: 100},
+		{Glob: "internal/blame/**", TrackID: "trk-lineage", Priority: 100},
+		{Glob: "cmd/htmlgraph/blame.go", TrackID: "trk-lineage", Priority: 110},
+		{Glob: "plugin/agents/*.md", TrackID: "trk-subagents", Priority: 100},
+	}}
+}
+
+func TestClassify_SingleTrackDominant(t *testing.T) {
+	rules := testRules()
+	files := fakeFiles("feat-001",
+		"cmd/htmlgraph/yolo.go",
+		"cmd/htmlgraph/tmux.go",
+		"internal/worktree/manager.go",
+		"internal/worktree/registry.go",
+	)
+	d := ClassifyFeature(rules, files, "trk-cd61bbae", 0.6)
+	if d.ProposedTrack != "trk-yolo" {
+		t.Fatalf("proposed_track = %q, want trk-yolo", d.ProposedTrack)
+	}
+	if d.Ambiguous {
+		t.Fatalf("expected confident, got ambiguous: %+v", d)
+	}
+	if d.DominantShare < 0.99 {
+		t.Fatalf("dominant_share = %v, want ~1.0", d.DominantShare)
+	}
+	if d.Reason != "confident" {
+		t.Fatalf("reason = %q, want confident", d.Reason)
+	}
+	if d.FileCount != 4 {
+		t.Fatalf("file_count = %d, want 4", d.FileCount)
+	}
+}
+
+func TestClassify_AmbiguousBelowThreshold(t *testing.T) {
+	rules := testRules()
+	// 3 plan files, 2 yolo files: dominant share = 3/5 = 0.6
+	files := fakeFiles("feat-002",
+		"cmd/htmlgraph/plan_create.go",
+		"cmd/htmlgraph/plan_show.go",
+		"cmd/htmlgraph/plan_finalize.go",
+		"cmd/htmlgraph/yolo.go",
+		"cmd/htmlgraph/tmux.go",
+	)
+	// threshold 0.7 → ambiguous (0.6 < 0.7)
+	d := ClassifyFeature(rules, files, "trk-old", 0.7)
+	if !d.Ambiguous {
+		t.Fatalf("expected ambiguous (share=0.6, threshold=0.7), got %+v", d)
+	}
+	if d.ProposedTrack != "trk-plan" {
+		t.Fatalf("proposed_track = %q, want trk-plan (still the leader)", d.ProposedTrack)
+	}
+	if d.Reason != "ambiguous" {
+		t.Fatalf("reason = %q, want ambiguous", d.Reason)
+	}
+}
+
+func TestClassify_NoFeatureFiles(t *testing.T) {
+	rules := testRules()
+	d := ClassifyFeature(rules, nil, "trk-old", 0.6)
+	if d.Reason != "no-attribution" {
+		t.Fatalf("reason = %q, want no-attribution", d.Reason)
+	}
+	if d.ProposedTrack != "" {
+		t.Fatalf("proposed_track = %q, want empty", d.ProposedTrack)
+	}
+	if d.FileCount != 0 {
+		t.Fatalf("file_count = %d, want 0", d.FileCount)
+	}
+}
+
+func TestClassify_RulePriorityWins(t *testing.T) {
+	// rule A glob=internal/blame/** (priority 100) → trk-lineage
+	// rule B glob=cmd/htmlgraph/blame.go (priority 110) → trk-lineage
+	// To test priority resolution we need two rules with overlapping globs but different track IDs.
+	rules := &RuleSet{Rules: []Rule{
+		{Glob: "cmd/htmlgraph/**", TrackID: "trk-broad", Priority: 50},
+		{Glob: "cmd/htmlgraph/blame.go", TrackID: "trk-lineage", Priority: 200},
+	}}
+	files := fakeFiles("feat-prio", "cmd/htmlgraph/blame.go")
+	d := ClassifyFeature(rules, files, "trk-old", 0.6)
+	if d.ProposedTrack != "trk-lineage" {
+		t.Fatalf("proposed_track = %q, want trk-lineage (higher priority should win)", d.ProposedTrack)
+	}
+}
+
+func TestClassify_NoMatchingRules(t *testing.T) {
+	rules := testRules()
+	files := fakeFiles("feat-noop", "some/random/path.txt", "another/file.md")
+	d := ClassifyFeature(rules, files, "trk-old", 0.6)
+	if d.Reason != "no-match" {
+		t.Fatalf("reason = %q, want no-match", d.Reason)
+	}
+	if d.Ambiguous {
+		t.Fatalf("no-match must not be flagged ambiguous: %+v", d)
+	}
+	if d.ProposedTrack != "" {
+		t.Fatalf("proposed_track = %q, want empty for no-match", d.ProposedTrack)
+	}
+	if d.FileCount != 2 {
+		t.Fatalf("file_count = %d, want 2 (files exist, just no rule matched)", d.FileCount)
+	}
+}
+
+func TestClassify_AlreadyOnDominantTrack(t *testing.T) {
+	rules := testRules()
+	files := fakeFiles("feat-stay", "cmd/htmlgraph/yolo.go", "cmd/htmlgraph/tmux.go")
+	d := ClassifyFeature(rules, files, "trk-yolo", 0.6) // current == dominant
+	if d.Reason != "no-change" {
+		t.Fatalf("reason = %q, want no-change", d.Reason)
+	}
+	if d.ProposedTrack != "trk-yolo" {
+		t.Fatalf("proposed_track = %q, want trk-yolo", d.ProposedTrack)
+	}
+}
+
+func TestLoadRules_ParsesYAML(t *testing.T) {
+	yaml := `rules:
+  - { glob: "cmd/htmlgraph/yolo.go", track_id: "trk-yolo", priority: 110 }
+  - { glob: "internal/blame/**", track_id: "trk-lineage", priority: 100 }
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rules.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	rs, err := LoadRules(path)
+	if err != nil {
+		t.Fatalf("LoadRules: %v", err)
+	}
+	if len(rs.Rules) != 2 {
+		t.Fatalf("got %d rules, want 2", len(rs.Rules))
+	}
+	if rs.Rules[0].Glob != "cmd/htmlgraph/yolo.go" || rs.Rules[0].TrackID != "trk-yolo" || rs.Rules[0].Priority != 110 {
+		t.Fatalf("rule[0] = %+v", rs.Rules[0])
+	}
+}
+
+func TestClassify_HandlesAbsolutePaths(t *testing.T) {
+	rules := testRules()
+	// File paths captured by hooks running in a worktree are absolute.
+	files := fakeFiles("feat-abs",
+		"/workspaces/htmlgraph/.claude/worktrees/wt-foo/cmd/htmlgraph/yolo.go",
+		"/workspaces/htmlgraph/cmd/htmlgraph/tmux.go",
+	)
+	d := ClassifyFeature(rules, files, "trk-old", 0.6)
+	if d.ProposedTrack != "trk-yolo" {
+		t.Fatalf("absolute paths not normalized: proposed=%q reason=%q", d.ProposedTrack, d.Reason)
+	}
+	if d.Reason != "confident" {
+		t.Fatalf("reason = %q, want confident", d.Reason)
+	}
+}
+
+func TestNormalizePath(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"cmd/htmlgraph/yolo.go", "cmd/htmlgraph/yolo.go"},
+		{"/workspaces/htmlgraph/cmd/htmlgraph/yolo.go", "cmd/htmlgraph/yolo.go"},
+		{"/repo/.claude/worktrees/x/internal/blame/blame.go", "internal/blame/blame.go"},
+		{"/random/path/with/no/anchor.txt", "/random/path/with/no/anchor.txt"},
+		{"/foo/plugin/agents/x.md", "plugin/agents/x.md"},
+		// Worktree prefix with cmd/ underneath
+		{"/workspaces/htmlgraph/.claude/worktrees/wt-foo/cmd/htmlgraph/plan_show.go",
+			"cmd/htmlgraph/plan_show.go"},
+		// .githooks anchor
+		{"/workspaces/htmlgraph/.githooks/pre-commit", ".githooks/pre-commit"},
+	}
+	for _, c := range cases {
+		got := normalizePath(c.in)
+		if got != c.want {
+			t.Errorf("normalizePath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestMatchGlob_DoubleStar(t *testing.T) {
+	cases := []struct {
+		glob, path string
+		want       bool
+	}{
+		{"internal/blame/**", "internal/blame/blame.go", true},
+		{"internal/blame/**", "internal/blame/sub/areas.go", true},
+		{"internal/blame/**", "internal/other/blame.go", false},
+		{"cmd/htmlgraph/plan_*.go", "cmd/htmlgraph/plan_create.go", true},
+		{"cmd/htmlgraph/plan_*.go", "cmd/htmlgraph/plan_sub/file.go", false},
+		{"cmd/htmlgraph/yolo.go", "cmd/htmlgraph/yolo.go", true},
+		{"cmd/htmlgraph/yolo.go", "cmd/htmlgraph/yolo_test.go", false},
+		{"plugin/agents/*.md", "plugin/agents/sonnet-coder.md", true},
+		{"plugin/agents/*.md", "plugin/agents/sub/x.md", false},
+	}
+	for _, c := range cases {
+		got := matchGlob(c.glob, c.path)
+		if got != c.want {
+			t.Errorf("matchGlob(%q, %q) = %v, want %v", c.glob, c.path, got, c.want)
+		}
+	}
+}

--- a/internal/migrate/tracks_test.go
+++ b/internal/migrate/tracks_test.go
@@ -131,6 +131,27 @@ func TestClassify_NoMatchingRules(t *testing.T) {
 	}
 }
 
+func TestClassify_LowConfidenceOnSameTrackStillAmbiguous(t *testing.T) {
+	// Regression: roborev finding — when a feature's current_track happens to
+	// be the dominant track but the dominance is below threshold, the result
+	// must be ambiguous, not no-change. A 1/4 share on the current track is
+	// still split attribution.
+	rules := testRules()
+	files := fakeFiles("feat-low",
+		"cmd/htmlgraph/yolo.go",         // 1 yolo
+		"cmd/htmlgraph/plan_create.go",  // 1 plan
+		"plugin/agents/x.md",            // 1 subagents
+		"internal/blame/blame.go",       // 1 lineage
+	)
+	d := ClassifyFeature(rules, files, "trk-yolo", 0.6)
+	if !d.Ambiguous {
+		t.Fatalf("expected ambiguous (1/4=0.25 < 0.6) even when current==dominant, got %+v", d)
+	}
+	if d.Reason != "ambiguous" {
+		t.Fatalf("reason = %q, want ambiguous", d.Reason)
+	}
+}
+
 func TestClassify_AlreadyOnDominantTrack(t *testing.T) {
 	rules := testRules()
 	files := fakeFiles("feat-stay", "cmd/htmlgraph/yolo.go", "cmd/htmlgraph/tmux.go")


### PR DESCRIPTION
## Summary

- Adds `htmlgraph migrate-tracks` — a rules-based classifier that walks every feature, matches its `feature_files` paths against a YAML glob catalog, and re-attributes confident matches to the dominant value-aligned track. Ambiguous features are flagged for human review rather than silently moved.
- Ships the live rule catalog at `docs/track-attribution-rules.yaml` covering Plan Mode, Subagents, Yolo Mode, and Workitem Attribution & Lineage.
- Includes the regenerated `docs/code-areas.md` snapshot reflecting the live `--write` run on the repo (2 confident moves; Yolo Mode file count grew from 3 to 15).

## Implementation highlights

- **`internal/migrate/`** new package: `Rule`, `RuleSet`, `Decision`, `LoadRules`, `ClassifyFeature`, `ClassifyAll`, plus a tiny `**`-aware glob matcher and worktree-prefix path normalization (so absolute paths captured by tool hooks match repo-relative globs).
- **`cmd/htmlgraph/migrate_tracks.go`** cobra command: `--dry-run` / `--write`, `--types features|bugs`, `--ambiguity-threshold`, `--format text|json`, `--force` for manifest overwrite. Direct re-attribution via `workitem.Project` (no subprocess); audit manifest at `.htmlgraph/migrations/track-backfill-<unix>.json`.
- Decision categories: `confident`, `ambiguous`, `no-attribution`, `no-match`, `no-change` — only `confident` mutates state.

## Roborev fixes (job 143, all 5 medium findings closed)

1. Ambiguity threshold now applied **before** the `currentTrack==dominantTrack` shortcut — split attribution that happens to land on the current track is no longer reported as `no-change`.
2. `Decision.ItemType` carries `feature` vs `bug`; `applyDecisions` dispatches via `collectionFor()` so `--types bugs --write` edits `p.Bugs` and bug `part_of` edges, not `p.Features`.
3. `runMigrateTracks` now takes a separate `status` writer wired to stderr — `--format json --write` keeps stdout pure-JSON-parseable.
4. New `validateProposedTracks()` runs before any mutation; aborts the `--write` run if any rule references a non-existent track ID (typo guard).
5. `internal/blame/areas.go` now distinguishes `ENOENT` (skip — file deleted) from other stat errors (propagate), so `git ls-files` ghosts don't leak into the area inventory via stale `feature_files` rows.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — all pass
- [x] Regression test per roborev finding (4 in `cmd/htmlgraph/migrate_tracks_test.go` + `internal/migrate/tracks_test.go`, 1 in `internal/blame/areas_test.go`)
- [x] Live `--dry-run` against full feature corpus (113 features classified)
- [x] Live `--write` applied (2 confident moves; manifest at `track-backfill-1777636735.json`)
- [x] `htmlgraph reindex --full` to refresh SQLite read index
- [x] `htmlgraph code-areas --format markdown` regenerated; Yolo Mode 3 → 15 files, Plan Mode stable at 11
- [x] Smoke tests: `htmlgraph blame cmd/htmlgraph/yolo.go` now attributes to Yolo Mode (was Local cockpit)

## Out of scope

- 85 features have no `feature_files` rows at all (separate upstream gap — features missing from the canonical HTML store). Documented; not addressed here.
- Bugs are opt-in via `--types bugs` but no live bug migration was performed in this PR (deferred to follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)