### PR TITLE
chore(.htmlgraph): record 7 resets + 2 completes from post-merge cleanup pass

### DIFF
--- a/.htmlgraph/bugs/bug-28544453.html
+++ b/.htmlgraph/bugs/bug-28544453.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-28544453"
              data-type="bug"
-             data-status="in-progress"
+             data-status="done"
              data-priority="high"
              data-created="2026-05-01T17:55:54.305561"
-             data-updated="2026-05-01T18:00:32.818746" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
+             data-updated="2026-05-01T18:17:47.122604" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
 
         <header>
             <h1>Add reset verb to revert work items from in-progress to todo</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-high">High Priority</span>
             </div>
         </header>

--- a/.htmlgraph/bugs/bug-cc26f6d1.html
+++ b/.htmlgraph/bugs/bug-cc26f6d1.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-cc26f6d1"
              data-type="bug"
-             data-status="todo"
+             data-status="done"
              data-priority="medium"
              data-created="2026-04-26T08:09:35.792433"
-             data-updated="2026-04-26T08:09:35.800458" data-agent-assigned="claude-code" data-track-id="trk-a30e8df4">
+             data-updated="2026-05-01T18:17:47.165941" data-agent-assigned="claude-code" data-track-id="trk-a30e8df4">
 
         <header>
             <h1>Stale doc claim: orchestrator skill says team_name is recorded, but no field/DB write exists</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>

--- a/.htmlgraph/bugs/bug-f0eff9b7.html
+++ b/.htmlgraph/bugs/bug-f0eff9b7.html
@@ -10,30 +10,30 @@
 <body>
     <article id="bug-f0eff9b7"
              data-type="bug"
-             data-status="in-progress"
+             data-status="todo"
              data-priority="high"
              data-created="2026-04-25T23:31:35.662584"
-             data-updated="2026-04-25T23:34:38.529801" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+             data-updated="2026-05-01T18:17:46.688393" data-track-id="trk-cb36e595">
 
         <header>
             <h1>Host registry accumulates thousands of ghost projects</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-todo">Todo</span>
                 <span class="badge priority-high">High Priority</span>
             </div>
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="implemented_in">
-                <h3>Implemented In:</h3>
-                <ul>
-                    <li><a href="5e85926c-910a-4822-acef-3718333ec6dc.html" data-relationship="implemented_in" data-since="2026-04-25T23:32:04.142017">session 5e85926c-910a-4822-acef-3718333ec6dc</a></li>
-                </ul>
-            </section>
             <section data-edge-type="part_of">
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="trk-cb36e595.html" data-relationship="part_of" data-since="2026-04-25T23:31:35.669933">trk-cb36e595</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="5e85926c-910a-4822-acef-3718333ec6dc.html" data-relationship="implemented_in" data-since="2026-04-25T23:32:04.142017">session 5e85926c-910a-4822-acef-3718333ec6dc</a></li>
                 </ul>
             </section>
         </nav>

--- a/.htmlgraph/features/feat-605aaaac.html
+++ b/.htmlgraph/features/feat-605aaaac.html
@@ -10,26 +10,20 @@
 <body>
     <article id="feat-605aaaac"
              data-type="feature"
-             data-status="in-progress"
+             data-status="todo"
              data-priority="medium"
              data-created="2026-04-26T20:02:40.881593"
-             data-updated="2026-04-26T20:06:57.084188" data-agent-assigned="claude-code" data-track-id="trk-c4615ad2">
+             data-updated="2026-05-01T18:17:46.763878" data-track-id="trk-c4615ad2">
 
         <header>
             <h1>PREREQ: Fix stale internal/otel/receiver import in indexer_test</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-todo">Todo</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="planned_in">
-                <h3>Planned In:</h3>
-                <ul>
-                    <li><a href="plan-8ee8f517.html" data-relationship="planned_in" data-since="2026-04-26T20:02:40.888865">plan-8ee8f517</a></li>
-                </ul>
-            </section>
             <section data-edge-type="part_of">
                 <h3>Part Of:</h3>
                 <ul>
@@ -40,6 +34,12 @@
                 <h3>Implemented In:</h3>
                 <ul>
                     <li><a href="9db86a91-da81-4149-b443-a3d8bb0fcc63.html" data-relationship="implemented_in" data-since="2026-04-26T20:06:57.083983">session 9db86a91-da81-4149-b443-a3d8bb0fcc63</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-8ee8f517.html" data-relationship="planned_in" data-since="2026-04-26T20:02:40.888865">plan-8ee8f517</a></li>
                 </ul>
             </section>
         </nav>

--- a/.htmlgraph/features/feat-79d030c4.html
+++ b/.htmlgraph/features/feat-79d030c4.html
@@ -10,15 +10,15 @@
 <body>
     <article id="feat-79d030c4"
              data-type="feature"
-             data-status="in-progress"
+             data-status="todo"
              data-priority="medium"
              data-created="2026-04-23T04:22:35.899495"
-             data-updated="2026-04-23T04:40:34.778015" data-agent-assigned="claude-code">
+             data-updated="2026-05-01T18:17:46.828732">
 
         <header>
             <h1>Path-normalization at write-time in work-item capture</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-todo">Todo</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>

