### PR TITLE
chore(.htmlgraph): record 4 work item completes from #81 + #82

### DIFF
--- a/.htmlgraph/bugs/bug-546cda63.html
+++ b/.htmlgraph/bugs/bug-546cda63.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-546cda63"
              data-type="bug"
-             data-status="in-progress"
+             data-status="done"
              data-priority="medium"
              data-created="2026-05-01T18:44:09.533559"
-             data-updated="2026-05-01T20:05:04.236976" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
+             data-updated="2026-05-01T20:46:26.235712" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
 
         <header>
             <h1>context-pack: Section 4 (Code-Surface Helpers) emits empty heading when track lookup yields no rows</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>

--- a/.htmlgraph/bugs/bug-680d0ee4.html
+++ b/.htmlgraph/bugs/bug-680d0ee4.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-680d0ee4"
              data-type="bug"
-             data-status="in-progress"
+             data-status="done"
              data-priority="medium"
              data-created="2026-05-01T18:55:54.21329"
-             data-updated="2026-05-01T20:05:04.388929" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
+             data-updated="2026-05-01T20:46:26.269793" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
 
         <header>
             <h1>context-pack: queries features.track_id column, misses features attributed to track via graph edges</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>

--- a/.htmlgraph/bugs/bug-792a8319.html
+++ b/.htmlgraph/bugs/bug-792a8319.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-792a8319"
              data-type="bug"
-             data-status="in-progress"
+             data-status="done"
              data-priority="medium"
              data-created="2026-05-01T18:44:09.645053"
-             data-updated="2026-05-01T20:05:04.48231" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
+             data-updated="2026-05-01T20:46:26.322042" data-agent-assigned="claude-code" data-track-id="trk-2c83a1e2">
 
         <header>
             <h1>context-pack: Section 5 file list is too broad on large tracks &#43; wrong package value for non-Go files</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>

--- a/.htmlgraph/bugs/bug-89990f33.html
+++ b/.htmlgraph/bugs/bug-89990f33.html
@@ -10,20 +10,26 @@
 <body>
     <article id="bug-89990f33"
              data-type="bug"
-             data-status="in-progress"
+             data-status="done"
              data-priority="high"
              data-created="2026-05-01T19:08:18.191506"
-             data-updated="2026-05-01T20:05:04.071194" data-agent-assigned="claude-code" data-track-id="trk-08dcbb33">
+             data-updated="2026-05-01T20:46:26.181669" data-agent-assigned="claude-code" data-track-id="trk-08dcbb33">
 
         <header>
             <h1>agent_events: silent FK constraint failure on parent_event_id drops Read/Bash events, breaking PreToolUse research-first guard</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-high">High Priority</span>
             </div>
         </header>
 
         <nav data-graph-edges>
+            <section data-edge-type="caused_by">
+                <h3>Caused By:</h3>
+                <ul>
+                    <li><a href="bug-92690d5b.html" data-relationship="caused_by" data-since="2026-05-01T19:08:18.201015">bug-92690d5b</a></li>
+                </ul>
+            </section>
             <section data-edge-type="part_of">
                 <h3>Part Of:</h3>
                 <ul>
@@ -34,12 +40,6 @@
                 <h3>Implemented In:</h3>
                 <ul>
                     <li><a href="d230fbcc-d1fa-4ae0-9bac-21f671f3ee06.html" data-relationship="implemented_in" data-since="2026-05-01T20:05:04.070894">session d230fbcc-d1fa-4ae0-9bac-21f671f3ee06</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="caused_by">
-                <h3>Caused By:</h3>
-                <ul>
-                    <li><a href="bug-92690d5b.html" data-relationship="caused_by" data-since="2026-05-01T19:08:18.201015">bug-92690d5b</a></li>
                 </ul>
             </section>
         </nav>


### PR DESCRIPTION
## Summary
- Marks 4 bugs complete in canonical HTML after PRs #81 and #82 merged
- Pure bookkeeping; no code changes

## Items completed
- bug-89990f33 — agent_events FK silent failure (shipped via #81)
- bug-546cda63 — context-pack §4 missing placeholder (shipped via #82)
- bug-680d0ee4 — context-pack edge attribution (shipped via #82)
- bug-792a8319 — context-pack §5 noise + non-Go pkg col (shipped via #82)

## Test plan
- [x] No code changes; nothing to test functionally
- [x] `htmlgraph wip show` reports 0 / 5