### PR TITLE
bug-92690d5b: htmlgraph yolo handles existing branch on --track re-run

### DIFF
--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -224,8 +224,18 @@ func addOrAttachWorktree(repoRoot, worktreePath, branchName string) (string, boo
 	// so the porcelain listing reflects current on-disk state. Best-effort.
 	_ = exec.Command("git", "-C", repoRoot, "worktree", "prune").Run()
 
+	managedRoot := filepath.Join(repoRoot, ".claude", "worktrees")
 	if existing := worktreeOnBranch(repoRoot, branchName); existing != "" {
-		return existing, false, nil
+		// Only reuse worktrees we manage. The branch may be checked out at the
+		// main repo path or some external worktree — silently running yolo
+		// against either of those would bypass isolation.
+		if isUnderDir(existing, managedRoot) {
+			return existing, false, nil
+		}
+		return "", false, fmt.Errorf(
+			"branch %s is already checked out at %s (outside %s); "+
+				"switch or remove that checkout before re-running",
+			branchName, existing, managedRoot)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(worktreePath), 0755); err != nil {
@@ -247,11 +257,33 @@ func addOrAttachWorktree(repoRoot, worktreePath, branchName string) (string, boo
 	return worktreePath, true, nil
 }
 
+// isUnderDir reports whether path is the same as, or nested under, dir.
+// Both paths are resolved to absolute form before comparison so callers can
+// pass repo-relative inputs from `git worktree list --porcelain` without
+// worrying about format differences.
+func isUnderDir(path, dir string) bool {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(absDir, absPath)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
 // worktreeOnBranch returns the path of the worktree currently checked out on
 // branchName per `git worktree list --porcelain`, or "" when no worktree is on
 // that branch. The porcelain format is more authoritative than scanning a
 // directory because it reflects worktrees registered anywhere in the repo and
-// stays accurate after `git worktree prune`.
+// stays accurate after `git worktree prune`. Callers must filter the result
+// against an expected parent directory before reusing — the helper itself
+// does not constrain location.
 func worktreeOnBranch(repoRoot, branchName string) string {
 	out, err := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain").Output()
 	if err != nil {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -98,20 +98,20 @@ func EnsureForFeature(featureID, repoRoot string, w io.Writer) (string, error) {
 		return worktreePath, nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(worktreePath), 0755); err != nil {
-		return "", fmt.Errorf("could not create worktrees directory: %w", err)
+	resolved, created, err := addOrAttachWorktree(repoRoot, worktreePath, branchName)
+	if err != nil {
+		return "", err
+	}
+	if !created {
+		fmt.Fprintf(w, "  Worktree: %s (reusing existing)\n", resolved)
+		return resolved, nil
 	}
 
-	cmd := exec.Command("git", "-C", repoRoot, "worktree", "add", worktreePath, "-b", branchName)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("git worktree add failed: %w\n%s", err, out)
-	}
+	fmt.Fprintf(w, "  Worktree: %s (branch: %s)\n", resolved, branchName)
+	excludeHtmlgraphFromWorktree(resolved, w)
+	reindexWorktree(resolved, w)
 
-	fmt.Fprintf(w, "  Worktree: %s (branch: %s)\n", worktreePath, branchName)
-	excludeHtmlgraphFromWorktree(worktreePath, w)
-	reindexWorktree(worktreePath, w)
-
-	return worktreePath, nil
+	return resolved, nil
 }
 
 // EnsureForTrack ensures a git worktree exists for the given track and returns its path.
@@ -126,20 +126,20 @@ func EnsureForTrack(trackID, repoRoot string, w io.Writer) (string, error) {
 		return worktreePath, nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(worktreePath), 0755); err != nil {
-		return "", fmt.Errorf("could not create worktrees directory: %w", err)
+	resolved, created, err := addOrAttachWorktree(repoRoot, worktreePath, branchName)
+	if err != nil {
+		return "", err
+	}
+	if !created {
+		fmt.Fprintf(w, "  Worktree: %s (reusing existing)\n", resolved)
+		return resolved, nil
 	}
 
-	cmd := exec.Command("git", "-C", repoRoot, "worktree", "add", worktreePath, "-b", branchName)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("git worktree add failed: %w\n%s", err, out)
-	}
+	fmt.Fprintf(w, "  Worktree: %s (branch: %s)\n", resolved, branchName)
+	excludeHtmlgraphFromWorktree(resolved, w)
+	reindexWorktree(resolved, w)
 
-	fmt.Fprintf(w, "  Worktree: %s (branch: %s)\n", worktreePath, branchName)
-	excludeHtmlgraphFromWorktree(worktreePath, w)
-	reindexWorktree(worktreePath, w)
-
-	return worktreePath, nil
+	return resolved, nil
 }
 
 // TrackWorktreeDirName returns the directory name to use for a track worktree.
@@ -193,20 +193,85 @@ func EnsureForTrackTitled(trackTitle, trackID, repoRoot string, w io.Writer) (st
 		return worktreePath, nil
 	}
 
+	resolved, created, err := addOrAttachWorktree(repoRoot, worktreePath, branchName)
+	if err != nil {
+		return "", err
+	}
+	if !created {
+		fmt.Fprintf(w, "  Worktree: %s (reusing existing)\n", resolved)
+		return resolved, nil
+	}
+
+	fmt.Fprintf(w, "  Worktree: %s (branch: %s)\n", resolved, branchName)
+	excludeHtmlgraphFromWorktree(resolved, w)
+	reindexWorktree(resolved, w)
+
+	return resolved, nil
+}
+
+// addOrAttachWorktree creates a git worktree at worktreePath for branchName, or
+// returns the path of an existing worktree when one is already checked out on the
+// branch. This makes track/feature worktree creation idempotent against the
+// "branch already exists" failure that occurs when the worktree directory was
+// removed but the branch reference persists from a prior run (bug-92690d5b).
+//
+// Returns (resolvedPath, created, err):
+//   - resolvedPath equals worktreePath when a new worktree was created,
+//     otherwise it's the path of the pre-existing worktree on branchName.
+//   - created is true only when this call created a new worktree on disk.
+func addOrAttachWorktree(repoRoot, worktreePath, branchName string) (string, bool, error) {
+	// Prune stale worktree registrations (e.g. from manually-deleted directories)
+	// so the porcelain listing reflects current on-disk state. Best-effort.
+	_ = exec.Command("git", "-C", repoRoot, "worktree", "prune").Run()
+
+	if existing := worktreeOnBranch(repoRoot, branchName); existing != "" {
+		return existing, false, nil
+	}
+
 	if err := os.MkdirAll(filepath.Dir(worktreePath), 0755); err != nil {
-		return "", fmt.Errorf("could not create worktrees directory: %w", err)
+		return "", false, fmt.Errorf("could not create worktrees directory: %w", err)
 	}
 
-	cmd := exec.Command("git", "-C", repoRoot, "worktree", "add", worktreePath, "-b", branchName)
+	branchExists := exec.Command("git", "-C", repoRoot, "rev-parse", "--verify", "refs/heads/"+branchName).Run() == nil
+
+	var cmd *exec.Cmd
+	if branchExists {
+		// Attach to existing branch — omit -b so git does not try to create it.
+		cmd = exec.Command("git", "-C", repoRoot, "worktree", "add", worktreePath, branchName)
+	} else {
+		cmd = exec.Command("git", "-C", repoRoot, "worktree", "add", worktreePath, "-b", branchName)
+	}
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("git worktree add failed: %w\n%s", err, out)
+		return "", false, fmt.Errorf("git worktree add failed: %w\n%s", err, out)
 	}
+	return worktreePath, true, nil
+}
 
-	fmt.Fprintf(w, "  Worktree: %s (branch: %s)\n", worktreePath, branchName)
-	excludeHtmlgraphFromWorktree(worktreePath, w)
-	reindexWorktree(worktreePath, w)
-
-	return worktreePath, nil
+// worktreeOnBranch returns the path of the worktree currently checked out on
+// branchName per `git worktree list --porcelain`, or "" when no worktree is on
+// that branch. The porcelain format is more authoritative than scanning a
+// directory because it reflects worktrees registered anywhere in the repo and
+// stays accurate after `git worktree prune`.
+func worktreeOnBranch(repoRoot, branchName string) string {
+	out, err := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain").Output()
+	if err != nil {
+		return ""
+	}
+	var path string
+	fullRef := "refs/heads/" + branchName
+	for line := range strings.SplitSeq(string(out), "\n") {
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			path = strings.TrimPrefix(line, "worktree ")
+		case strings.HasPrefix(line, "branch "):
+			if strings.TrimPrefix(line, "branch ") == fullRef {
+				return path
+			}
+		case line == "":
+			path = ""
+		}
+	}
+	return ""
 }
 
 // findExistingWorktreeForBranch scans the worktrees directory under repoRoot for any

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -344,6 +344,36 @@ func TestEnsureForTrackTitled_BranchExistsWithoutWorktree(t *testing.T) {
 	}
 }
 
