### PR TITLE
context-pack v1.1: edge attribution + §4 placeholder + §5 cap (bug-546cda63 bug-680d0ee4 bug-792a8319)

### DIFF
--- a/.htmlgraph/bugs/bug-546cda63.html
+++ b/.htmlgraph/bugs/bug-546cda63.html
@@ -10,30 +10,36 @@
 <body>
     <article id="bug-546cda63"
              data-type="bug"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-01T18:44:09.533559"
-             data-updated="2026-05-01T18:44:09.556935" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
+             data-updated="2026-05-01T20:05:04.236976" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
 
         <header>
             <h1>context-pack: Section 4 (Code-Surface Helpers) emits empty heading when track lookup yields no rows</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="caused_by">
-                <h3>Caused By:</h3>
-                <ul>
-                    <li><a href="bug-92690d5b.html" data-relationship="caused_by" data-since="2026-05-01T18:44:09.545744">bug-92690d5b</a></li>
-                </ul>
-            </section>
             <section data-edge-type="part_of">
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="trk-2c83a1e2.html" data-relationship="part_of" data-since="2026-05-01T18:44:09.556496">trk-2c83a1e2</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="d230fbcc-d1fa-4ae0-9bac-21f671f3ee06.html" data-relationship="implemented_in" data-since="2026-05-01T20:05:04.236842">session d230fbcc-d1fa-4ae0-9bac-21f671f3ee06</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="caused_by">
+                <h3>Caused By:</h3>
+                <ul>
+                    <li><a href="bug-92690d5b.html" data-relationship="caused_by" data-since="2026-05-01T18:44:09.545744">bug-92690d5b</a></li>
                 </ul>
             </section>
         </nav>

--- a/.htmlgraph/bugs/bug-680d0ee4.html
+++ b/.htmlgraph/bugs/bug-680d0ee4.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-680d0ee4"
              data-type="bug"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-01T18:55:54.21329"
-             data-updated="2026-05-01T18:55:54.246842" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
+             data-updated="2026-05-01T20:05:04.388929" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
 
         <header>
             <h1>context-pack: queries features.track_id column, misses features attributed to track via graph edges</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -34,6 +34,12 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="trk-2c83a1e2.html" data-relationship="part_of" data-since="2026-05-01T18:55:54.246574">trk-2c83a1e2</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="d230fbcc-d1fa-4ae0-9bac-21f671f3ee06.html" data-relationship="implemented_in" data-since="2026-05-01T20:05:04.388698">session d230fbcc-d1fa-4ae0-9bac-21f671f3ee06</a></li>
                 </ul>
             </section>
         </nav>

--- a/.htmlgraph/bugs/bug-792a8319.html
+++ b/.htmlgraph/bugs/bug-792a8319.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-792a8319"
              data-type="bug"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-01T18:44:09.645053"
-             data-updated="2026-05-01T18:44:09.656891" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
+             data-updated="2026-05-01T20:05:04.48231" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
 
         <header>
             <h1>context-pack: Section 5 file list is too broad on large tracks &#43; wrong package value for non-Go files</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -34,6 +34,12 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="trk-2c83a1e2.html" data-relationship="part_of" data-since="2026-05-01T18:44:09.656322">trk-2c83a1e2</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="d230fbcc-d1fa-4ae0-9bac-21f671f3ee06.html" data-relationship="implemented_in" data-since="2026-05-01T20:05:04.482152">session d230fbcc-d1fa-4ae0-9bac-21f671f3ee06</a></li>
                 </ul>
             </section>
         </nav>

--- a/cmd/htmlgraph/context_pack.go
+++ b/cmd/htmlgraph/context_pack.go
@@ -19,6 +19,7 @@ import (
 )
 
 const contextPackCommitLimit = 8
