### PR TITLE
bug-cc26f6d1: remove stale team_name claim from orchestrator skill doc

### DIFF
--- a/packages/codex-marketplace/.agents/plugins/htmlgraph/skills/orchestrator-directives-skill/SKILL.md
+++ b/packages/codex-marketplace/.agents/plugins/htmlgraph/skills/orchestrator-directives-skill/SKILL.md
@@ -961,7 +961,7 @@ htmlgraph feature start/complete for attribution.
 
 When agent teams are active, HtmlGraph automatically records:
 
-- **Teammate identity** — every TeammateIdle, TaskCreated, and TaskCompleted event includes `teammate_name` and `team_name`
+- **Teammate identity** — every TeammateIdle, TaskCreated, and TaskCompleted event includes `teammate_name`
 - **Step attribution** — feature steps are prefixed with `[teammate-name]` so `htmlgraph snapshot` shows who did what
 - **Optional quality gate** — TaskCompleted can run build/test gates before allowing task completion. Opt-in via `.htmlgraph/config.json`:
 

--- a/packages/gemini-extension/skills/orchestrator-directives-skill/SKILL.md
+++ b/packages/gemini-extension/skills/orchestrator-directives-skill/SKILL.md
@@ -961,7 +961,7 @@ htmlgraph feature start/complete for attribution.
 
 When agent teams are active, HtmlGraph automatically records:
 
-- **Teammate identity** — every TeammateIdle, TaskCreated, and TaskCompleted event includes `teammate_name` and `team_name`
+- **Teammate identity** — every TeammateIdle, TaskCreated, and TaskCompleted event includes `teammate_name`
 - **Step attribution** — feature steps are prefixed with `[teammate-name]` so `htmlgraph snapshot` shows who did what
 - **Optional quality gate** — TaskCompleted can run build/test gates before allowing task completion. Opt-in via `.htmlgraph/config.json`:
 

--- a/plugin/skills/orchestrator-directives-skill/SKILL.md
+++ b/plugin/skills/orchestrator-directives-skill/SKILL.md
@@ -961,7 +961,7 @@ htmlgraph feature start/complete for attribution.
 
 When agent teams are active, HtmlGraph automatically records:
 
-- **Teammate identity** — every TeammateIdle, TaskCreated, and TaskCompleted event includes `teammate_name` and `team_name`
+- **Teammate identity** — every TeammateIdle, TaskCreated, and TaskCompleted event includes `teammate_name`
 - **Step attribution** — feature steps are prefixed with `[teammate-name]` so `htmlgraph snapshot` shows who did what
 - **Optional quality gate** — TaskCompleted can run build/test gates before allowing task completion. Opt-in via `.htmlgraph/config.json`:
 


### PR DESCRIPTION
## Summary
- Removes the stale `team_name` claim from `plugin/skills/orchestrator-directives-skill/SKILL.md:964`
- Regenerates the harness-port copies (Codex marketplace + Gemini extension) so all three trees stay in sync
- Closes roborev review 157 (verdict was Fail on the first commit because regen was missing — fix added in second commit)

## Why
The doc claimed every `TeammateIdle` / `TaskCreated` / `TaskCompleted` event includes both `teammate_name` and `team_name`. Verified false:
- `internal/hooks/runner.go:65` — `TeamName` field exists on the `CloudEvent` struct
- `internal/hooks/missing_events.go:113-256` — the three handlers never populate or persist `TeamName`; attribution is keyed off `TeammateName` only

## Commits
1. `a75fb951` — strip the stale claim from the canonical source
2. `8715b570` — `htmlgraph plugin build-ports` to propagate to generated Codex/Gemini trees

## Test plan
- [x] Doc-only change; no functional tests apply
- [x] Surrounding sentence remains grammatical and the bullet structure is intact
- [x] All three skill copies (plugin/, packages/codex-marketplace/, packages/gemini-extension/) carry identical text
- [x] Roborev review 157 addressed and closed

## Out of scope
Option (b) from the bug spec — wire up `team_name` end-to-end. Defer until per-team analytics is required.