+// TestEnsureForTrackTitled_BranchCheckedOutInMainRepo guards against silently
+// reusing a non-isolated checkout (review finding from job 162). When the track
+// branch happens to be checked out in the main repo (or any path outside
+// .claude/worktrees/), EnsureForTrackTitled must refuse to attach rather than
+// running yolo against the user's primary working tree.
+func TestEnsureForTrackTitled_BranchCheckedOutInMainRepo(t *testing.T) {
+	dir := setupGitRepo(t)
+
+	// Create the track branch and check it out in the MAIN repo — simulating
+	// `git checkout trk-X` outside any managed worktree.
+	if out, err := exec.Command("git", "-C", dir, "checkout", "-b", "trk-mainrepo01").CombinedOutput(); err != nil {
+		t.Fatalf("git checkout -b: %v: %s", err, out)
+	}
+
+	// EnsureForTrackTitled must NOT reuse the main repo path.
+	_, err := worktree.EnsureForTrackTitled("Main Repo Track", "trk-mainrepo01", dir, io.Discard)
+	if err == nil {
+		t.Fatalf("expected error when branch is checked out in main repo, got nil")
+	}
+	if !strings.Contains(err.Error(), "already checked out") {
+		t.Errorf("expected 'already checked out' in error, got: %v", err)
+	}
+
+	// And the managed worktree directory must NOT have been created.
+	managedPath := filepath.Join(dir, ".claude", "worktrees", "main-repo-track-trk-mainrepo01")
+	if _, statErr := os.Stat(managedPath); statErr == nil {
+		t.Errorf("managed worktree should not have been created at %s", managedPath)
+	}
+}
+
 // TestEnsureForTrackTitled_StaleRegistrationAfterManualRemoval covers the case
 // where the worktree directory was rm-rf'd manually (no `git worktree remove`),
 // so git's worktree registration is stale. EnsureForTrackTitled must prune and

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -295,3 +295,77 @@ func TestEnsureForTrackTitled_TitleRenameIdempotent(t *testing.T) {
 		t.Errorf("title rename must not change worktree path: before=%q after=%q", path1, path2)
 	}
 }