--- a/.htmlgraph/features/feat-ac7532be.html
+++ b/.htmlgraph/features/feat-ac7532be.html
@@ -10,15 +10,15 @@
 <body>
     <article id="feat-ac7532be"
              data-type="feature"
-             data-status="in-progress"
+             data-status="todo"
              data-priority="medium"
              data-created="2026-04-29T16:43:57.363196"
-             data-updated="2026-04-30T06:30:41.292016" data-agent-assigned="claude-code" data-track-id="trk-cb36e595">
+             data-updated="2026-05-01T18:17:46.914583" data-track-id="trk-cb36e595">
 
         <header>
             <h1>Resilient harness-agnostic telemetry capture (collector hardening &#43; Codex/Gemini support)</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-todo">Todo</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>

--- a/.htmlgraph/features/feat-d1f3b2a6.html
+++ b/.htmlgraph/features/feat-d1f3b2a6.html
@@ -10,20 +10,32 @@
 <body>
     <article id="feat-d1f3b2a6"
              data-type="feature"
-             data-status="in-progress"
+             data-status="todo"
              data-priority="medium"
              data-created="2026-04-26T20:02:40.862401"
-             data-updated="2026-04-26T21:34:25.515225" data-agent-assigned="claude-code" data-track-id="trk-c4615ad2">
+             data-updated="2026-05-01T18:17:46.988126" data-track-id="trk-c4615ad2">
 
         <header>
             <h1>Document NDJSON-canonical, SQLite-derived contract</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-todo">Todo</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
 
         <nav data-graph-edges>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="9db86a91-da81-4149-b443-a3d8bb0fcc63.html" data-relationship="implemented_in" data-since="2026-04-26T21:34:25.514922">session 9db86a91-da81-4149-b443-a3d8bb0fcc63</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-c4615ad2.html" data-relationship="part_of" data-since="2026-04-26T20:02:40.864522">trk-c4615ad2</a></li>
+                </ul>
+            </section>
             <section data-edge-type="planned_in">
                 <h3>Planned In:</h3>
                 <ul>
@@ -37,18 +49,6 @@
                     <li><a href="feat-03deaa60.html" data-relationship="blocked_by" data-since="2026-04-26T20:02:40.917516">feat-03deaa60</a></li>
                     <li><a href="feat-0fe674d9.html" data-relationship="blocked_by" data-since="2026-04-26T20:02:40.91933">feat-0fe674d9</a></li>
                     <li><a href="feat-7837411f.html" data-relationship="blocked_by" data-since="2026-04-26T20:02:40.921736">feat-7837411f</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="implemented_in">
-                <h3>Implemented In:</h3>
-                <ul>
-                    <li><a href="9db86a91-da81-4149-b443-a3d8bb0fcc63.html" data-relationship="implemented_in" data-since="2026-04-26T21:34:25.514922">session 9db86a91-da81-4149-b443-a3d8bb0fcc63</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="part_of">
-                <h3>Part Of:</h3>
-                <ul>
-                    <li><a href="trk-c4615ad2.html" data-relationship="part_of" data-since="2026-04-26T20:02:40.864522">trk-c4615ad2</a></li>
                 </ul>
             </section>
         </nav>

--- a/.htmlgraph/features/feat-de257710.html
+++ b/.htmlgraph/features/feat-de257710.html
@@ -10,15 +10,15 @@
 <body>
     <article id="feat-de257710"
              data-type="feature"
-             data-status="in-progress"
+             data-status="todo"
              data-priority="medium"
              data-created="2026-04-21T17:45:17.462683"
-             data-updated="2026-04-21T19:32:14.596256" data-agent-assigned="claude-code" data-track-id="trk-0677c709">
+             data-updated="2026-05-01T18:17:47.021107" data-track-id="trk-0677c709">
 
         <header>
             <h1>Configure Oh My Posh statusline</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-todo">Todo</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>

--- a/.htmlgraph/spikes/spk-09d20cf8.html
+++ b/.htmlgraph/spikes/spk-09d20cf8.html
@@ -10,15 +10,15 @@
 <body>
     <article id="spk-09d20cf8"
              data-type="spike"
-             data-status="in-progress"
+             data-status="todo"
              data-priority="medium"
              data-created="2026-04-25T22:55:02.28288"
-             data-updated="2026-04-25T22:55:24.550767" data-agent-assigned="claude-code">
+             data-updated="2026-05-01T18:17:47.06126">
 
         <header>
             <h1>TUI dashboard prototype</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-todo">Todo</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>


### PR DESCRIPTION
## Summary
- 7 stale items reverted to todo via the new `htmlgraph X reset` verb (PR #74)
- 2 bugs marked complete: bug-28544453 (reset verb) and bug-cc26f6d1 (doc fix)
- Pure bookkeeping; no code changes

## Why
Post-merge cleanup of WIP. The 7 reset items were "in-progress" but never started — `reset` (newly available after #74 merged) is the right verb. The 2 completed bugs shipped via the merged PRs.

WIP went from 9 → 0 active.

## Test plan
- [x] `git diff` shows only `data-status` and `data-updated` flips
- [x] No code changes; nothing to test functionally
- [x] `htmlgraph wip show` reports 0 / 5