+const contextPackFileLimit = 20
 
 // contextPackCmd returns the cobra command for `htmlgraph context-pack <id>`.
 func contextPackCmd() *cobra.Command {
@@ -118,20 +119,21 @@ func resolveNode(proj *workitem.Project, id string) (*models.Node, error) {
 
 // commitsByTrack collects and deduplicates commits across all features in the
 // given track, sorted by timestamp descending, capped at contextPackCommitLimit.
-// Private because GetCommitsByTrack does not exist in internal/db.
+// Uses a UNION of column-based and edge-based track membership so that features
+// attributed via migrate-tracks (graph_edges) are included alongside direct ones.
 func commitsByTrack(proj *workitem.Project, trackID string) ([]models.GitCommit, error) {
 	if trackID == "" {
 		return nil, nil
 	}
-	features, err := proj.Features.Collection.List(workitem.WithTrackID(trackID))
+	featureIDs, err := dbpkg.GetFeatureIDsByTrack(proj.DB, trackID)
 	if err != nil {
 		return nil, err
 	}
 
 	seen := make(map[string]bool)
 	var all []models.GitCommit
-	for _, f := range features {
-		cs, err := dbpkg.GetCommitsByFeature(proj.DB, f.ID)
+	for _, fid := range featureIDs {
+		cs, err := dbpkg.GetCommitsByFeature(proj.DB, fid)
 		if err != nil {
 			continue
 		}
@@ -257,18 +259,38 @@ func renderContextPack(
 		fmt.Fprintln(&buf)
 	}
 
-	// Sections 4 & 5: Code surface
+	// Section 4: Code-Surface Helpers
 	fmt.Fprintln(&buf, "## 4. Code-Surface Helpers")
-	fmt.Fprintln(&buf, "\n## 5. File Paths with Package Qualifiers")
+	if node.TrackID == "" {
+		fmt.Fprintln(&buf, "\n(no track attribution)")
+	} else {
+		fmt.Fprintln(&buf, "\nUse `htmlgraph blame <file>` to identify file owners.")
+		fmt.Fprintf(&buf, "Use `htmlgraph code-areas --track %s` for the full file list.\n\n", node.TrackID)
+	}
+
+	// Section 5: File Paths with Package Qualifiers
+	fmt.Fprintln(&buf, "## 5. File Paths with Package Qualifiers")
 	if node.TrackID == "" || trackArea == nil {
 		fmt.Fprintln(&buf, "\n(no track attribution)")
 	} else {
 		fmt.Fprintf(&buf, "\nTrack: **%s** (%s)\n\n", trackArea.TrackTitle, trackArea.TrackID)
 		fmt.Fprintln(&buf, "| File | Package | Features | Touches |")
 		fmt.Fprintln(&buf, "|------|---------|----------|---------|")
-		for _, f := range trackArea.Files {
+		files := trackArea.Files
+		truncated := len(files) - contextPackFileLimit
+		if truncated > 0 {
+			files = files[:contextPackFileLimit]
+		}
+		for _, f := range files {
 			pkg := goPackageQualifier(f.Path)
-			fmt.Fprintf(&buf, "| %s | %s | %d | %d |\n", f.Path, pkg, f.Features, f.Touches)
+			pkgCol := pkg
+			if pkgCol == "" {
+				pkgCol = "—"
+			}
+			fmt.Fprintf(&buf, "| %s | %s | %d | %d |\n", f.Path, pkgCol, f.Features, f.Touches)
+		}
+		if truncated > 0 {
+			fmt.Fprintf(&buf, "\n… and %d more files in this track (use `htmlgraph code-areas --track %s` to see all).\n", truncated, trackArea.TrackID)
 		}
 		fmt.Fprintln(&buf)
 	}
@@ -315,12 +337,13 @@ func renderContextPack(
 	return buf.String()
 }
 
-// goPackageQualifier returns "package <dir>" for .go files; the raw path otherwise.
+// goPackageQualifier returns "package <dir>" for .go files; empty string otherwise.
 // The package name is inferred from the immediate parent directory, matching Go
-// convention (internal/foo/bar.go → "package foo").
+// convention (internal/foo/bar.go → "package foo"). Callers should render ""
+// as "—" in table columns.
 func goPackageQualifier(path string) string {
 	if !strings.HasSuffix(path, ".go") {
-		return path
+		return ""
 	}
 	dir := filepath.Dir(path)
 	if dir == "." || dir == "" {

--- a/cmd/htmlgraph/context_pack.go
+++ b/cmd/htmlgraph/context_pack.go
@@ -119,20 +119,39 @@ func resolveNode(proj *workitem.Project, id string) (*models.Node, error) {
 
 // commitsByTrack collects and deduplicates commits across all features in the
 // given track, sorted by timestamp descending, capped at contextPackCommitLimit.
-// Uses a UNION of column-based and edge-based track membership so that features
-// attributed via migrate-tracks (graph_edges) are included alongside direct ones.
+// Uses both database-derived track membership (GetFeatureIDsByTrack) and canonical-HTML
+// direct lookup (proj.Features with WithTrackID) to ensure no memberships are missed
+// due to stale local caches.
 func commitsByTrack(proj *workitem.Project, trackID string) ([]models.GitCommit, error) {
 	if trackID == "" {
 		return nil, nil
 	}
-	featureIDs, err := dbpkg.GetFeatureIDsByTrack(proj.DB, trackID)
+
+	// Collect feature IDs from two sources: SQLite index and canonical HTML.
+	dbIDs, err := dbpkg.GetFeatureIDsByTrack(proj.DB, trackID)
 	if err != nil {
 		return nil, err
 	}
 
+	// Also load directly from canonical HTML to catch any stale-DB misses.
+	htmlIDs, err := proj.Features.Collection.List(workitem.WithTrackID(trackID))
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge and dedupe feature IDs.
+	idSet := make(map[string]struct{})
+	for _, id := range dbIDs {
+		idSet[id] = struct{}{}
+	}
+	for _, node := range htmlIDs {
+		idSet[node.ID] = struct{}{}
+	}
+
+	// Load commits for each feature.
 	seen := make(map[string]bool)
 	var all []models.GitCommit
-	for _, fid := range featureIDs {
+	for fid := range idSet {
 		cs, err := dbpkg.GetCommitsByFeature(proj.DB, fid)
 		if err != nil {
 			continue

--- a/cmd/htmlgraph/context_pack_test.go
+++ b/cmd/htmlgraph/context_pack_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/shakestzd/htmlgraph/internal/blame"
 	dbpkg "github.com/shakestzd/htmlgraph/internal/db"
 	"github.com/shakestzd/htmlgraph/internal/htmlparse"
 	"github.com/shakestzd/htmlgraph/internal/models"
@@ -289,6 +291,7 @@ func TestContextPack_CmdRegistered(t *testing.T) {
 }
 
 // TestContextPack_GoPackageQualifier validates the package inference logic.
+// Non-Go files return "" so callers can render "—" in table columns.
 func TestContextPack_GoPackageQualifier(t *testing.T) {
 	cases := []struct {
 		path string
@@ -297,8 +300,11 @@ func TestContextPack_GoPackageQualifier(t *testing.T) {
 		{"internal/foo/bar.go", "package foo"},
 		{"cmd/htmlgraph/main.go", "package htmlgraph"},
 		{"internal/db/schema.go", "package db"},
-		{"README.md", "README.md"},
-		{"Makefile", "Makefile"},
+		{"README.md", ""},
+		{"Makefile", ""},
+		{".devcontainer/Dockerfile", ""},
+		{"plugin/hooks/hooks.json", ""},
+		{"scripts/deploy.sh", ""},
 		{"top.go", "package main"},
 	}
 	for _, tc := range cases {
@@ -306,6 +312,169 @@ func TestContextPack_GoPackageQualifier(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("goPackageQualifier(%q) = %q, want %q", tc.path, got, tc.want)
 		}
+	}
+}
+
+// TestContextPack_Section4Placeholder verifies §4 shows "(no track attribution)"
+// when the work item has no track (bug-546cda63).
+func TestContextPack_Section4Placeholder(t *testing.T) {
+	_, hgDir, _ := setupContextPackEnv(t)
+
+	if err := runWiCreate("feature", "Untracked Feature", &wiCreateOpts{
+		priority:         "medium",
+		standaloneReason: "test",
+	}); err != nil {
+		t.Fatalf("create feature: %v", err)
+	}
+	featFiles, _ := filepath.Glob(filepath.Join(hgDir, "features", "feat-*.html"))
+	featNode, _ := htmlparse.ParseFile(featFiles[0])
+
+	out := renderContextPack(featNode, "main", 0, 0, nil, nil, nil)
+
+	// §4 must contain the placeholder.
+	idx4 := strings.Index(out, "## 4. Code-Surface Helpers")
+	if idx4 == -1 {
+		t.Fatal("§4 header not found")
+	}
+	snippet4 := out[idx4 : idx4+150]
+	if !strings.Contains(snippet4, "(no track attribution)") {
+		t.Errorf("§4: expected '(no track attribution)', got:\n%s", snippet4)
+	}
+}
+
+// TestContextPack_EdgeAttributedCommits verifies that commitsByTrack finds
+// features attached via graph_edges (edge-based attribution from migrate-tracks),
+// not only via the track_id column (bug-680d0ee4).
+func TestContextPack_EdgeAttributedCommits(t *testing.T) {
+	_, _, proj := setupContextPackEnv(t)
+
+	trackID := "trk-edgetest"
+	featID := "feat-edgetest"
+
+	// Insert a minimal track + feature into SQLite WITHOUT setting track_id column.
+	// The feature belongs to the track only via a graph_edges row.
+	if _, err := proj.DB.Exec(`INSERT OR IGNORE INTO tracks (id, type, title, status, created_at, updated_at) VALUES (?, 'track', 'Edge Track', 'open', datetime('now'), datetime('now'))`, trackID); err != nil {
+		t.Fatalf("insert track: %v", err)
+	}
+	if _, err := proj.DB.Exec(`INSERT OR IGNORE INTO features (id, type, title, status, priority, created_at, updated_at) VALUES (?, 'feature', 'Edge Feature', 'open', 'medium', datetime('now'), datetime('now'))`, featID); err != nil {
+		t.Fatalf("insert feature: %v", err)
+	}
+	// Attach via edge, not column.
+	if _, err := proj.DB.Exec(`INSERT OR REPLACE INTO graph_edges (edge_id, from_node_id, from_node_type, to_node_id, to_node_type, relationship_type) VALUES ('e1', ?, 'feature', ?, 'track', 'part_of')`, featID, trackID); err != nil {
+		t.Fatalf("insert edge: %v", err)
+	}
+
+	// Seed a commit for the edge-attributed feature.
+	seedCommit(t, proj, "edge1234abcd5678", featID, "chore: edge-attributed commit", time.Now().UTC())
+
+	commits, err := commitsByTrack(proj, trackID)
+	if err != nil {
+		t.Fatalf("commitsByTrack: %v", err)
+	}
+	if len(commits) == 0 {
+		t.Error("expected at least one commit from edge-attributed feature, got none")
+	}
+}
+
+// TestContextPack_FileCap verifies §5 is capped at contextPackFileLimit rows and
+// emits a footer when truncated (bug-792a8319 symptom A).
+func TestContextPack_FileCap(t *testing.T) {
+	_, hgDir, _ := setupContextPackEnv(t)
+
+	if err := testCreate("track", "Big Track", "", "medium", false, false); err != nil {
+		t.Fatalf("create track: %v", err)
+	}
+	trackFiles, _ := filepath.Glob(filepath.Join(hgDir, "tracks", "trk-*.html"))
+	trackNode, _ := htmlparse.ParseFile(trackFiles[0])
+
+	if err := testCreate("feature", "Big Feature", trackNode.ID, "medium", false, false); err != nil {
+		t.Fatalf("create feature: %v", err)
+	}
+	featFiles, _ := filepath.Glob(filepath.Join(hgDir, "features", "feat-*.html"))
+	featNode, _ := htmlparse.ParseFile(featFiles[0])
+	featNode.TrackID = trackNode.ID
+
+	// Build a fake TrackArea with 30 files.
+	files := make([]blame.FileEntry, 30)
+	for i := range files {
+		files[i] = blame.FileEntry{
+			Path:     fmt.Sprintf("internal/pkg%d/file.go", i),
+			Features: 1,
+			Touches:  i + 1,
+		}
+	}
+	trackArea := &blame.TrackArea{
+		TrackID:    trackNode.ID,
+		TrackTitle: "Big Track",
+		Files:      files,
+	}
+
+	out := renderContextPack(featNode, "main", 0, 0, trackArea, nil, nil)
+
+	// Count table rows in §5.
+	lines := strings.Split(out, "\n")
+	tableRows := 0
+	inSection5 := false
+	for _, line := range lines {
+		if strings.HasPrefix(line, "## 5.") {
+			inSection5 = true
+			continue
+		}
+		if strings.HasPrefix(line, "## ") && inSection5 {
+			break
+		}
+		if inSection5 && strings.HasPrefix(line, "| internal/") {
+			tableRows++
+		}
+	}
+	if tableRows > contextPackFileLimit {
+		t.Errorf("§5 has %d table rows, want at most %d", tableRows, contextPackFileLimit)
+	}
+	if !strings.Contains(out, "… and 10 more files") {
+		t.Errorf("expected truncation footer '… and 10 more files' in output, got:\n%s", out)
+	}
+}
+
+// TestContextPack_NonGoPackageColumn verifies non-Go files render "—" in the Package column
+// (bug-792a8319 symptom B).
+func TestContextPack_NonGoPackageColumn(t *testing.T) {
+	_, hgDir, _ := setupContextPackEnv(t)
+
+	if err := testCreate("track", "Mixed Track", "", "medium", false, false); err != nil {
+		t.Fatalf("create track: %v", err)
+	}
+	trackFiles, _ := filepath.Glob(filepath.Join(hgDir, "tracks", "trk-*.html"))
+	trackNode, _ := htmlparse.ParseFile(trackFiles[0])
+
+	if err := testCreate("feature", "Mixed Feature", trackNode.ID, "medium", false, false); err != nil {
+		t.Fatalf("create feature: %v", err)
+	}
+	featFiles, _ := filepath.Glob(filepath.Join(hgDir, "features", "feat-*.html"))
+	featNode, _ := htmlparse.ParseFile(featFiles[0])
+	featNode.TrackID = trackNode.ID
+
+	trackArea := &blame.TrackArea{
+		TrackID:    trackNode.ID,
+		TrackTitle: "Mixed Track",
+		Files: []blame.FileEntry{
+			{Path: "internal/foo/bar.go", Features: 1, Touches: 3},
+			{Path: "README.md", Features: 1, Touches: 1},
+			{Path: "scripts/deploy.sh", Features: 1, Touches: 2},
+		},
+	}
+
+	out := renderContextPack(featNode, "main", 0, 0, trackArea, nil, nil)
+
+	// "README.md" must NOT appear as a package column value — it should be "—".
+	if strings.Contains(out, "| README.md | README.md |") {
+		t.Error("non-Go file path should not appear as package column value")
+	}
+	if !strings.Contains(out, "| README.md | — |") {
+		t.Errorf("expected '| README.md | — |' in output, got:\n%s", out)
+	}
+	// Go file should still show package.
+	if !strings.Contains(out, "package foo") {
+		t.Errorf("expected 'package foo' for Go file in output, got:\n%s", out)
 	}
 }
 

--- a/internal/db/track_repo.go
+++ b/internal/db/track_repo.go
@@ -21,9 +21,11 @@ type Track struct {
 }
 
 // GetFeatureIDsByTrack returns all feature IDs belonging to a track, combining
-// two sources: (1) features.track_id column (direct attribution) and
+// three sources: (1) features.track_id column (direct attribution),
 // (2) graph_edges rows of type 'part_of' or 'member_of' where to_node_id = trackID
-// (edge-based attribution from migrate-tracks). Duplicates are deduplicated.
+// (edge-based attribution from migrate-tracks), and (3) graph_edges rows of type
+// 'contains' where from_node_id = trackID (track→feature containment edges).
+// Duplicates are deduplicated.
 func GetFeatureIDsByTrack(db *sql.DB, trackID string) ([]string, error) {
 	rows, err := db.Query(`
 		SELECT id FROM features WHERE track_id = ?
@@ -31,8 +33,13 @@ func GetFeatureIDsByTrack(db *sql.DB, trackID string) ([]string, error) {
 		SELECT from_node_id FROM graph_edges
 		WHERE to_node_id = ?
 		  AND relationship_type IN ('part_of', 'member_of')
-		  AND from_node_id LIKE 'feat-%'`,
-		trackID, trackID,
+		  AND from_node_id LIKE 'feat-%'
+		UNION
+		SELECT to_node_id FROM graph_edges
+		WHERE from_node_id = ?
+		  AND relationship_type = 'contains'
+		  AND to_node_id LIKE 'feat-%'`,
+		trackID, trackID, trackID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get feature IDs for track %s: %w", trackID, err)

--- a/internal/db/track_repo.go
+++ b/internal/db/track_repo.go
@@ -20,6 +20,36 @@ type Track struct {
 	CompletedAt time.Time
 }
 
+// GetFeatureIDsByTrack returns all feature IDs belonging to a track, combining
+// two sources: (1) features.track_id column (direct attribution) and
+// (2) graph_edges rows of type 'part_of' or 'member_of' where to_node_id = trackID
+// (edge-based attribution from migrate-tracks). Duplicates are deduplicated.
+func GetFeatureIDsByTrack(db *sql.DB, trackID string) ([]string, error) {
+	rows, err := db.Query(`
+		SELECT id FROM features WHERE track_id = ?
+		UNION
+		SELECT from_node_id FROM graph_edges
+		WHERE to_node_id = ?
+		  AND relationship_type IN ('part_of', 'member_of')
+		  AND from_node_id LIKE 'feat-%'`,
+		trackID, trackID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get feature IDs for track %s: %w", trackID, err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // UpsertTrack inserts or updates a track row.
 // On conflict by id, all mutable fields are updated.
 // Tracks must be upserted BEFORE features to satisfy the FK constraint

--- a/internal/db/track_repo_test.go
+++ b/internal/db/track_repo_test.go
@@ -1,6 +1,7 @@
 package db_test
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -124,5 +125,58 @@ func TestUpsertTrack_FeatureFK(t *testing.T) {
 	).Scan(&trackID)
 	if trackID != "trk-fk-001" {
 		t.Errorf("track_id: got %q, want %q", trackID, "trk-fk-001")
+	}
+}
+
+func TestGetFeatureIDsByTrack_ContainsEdge(t *testing.T) {
+	database := openTestDB(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Insert a track.
+	track := &db.Track{
+		ID:        "trk-contains-001",
+		Title:     "Contains Test Track",
+		Status:    "todo",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := db.UpsertTrack(database, track); err != nil {
+		t.Fatalf("UpsertTrack: %v", err)
+	}
+
+	// Insert a feature WITHOUT setting track_id on the feature itself.
+	feat := &db.Feature{
+		ID:        "feat-contains-001",
+		Type:      "feature",
+		Title:     "Feature in Contains Edge",
+		Status:    "todo",
+		Priority:  "medium",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := db.UpsertFeature(database, feat); err != nil {
+		t.Fatalf("UpsertFeature: %v", err)
+	}
+
+	// Insert a 'contains' edge: track → feature.
+	if err := db.InsertEdge(
+		database,
+		"trk-contains-001-contains-feat-contains-001",
+		"trk-contains-001", "track",
+		"feat-contains-001", "feature",
+		"contains", nil,
+	); err != nil {
+		t.Fatalf("InsertEdge: %v", err)
+	}
+
+	// Call GetFeatureIDsByTrack and verify the feature is returned.
+	ids, err := db.GetFeatureIDsByTrack(database, "trk-contains-001")
+	if err != nil {
+		t.Fatalf("GetFeatureIDsByTrack: %v", err)
+	}
+
+	if !slices.Contains(ids, "feat-contains-001") {
+		t.Errorf("feature not found via contains edge; got %v, want to include %q", ids, "feat-contains-001")
 	}
 }


### PR DESCRIPTION
## Summary
Three dogfood-discovered context-pack defects, bundled into one PR.

### bug-546cda63 — §4 missing placeholder
Section 4 (Code-Surface Helpers) emitted heading with no body when the work item had no track attribution. Now emits `(no track attribution)` consistent with §5/6/7.

### bug-680d0ee4 — edge-attributed members missed
context-pack queried `features.track_id` directly, missing features attributed to a track via `graph_edges` (the path used by `htmlgraph migrate-tracks`). New helper `internal/db.GetFeatureIDsByTrack` does a UNION query covering both column-based and edge-based attribution. `commitsByTrack` now uses it.

### bug-792a8319 — §5 noise + non-Go package column
- §5 file table was unbounded (145+ rows on Launch Readiness track). Now capped at 20 rows with a footer line pointing to `htmlgraph code-areas --track <id>`.
- Non-Go files now render `—` in the Package column instead of the full file path.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` all pass
- [x] New tests in `cmd/htmlgraph/context_pack_test.go` cover all four acceptance criteria
- [x] `htmlgraph context-pack feat-79d030c4` (untracked) shows `(no track attribution)` under §4
- [x] `htmlgraph context-pack bug-92690d5b` (edge-attributed track) shows non-empty §5/§6
- [x] §5 capped at 20 files for any input
- [x] Non-Go files render `—` in Package column