+
+// TestEnsureForTrackTitled_BranchExistsWithoutWorktree is the regression test for
+// bug-92690d5b: a prior `htmlgraph yolo --track <id>` left the branch behind but
+// the worktree directory was removed (or the path was deleted manually). A second
+// invocation must succeed by attaching to the existing branch instead of failing
+// with `fatal: a branch named '<id>' already exists`.
+func TestEnsureForTrackTitled_BranchExistsWithoutWorktree(t *testing.T) {
+	dir := setupGitRepo(t)
+
+	// First call creates branch + titled worktree.
+	path1, err := worktree.EnsureForTrackTitled("Re-run Track", "trk-rerun01", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("first EnsureForTrackTitled: %v", err)
+	}
+
+	// Properly remove the worktree (branch persists, worktree registration is
+	// deleted along with the directory). This is the steady-state shape of the
+	// bug — a prior session torn down its worktree but the branch sticks around.
+	if out, err := exec.Command("git", "-C", dir, "worktree", "remove", "--force", path1).CombinedOutput(); err != nil {
+		t.Fatalf("git worktree remove: %v: %s", err, out)
+	}
+
+	// Sanity: the directory is gone but the branch survives.
+	if _, err := os.Stat(path1); !os.IsNotExist(err) {
+		t.Fatalf("worktree dir should be gone, got err=%v", err)
+	}
+	if err := exec.Command("git", "-C", dir, "rev-parse", "--verify", "refs/heads/trk-rerun01").Run(); err != nil {
+		t.Fatalf("branch should still exist after worktree remove: %v", err)
+	}
+
+	// Second call must succeed by attaching to the existing branch.
+	path2, err := worktree.EnsureForTrackTitled("Re-run Track", "trk-rerun01", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("second EnsureForTrackTitled (regression for bug-92690d5b): %v", err)
+	}
+	if _, err := os.Stat(path2); err != nil {
+		t.Errorf("second-run worktree should exist at %s: %v", path2, err)
+	}
+
+	// Confirm the worktree is now checked out on the original branch.
+	out, err := exec.Command("git", "-C", path2, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD in re-attached worktree: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "trk-rerun01" {
+		t.Errorf("re-attached worktree HEAD: got %q, want %q", got, "trk-rerun01")
+	}
+}
+
+// TestEnsureForTrackTitled_StaleRegistrationAfterManualRemoval covers the case
+// where the worktree directory was rm-rf'd manually (no `git worktree remove`),
+// so git's worktree registration is stale. EnsureForTrackTitled must prune and
+// recreate without erroring.
+func TestEnsureForTrackTitled_StaleRegistrationAfterManualRemoval(t *testing.T) {
+	dir := setupGitRepo(t)
+
+	path1, err := worktree.EnsureForTrackTitled("Stale Reg Track", "trk-stale01", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("first EnsureForTrackTitled: %v", err)
+	}
+
+	// Manually remove the worktree directory — leaves a stale registration.
+	if err := os.RemoveAll(path1); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	path2, err := worktree.EnsureForTrackTitled("Stale Reg Track", "trk-stale01", dir, io.Discard)
+	if err != nil {
+		t.Fatalf("second EnsureForTrackTitled after manual rm (bug-92690d5b): %v", err)
+	}
+	if _, err := os.Stat(path2); err != nil {
+		t.Errorf("re-created worktree should exist at %s: %v", path2, err)
+	}
+}


### PR DESCRIPTION
## Motivation

Re-running `htmlgraph yolo --track <id>` against a track whose worktree
directory was removed (but whose branch survives) failed with:

```
git worktree add failed: exit status 255
Preparing worktree (new branch 'trk-6e10c73c')
fatal: a branch named 'trk-6e10c73c' already exists
```

Track/feature worktree creation always passed `-b <branch>`, so any
prior run that left the branch behind made every subsequent invocation
fail until the user manually deleted the branch.

## Root cause

`EnsureForTrack`, `EnsureForTrackTitled`, and `EnsureForFeature` in
`internal/worktree/worktree.go` all called `git worktree add <path> -b
<branch>` unconditionally. There was no detect-and-attach path for the
"branch survives, worktree is gone" steady state.

## Fix path

Path (a) from the bug brief: explicit detection beats parsing stderr.

A new `addOrAttachWorktree` helper:

1. Runs `git worktree prune` to clear stale registrations from
   manually-removed worktree directories.
2. Consults `git worktree list --porcelain` for an existing checkout on
   the target branch — if found, returns that path (no new worktree is
   created, no setup steps re-run).
3. Probes `git rev-parse --verify refs/heads/<branch>` and runs
   `git worktree add <path> <branch>` (no `-b`) when the branch already
   exists locally; otherwise creates with `-b` as before.

The three `EnsureFor…` functions now share this helper and skip
`exclude` / `reindex` setup when attaching to an existing worktree.

## Acceptance checklist

- [x] Running `htmlgraph yolo --track <id>` twice in a row succeeds both
      times — covered by the new regression tests.
- [x] Fresh-track creation still works — existing
      `TestEnsureForTrackIdempotent` and friends pass unchanged.
- [x] New unit tests exercise the second-run scenario:
      `TestEnsureForTrackTitled_BranchExistsWithoutWorktree` (graceful
      `git worktree remove`) and
      `TestEnsureForTrackTitled_StaleRegistrationAfterManualRemoval`
      (manual `rm -rf`). Both reproduce the exact stderr from the bug
      report against unpatched code.
- [x] `go build ./... && go vet ./... && go test ./...` all pass.
- [x] `htmlgraph build` succeeds.

## Out of scope

- The "Update available" banner UX point in the bug description (filed
  separately, not addressed here).
- The two context-pack v1 caveats (bug-546cda63, bug-792a8319) — already
  filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)