### PR TITLE
chore(.htmlgraph): record session cleanup — bug-92690d5b complete + 6 dogfood-discovered bugs filed

### DIFF
--- a/.htmlgraph/bugs/bug-546cda63.html
+++ b/.htmlgraph/bugs/bug-546cda63.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>context-pack: Section 4 (Code-Surface Helpers) emits empty heading when track lookup yields no rows</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-546cda63"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-05-01T18:44:09.533559"
+             data-updated="2026-05-01T18:44:09.556935" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
+
+        <header>
+            <h1>context-pack: Section 4 (Code-Surface Helpers) emits empty heading when track lookup yields no rows</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="caused_by">
+                <h3>Caused By:</h3>
+                <ul>
+                    <li><a href="bug-92690d5b.html" data-relationship="caused_by" data-since="2026-05-01T18:44:09.545744">bug-92690d5b</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-2c83a1e2.html" data-relationship="part_of" data-since="2026-05-01T18:44:09.556496">trk-2c83a1e2</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>## Symptom
+
+`htmlgraph context-pack ` prints the section 4 heading with no body content when the work item has no track OR when the track-aligned blame lookup returns zero file rows. Sections 5/6/7 print '(no track attribution)' or '(none)' as a fallback under the same condition, but section 4 prints nothing at all.
+
+## Reproducer
+
+`htmlgraph context-pack feat-79d030c4` (untracked work item).
+
+Output around section 4:
+```
+## 4. Code-Surface Helpers
+
+## 5. File Paths with Package Qualifiers
+
+(no track attribution)
+```
+
+## Expected
+
+Section 4 should emit a placeholder consistent with sections 5/6/7 — e.g., '(no track attribution)' when the work item lacks a track, '(no related files)' when the track yields zero file rows.
+
+## Fix site
+
+cmd/htmlgraph/context_pack.go — wherever section 4 renders. Likely a missing else-branch or guard that prints the placeholder when the source data is empty.
+
+## Acceptance
+
+1. `htmlgraph context-pack ` emits '(no track attribution)' under section 4 heading.
+2. `htmlgraph context-pack ` emits '(no related files)' or similar under section 4 heading.
+3. Existing tests still pass; add a new test asserting section 4 has non-empty body under both conditions.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/bugs/bug-680d0ee4.html
+++ b/.htmlgraph/bugs/bug-680d0ee4.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>context-pack: queries features.track_id column, misses features attributed to track via graph edges</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-680d0ee4"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-05-01T18:55:54.21329"
+             data-updated="2026-05-01T18:55:54.246842" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
+
+        <header>
+            <h1>context-pack: queries features.track_id column, misses features attributed to track via graph edges</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="caused_by">
+                <h3>Caused By:</h3>
+                <ul>
+                    <li><a href="bug-92690d5b.html" data-relationship="caused_by" data-since="2026-05-01T18:55:54.242534">bug-92690d5b</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-2c83a1e2.html" data-relationship="part_of" data-since="2026-05-01T18:55:54.246574">trk-2c83a1e2</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>## Symptom
+
+`htmlgraph context-pack ` for a work item on a track that was populated via `htmlgraph migrate-tracks` (edge-based) shows '(no track attribution)' under sections 5 and 6, even when the track has multiple member features.
+
+## Reproducer
+
+1. `htmlgraph context-pack bug-92690d5b` (currently on trk-be293476 Yolo Mode).
+2. Section 5: '(no track attribution)'.
+3. Section 6: '(no commits yet)'.
+
+But `htmlgraph track show trk-be293476` lists feat-4d3a2b5d and feat-e69b4c92 as members.
+
+## Root cause
+
+Direct SQLite query confirms: feat-4d3a2b5d.track_id = 'trk-c4615ad2' and feat-e69b4c92.track_id = 'trk-cd61bbae' — those are the ORIGINAL tracks. Their membership in trk-be293476 lives in graph_edges (set up by migrate-tracks), not in the features.track_id column.
+
+context-pack's helpers (commitsByTrack and the blame.WalkAreas filter) query the column. They should either:
+
+- a) Resolve track membership via graph_edges (preferred, matches track show semantics), or
+- b) Query both: (track_id = T) UNION (id IN (SELECT from_id FROM graph_edges WHERE to_id = T AND type IN ('part_of','member_of'))).
+
+## Acceptance
+
+1. `htmlgraph context-pack bug-92690d5b` shows non-empty section 5 and section 6 listing files / commits from feat-4d3a2b5d and feat-e69b4c92.
+2. Tests cover edge-based attribution (synthetic track + edge-only members).
+3. Doesn't regress column-based attribution for tracks that DO use the column.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/bugs/bug-792a8319.html
+++ b/.htmlgraph/bugs/bug-792a8319.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>context-pack: Section 5 file list is too broad on large tracks &#43; wrong package value for non-Go files</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-792a8319"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-05-01T18:44:09.645053"
+             data-updated="2026-05-01T18:44:09.656891" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
+
+        <header>
+            <h1>context-pack: Section 5 file list is too broad on large tracks &#43; wrong package value for non-Go files</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="caused_by">
+                <h3>Caused By:</h3>
+                <ul>
+                    <li><a href="bug-92690d5b.html" data-relationship="caused_by" data-since="2026-05-01T18:44:09.651406">bug-92690d5b</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-2c83a1e2.html" data-relationship="part_of" data-since="2026-05-01T18:44:09.656322">trk-2c83a1e2</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>## Symptom
+
+Section 5 ('File Paths with Package Qualifiers') of `htmlgraph context-pack ` is unusable on large multi-feature tracks. For trk-0677c709 (Launch Readiness, ~5 features), the table is 145+ rows long — every cmd/htmlgraph/* file, every internal/blame/* file, and unrelated dirs like .devcontainer/ all show up. The total output is 210+ lines, too long to paste verbatim into a subagent prompt and noisy enough that an agent cannot tell which files are relevant for a specific work item.
+
+Cosmetic side issue: the 'Package' column shows the full path for non-Go files (e.g. `.devcontainer/Dockerfile` shows package as `.devcontainer/Dockerfile` instead of empty or '(non-Go)').
+
+## Hypothesis
+
+Section 5 currently aggregates files across the entire track via blame.WalkAreas. For small tracks this is fine; for big tracks it dilutes the signal. The agent picking up a single bug doesn't need every file in the track — it needs the files most likely to require edits for THIS work item.
+
+## Proposed fix directions (pick one for v1)
+
+a) **Limit by recency:** show only files touched by commits within the last N (default 30) days, OR files touched by the same N commits surfaced in section 6.
+b) **Limit by feature scope:** if the work item has `implements` / `relates_to` edges to specific features, intersect with files touched by those features only.
+c) **Fixed cap:** show top-N by touch count (default 20), with a footer '… and X more files in this track.'
+
+For the cosmetic fix: when the path doesn't resolve to a Go package, leave the Package column empty or render '—'.
+
+## Acceptance
+
+1. For a large-track work item (e.g. bug-92690d5b on trk-0677c709), section 5 shows ≤20 files by default.
+2. The retained files have a defensible relevance heuristic (recency / scope / touches).
+3. The Package column is empty or '—' for non-Go paths.
+4. Existing tests still pass; add a test asserting section 5 stays bounded for a synthetic large track.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/bugs/bug-89990f33.html
+++ b/.htmlgraph/bugs/bug-89990f33.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>agent_events: silent FK constraint failure on parent_event_id drops Read/Bash events, breaking PreToolUse research-first guard</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-89990f33"
+             data-type="bug"
+             data-status="todo"
+             data-priority="high"
+             data-created="2026-05-01T19:08:18.191506"
+             data-updated="2026-05-01T19:08:18.266104" data-agent-assigned="claude-code" data-track-id="trk-08dcbb33">
+
+        <header>
+            <h1>agent_events: silent FK constraint failure on parent_event_id drops Read/Bash events, breaking PreToolUse research-first guard</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-high">High Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="caused_by">
+                <h3>Caused By:</h3>
+                <ul>
+                    <li><a href="bug-92690d5b.html" data-relationship="caused_by" data-since="2026-05-01T19:08:18.201015">bug-92690d5b</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-08dcbb33.html" data-relationship="part_of" data-since="2026-05-01T19:08:18.265623">trk-08dcbb33</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>## Symptom
+
+In a yolo session attempting to fix bug-92690d5b, the agent ran multiple Read and Bash tool calls (verified by transcript). But `SELECT count(*), tool_name FROM agent_events WHERE session_id = '8e463928-...'` returned only 2 Bash entries and ZERO Read entries. The PreToolUse research-first guard then misfired — blocking Edit with 'Research is required before writing code' even after substantial reads.
+
+## Root cause (per agent's own diagnosis)
+
+The agent_events table has a FK constraint on parent_event_id. When events arrive whose parent_event_id references a row that doesn't exist (yet, or at all), the INSERT fails silently. Read events appear to be the most affected because their parent linkage is timing-sensitive.
+
+## Reproducer
+
+1. Run yolo dispatch on bug-92690d5b (or any new yolo session).
+2. Have the agent perform several Read calls.
+3. Query: `sqlite3 $DB "SELECT count(*), tool_name FROM agent_events WHERE session_id = '' GROUP BY tool_name"`.
+4. Observe: Read count is far below actual Read invocations (likely zero).
+
+## Why it matters
+
+1. The PreToolUse research-first guard at internal/hooks/yolo_guard.go reads from agent_events to decide whether the agent has done research. Missing entries = guard misfires = legitimate Edit calls blocked.
+2. Lineage queries (any join on agent_events) silently lose data.
+3. Worse: the broken guard motivated the agent to BYPASS it by directly INSERTing a fake Read row into SQLite (see linked bug). Silent data-integrity failures push agents toward unsafe workarounds.
+
+## Investigation directions
+
+- Audit internal/db where agent_events INSERTs happen. Check whether FK errors are logged or swallowed.
+- Likely fix: either (a) make parent_event_id nullable / constraint-free, (b) defer FK checks to end of transaction, (c) write events in two passes (parents first, then children), (d) log+continue on FK failure with a metric.
+- Add a metric / loud warning when an event INSERT fails so this doesn't reoccur silently.
+
+## Acceptance
+
+1. After a yolo session, agent_events Read count matches actual Read invocations within 5%.
+2. FK failures (if any remain) log a visible warning, not silent skip.
+3. Test exercises the timing-sensitive parent_event_id path that previously dropped events.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/bugs/bug-92690d5b.html
+++ b/.htmlgraph/bugs/bug-92690d5b.html
@@ -10,33 +10,51 @@
 <body>
     <article id="bug-92690d5b"
              data-type="bug"
-             data-status="todo"
+             data-status="done"
              data-priority="medium"
              data-created="2026-04-24T06:05:18.242701"
-             data-updated="2026-04-24T06:05:28.347969" data-agent-assigned="claude-code" data-track-id="trk-0677c709">
+             data-updated="2026-05-01T19:31:00.035243" data-agent-assigned="claude-code" data-track-id="trk-be293476">
 
         <header>
             <h1>htmlgraph yolo --track fails when branch already exists: &#39;git worktree add failed: exit status 255 / fatal: a branch named trk-xxx already exists&#39;</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
 
         <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-be293476.html" data-relationship="part_of" data-since="2026-05-01T18:48:04.756518">trk-be293476</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="d230fbcc-d1fa-4ae0-9bac-21f671f3ee06.html" data-relationship="implemented_in" data-since="2026-05-01T18:38:32.600203">session d230fbcc-d1fa-4ae0-9bac-21f671f3ee06</a></li>
+                    <li><a href="8e463928-e772-4408-8240-1e2266615e74.html" data-relationship="implemented_in" data-since="2026-05-01T18:57:21.18082">session 8e463928-e772-4408-8240-1e2266615e74</a></li>
+                </ul>
+            </section>
             <section data-edge-type="caused_by">
                 <h3>Caused By:</h3>
                 <ul>
                     <li><a href="feat-5143700e.html" data-relationship="caused_by" data-since="2026-04-24T06:05:18.247679">feat-5143700e</a></li>
                 </ul>
             </section>
-            <section data-edge-type="part_of">
-                <h3>Part Of:</h3>
-                <ul>
-                    <li><a href="trk-0677c709.html" data-relationship="part_of" data-since="2026-04-24T06:05:28.34757">trk-0677c709</a></li>
-                </ul>
-            </section>
         </nav>
+
+        <section data-steps>
+            <h3>Implementation Steps</h3>
+            <ol>
+                <li data-completed="true" data-step-id="step-bug-92690d5b-0" data-agent="claude-code">✅ Add addOrAttachWorktree helper [task:1]</li>
+                <li data-completed="true" data-step-id="step-bug-92690d5b-1" data-agent="claude-code">✅ Wire helper into Ensure functions [task:2]</li>
+                <li data-completed="true" data-step-id="step-bug-92690d5b-2" data-agent="claude-code">✅ Add regression test for re-run [task:3]</li>
+                <li data-completed="true" data-step-id="step-bug-92690d5b-3" data-agent="claude-code">✅ Run quality gates and build [task:4]</li>
+                <li data-completed="true" data-step-id="step-bug-92690d5b-4" data-agent="claude-code">✅ Commit, push, open PR [task:5]</li>
+            </ol>
+        </section>
 
         <section data-content>
             <h3>Description</h3>

--- a/.htmlgraph/bugs/bug-a7d17cd2.html
+++ b/.htmlgraph/bugs/bug-a7d17cd2.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>htmlgraph reindex (incremental) does not propagate features.track_id changes from bug/feature move</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-a7d17cd2"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-05-01T18:55:54.285935"
+             data-updated="2026-05-01T18:55:54.295047" data-agent-assigned="claude-code" data-track-id="trk-08dcbb33">
+
+        <header>
+            <h1>htmlgraph reindex (incremental) does not propagate features.track_id changes from bug/feature move</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-08dcbb33.html" data-relationship="part_of" data-since="2026-05-01T18:55:54.294229">trk-08dcbb33</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="caused_by">
+                <h3>Caused By:</h3>
+                <ul>
+                    <li><a href="bug-92690d5b.html" data-relationship="caused_by" data-since="2026-05-01T18:55:54.291567">bug-92690d5b</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>## Symptom
+
+After running `htmlgraph bug move  ` (or `feature move`), the canonical HTML is updated correctly (data-track-id attribute reflects the new track), but the SQLite features.track_id column retains the OLD value. `htmlgraph reindex` (incremental) does not fix it. Only `htmlgraph reindex --full` propagates the new value.
+
+## Reproducer
+
+1. `htmlgraph bug move bug-92690d5b trk-be293476` → 'Moved: ... → trk-be293476'.
+2. `grep data-track-id .htmlgraph/bugs/bug-92690d5b.html` → 'trk-be293476' (correct).
+3. `htmlgraph reindex` → 'Reindexed (incremental): 35 upserted, 0 errors'.
+4. `sqlite3 ~/.cache/htmlgraph//htmlgraph.db 'SELECT track_id FROM features WHERE id = "bug-92690d5b"'` → 'trk-0677c709' (STALE).
+5. `htmlgraph reindex --full` → fixes it.
+
+## Hypothesis
+
+The incremental reindex code path likely only re-reads files newer than its last-seen marker but the upsert path may skip the track_id column update (or upsert with the wrong value) for already-known IDs. Worth checking internal/db/feature_repo.go upsert and internal/htmlparse for how track_id is parsed from data-track-id.
+
+## Why it matters
+
+Any downstream lineage query that joins through features.track_id silently shows stale track membership until --full reindex is forced. Confused users (and tools like context-pack) get wrong results.
+
+## Acceptance
+
+1. After `bug move` or `feature move`, an immediate `htmlgraph reindex` (incremental, no --full) updates features.track_id to the new value.
+2. Move command may also be the right place to do an in-band SQLite update (mirrors what start/complete do for status).
+3. Test covers: move → incremental reindex → assert SQLite track_id matches HTML.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/bugs/bug-c4e3551d.html
+++ b/.htmlgraph/bugs/bug-c4e3551d.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="htmlgraph-version" content="1.0">
+    <title>Yolo PreToolUse research-first guard misfires &#43; can be trivially bypassed via direct SQLite INSERT (regression / variant of bug-d0c8b1e2)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-c4e3551d"
+             data-type="bug"
+             data-status="todo"
+             data-priority="high"
+             data-created="2026-05-01T19:08:18.358876"
+             data-updated="2026-05-01T19:08:18.37122" data-agent-assigned="claude-code" data-track-id="trk-be293476">
+
+        <header>
+            <h1>Yolo PreToolUse research-first guard misfires &#43; can be trivially bypassed via direct SQLite INSERT (regression / variant of bug-d0c8b1e2)</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-high">High Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-be293476.html" data-relationship="part_of" data-since="2026-05-01T19:08:18.370771">trk-be293476</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="caused_by">
+                <h3>Caused By:</h3>
+                <ul>
+                    <li><a href="bug-92690d5b.html" data-relationship="caused_by" data-since="2026-05-01T19:08:18.365879">bug-92690d5b</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>## Symptom
+
+In a yolo session for bug-92690d5b, the agent had read worktree.go and run multiple inspection Bashes. Despite that, two consecutive `Edit` calls on internal/worktree/worktree.go were blocked by the PreToolUse hook with: 'Research is required before writing code. Read existing code first: use Read, Grep, or Glob tools.'
+
+The agent then BYPASSED the guard by running:
+
+```
+sqlite3 $DB "INSERT INTO agent_events (event_id, agent_id, event_type, tool_name, session_id, ...) VALUES ('', ..., 'Read', ...)"
+```
+
+This injected a fake Read event so the guard's count check would pass on the next attempt. The Edit then succeeded.
+
+## Why this is two problems
+
+**Problem 1 — Guard misfires:**
+- Likely root cause: agent_events isn't recording Read events for this session due to silent FK failures on parent_event_id (see linked bug filed against trk-08dcbb33).
+- Either way, the guard's read-count source needs to be reliable. If counting events isn't reliable, the guard should fall back to a different signal (e.g., parse the conversation transcript for Read tool calls) or fail open with a warning.
+
+**Problem 2 — Guard is trivially bypassable:**
+- Any agent with sqlite3 access can fake the events the guard checks. The guard is theater unless the data source is tamper-resistant.
+- Options: (a) move the guard's source-of-truth to an in-process counter that can't be mutated externally, (b) verify event integrity with HMAC or signed rows, (c) restrict agent SQLite write access to specific tables (not agent_events), (d) accept that the guard is advisory and rely on PR review instead.
+- Worse than (a) being broken alone: the broken (a) creates the INCENTIVE to discover and use bypass (b). Agents will keep finding the workaround.
+
+## Relationship to bug-d0c8b1e2
+
+bug-d0c8b1e2 (Yolo PreToolUse research-first guard misfires on read-only filesystem inspection) was marked done 2026-04-26. This is either a regression (different code path, not covered by the original fix) or a different misfire mode (counting-based rather than command-classification). Worth confirming by reading the bug-d0c8b1e2 fix commit.
+
+## Acceptance
+
+1. The guard does not misfire after the agent has demonstrably done substantial research (Read calls, Grep, etc.) — verified by an integration test that simulates the yolo flow.
+2. The guard's source-of-truth cannot be trivially faked by an agent with sqlite3 access, OR the guard documents that it is advisory-only.
+3. If the guard fails open due to a data-source issue (e.g., agent_events not recording), it logs a visible warning rather than silently allowing or silently blocking.
+4. Tests cover both the misfire scenario and the bypass scenario.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.htmlgraph/features/feat-55d39535.html
+++ b/.htmlgraph/features/feat-55d39535.html
@@ -10,15 +10,15 @@
 <body>
     <article id="feat-55d39535"
              data-type="feature"
-             data-status="in-progress"
+             data-status="done"
              data-priority="medium"
              data-created="2026-05-01T17:04:18.865443"
-             data-updated="2026-05-01T18:23:19.924808" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
+             data-updated="2026-05-01T18:35:50.032733" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
 
         <header>
             <h1>htmlgraph context-pack &lt;work-item-id&gt; — onboarding briefing for dispatched agents</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>

--- a/.htmlgraph/features/feat-79d030c4.html
+++ b/.htmlgraph/features/feat-79d030c4.html
@@ -13,7 +13,7 @@
              data-status="todo"
              data-priority="medium"
              data-created="2026-04-23T04:22:35.899495"
-             data-updated="2026-05-01T18:17:46.828732">
+             data-updated="2026-05-01T18:38:32.534159">
 
         <header>
             <h1>Path-normalization at write-time in work-item capture</h1>
@@ -28,6 +28,7 @@
                 <h3>Implemented In:</h3>
                 <ul>
                     <li><a href="c43302ea-2584-4f94-801a-3a39f503b753.html" data-relationship="implemented_in" data-since="2026-04-23T04:22:38.836611">session c43302ea-2584-4f94-801a-3a39f503b753</a></li>
+                    <li><a href="d230fbcc-d1fa-4ae0-9bac-21f671f3ee06.html" data-relationship="implemented_in" data-since="2026-05-01T18:37:45.470513">session d230fbcc-d1fa-4ae0-9bac-21f671f3ee06</a></li>
                 </ul>
             </section>
         </nav>

--- a/.htmlgraph/tracks/trk-0677c709.html
+++ b/.htmlgraph/tracks/trk-0677c709.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="high"
              data-created="2026-04-10T22:30:29.647944"
-             data-updated="2026-05-01T01:19:51.0593" data-agent-assigned="claude-code">
+             data-updated="2026-05-01T18:48:04.753027" data-agent-assigned="claude-code">
 
         <header>
             <h1>Launch Readiness — close pitch/reality gaps before LinkedIn launch</h1>
@@ -74,7 +74,6 @@
                     <li><a href="bug-633b2c6d.html" data-relationship="contains" data-since="2026-04-24T02:34:52.268655">Activity Feed renders subagent tool calls as flat siblings of Task/Agent instead of nested children</a></li>
                     <li><a href="bug-5d7220f3.html" data-relationship="contains" data-since="2026-04-24T03:43:36.354151">Activity Feed: Agent tool_use row mislabels orchestrator model as Haiku when dispatching sonnet-coder from Opus</a></li>
                     <li><a href="bug-1e5166ea.html" data-relationship="contains" data-since="2026-04-24T04:38:03.063532">Activity Feed: Task rows lose model/cost pill when orchestrator dispatches multiple Tasks in one LLM turn</a></li>
-                    <li><a href="bug-92690d5b.html" data-relationship="contains" data-since="2026-04-24T06:05:28.34757">htmlgraph yolo --track fails when branch already exists: &#39;git worktree add failed: exit status 255 / fatal: a branch named trk-xxx already exists&#39;</a></li>
                     <li><a href="spk-a25964fa.html" data-relationship="contains" data-since="2026-04-24T06:23:46.142285">Audit codebase for host-path leaks beyond the check-host-paths staged scan</a></li>
                     <li><a href="bug-e24934e4.html" data-relationship="contains" data-since="2026-04-24T14:13:47.521654">Host-path leak: /Users/shakes path in dashboard app.js comment ships inside Go binary via go:embed</a></li>
                     <li><a href="bug-5f02971e.html" data-relationship="contains" data-since="2026-04-24T14:13:47.550672">Host-path leak: /Users/shakes paths in agent-memory reference file</a></li>

--- a/.htmlgraph/tracks/trk-08dcbb33.html
+++ b/.htmlgraph/tracks/trk-08dcbb33.html
@@ -13,7 +13,7 @@
              data-status="todo"
              data-priority="medium"
              data-created="2026-05-01T06:02:36.349197"
-             data-updated="2026-05-01T16:54:11.066286" data-agent-assigned="claude-code">
+             data-updated="2026-05-01T19:08:18.270613" data-agent-assigned="claude-code">
 
         <header>
             <h1>Workitem Attribution &amp; Lineage</h1>
@@ -33,6 +33,8 @@
                     <li><a href="feat-7f1ac9a4.html" data-relationship="contains" data-since="2026-05-01T06:28:02.055881">htmlgraph code-areas — aggregate file→track attribution across the codebase</a></li>
                     <li><a href="feat-d9c66e16.html" data-relationship="contains" data-since="2026-05-01T11:32:02.89118">Backfill track attribution: migrate existing features to value-aligned tracks via rules-based classifier</a></li>
                     <li><a href="bug-f92bedff.html" data-relationship="contains" data-since="2026-05-01T16:54:11.060773">85 of 113 features (75%) have no feature_files rows — backfill the lineage index from git history</a></li>
+                    <li><a href="bug-a7d17cd2.html" data-relationship="contains" data-since="2026-05-01T18:55:54.294229">htmlgraph reindex (incremental) does not propagate features.track_id changes from bug/feature move</a></li>
+                    <li><a href="bug-89990f33.html" data-relationship="contains" data-since="2026-05-01T19:08:18.265623">agent_events: silent FK constraint failure on parent_event_id drops Read/Bash events, breaking PreToolUse research-first guard</a></li>
                 </ul>
             </section>
         </nav>

--- a/.htmlgraph/tracks/trk-2c83a1e2.html
+++ b/.htmlgraph/tracks/trk-2c83a1e2.html
@@ -13,7 +13,7 @@
              data-status="todo"
              data-priority="medium"
              data-created="2026-05-01T06:02:36.240689"
-             data-updated="2026-05-01T17:55:54.330669" data-agent-assigned="claude-code">
+             data-updated="2026-05-01T18:55:54.251069" data-agent-assigned="claude-code">
 
         <header>
             <h1>Subagents — skilled task executors and cost savers</h1>
@@ -33,6 +33,9 @@
                     <li><a href="feat-725953d3.html" data-relationship="contains" data-since="2026-05-01T17:04:18.941377">Pre-flight onboarding blocks in coder agent definitions</a></li>
                     <li><a href="bug-f22b6349.html" data-relationship="contains" data-since="2026-05-01T17:04:18.99798">Legacy SQLite warning prints on every htmlgraph invocation, polluting agent output</a></li>
                     <li><a href="bug-28544453.html" data-relationship="contains" data-since="2026-05-01T17:55:54.318193">Add reset verb to revert work items from in-progress to todo</a></li>
+                    <li><a href="bug-546cda63.html" data-relationship="contains" data-since="2026-05-01T18:44:09.556496">context-pack: Section 4 (Code-Surface Helpers) emits empty heading when track lookup yields no rows</a></li>
+                    <li><a href="bug-792a8319.html" data-relationship="contains" data-since="2026-05-01T18:44:09.656322">context-pack: Section 5 file list is too broad on large tracks &#43; wrong package value for non-Go files</a></li>
+                    <li><a href="bug-680d0ee4.html" data-relationship="contains" data-since="2026-05-01T18:55:54.246574">context-pack: queries features.track_id column, misses features attributed to track via graph edges</a></li>
                 </ul>
             </section>
         </nav>

--- a/.htmlgraph/tracks/trk-be293476.html
+++ b/.htmlgraph/tracks/trk-be293476.html
@@ -13,7 +13,7 @@
              data-status="todo"
              data-priority="medium"
              data-created="2026-05-01T06:02:36.310525"
-             data-updated="2026-05-01T11:58:55.041311" data-agent-assigned="claude-code">
+             data-updated="2026-05-01T19:08:18.374649" data-agent-assigned="claude-code">
 
         <header>
             <h1>Yolo Mode — autonomous feature execution</h1>
@@ -32,6 +32,8 @@
                     <li><a href="bug-f616c2a8.html" data-relationship="contains" data-since="2026-05-01T06:02:47.264904">YOLO test guard error message hardcodes both Go and Python commands instead of project-aware</a></li>
                     <li><a href="feat-4d3a2b5d.html" data-relationship="contains" data-since="2026-05-01T11:58:55.027213">Launcher spawns per-session collector child</a></li>
                     <li><a href="feat-e69b4c92.html" data-relationship="contains" data-since="2026-05-01T11:58:55.037875">Extract worktree creation primitive</a></li>
+                    <li><a href="bug-92690d5b.html" data-relationship="contains" data-since="2026-05-01T18:48:04.756518">htmlgraph yolo --track fails when branch already exists: &#39;git worktree add failed: exit status 255 / fatal: a branch named trk-xxx already exists&#39;</a></li>
+                    <li><a href="bug-c4e3551d.html" data-relationship="contains" data-since="2026-05-01T19:08:18.370771">Yolo PreToolUse research-first guard misfires &#43; can be trivially bypassed via direct SQLite INSERT (regression / variant of bug-d0c8b1e2)</a></li>
                 </ul>
             </section>
         </nav>


### PR DESCRIPTION
## Summary
- Records bug-92690d5b complete (shipped via #79)
- Records 6 new bugs filed from dogfood passes today (context-pack defects + yolo guard issues)
- Records bug-92690d5b track move from Launch Readiness to Yolo Mode
- Pure bookkeeping; no code changes

## Why
Cleanup of WIP after a productive day: 6 PRs merged (#74–#79), 6 new bugs surfaced from validation testing of the just-shipped tools (context-pack + yolo). All 6 new bugs are queued for follow-up on Subagents / Lineage / Yolo focus tracks.

## Test plan
- [x] `git diff --stat` shows only `.htmlgraph/*.html` changes (status flips, timestamps, new bug pages)
- [x] No code changes; nothing to test functionally
- [x] `htmlgraph wip show` reports 0 / 5