### PR TITLE
fix(release): reconcile artifact naming across release pipeline

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,9 +16,6 @@ builds:
       - -s -w -X main.version={{.Version}}
     env:
       - CGO_ENABLED=0
-    post:
-      - cmd: ln -sfn wipnote wn
-        dir: "{{ dir .Path }}"
 
 archives:
   - id: wipnote
@@ -26,9 +23,6 @@ archives:
       - wipnote
     name_template: "wipnote_{{.Version}}_{{.Os}}_{{.Arch}}"
     format: tar.gz
-    files:
-      - src: dist/wipnote_{{ .Os }}_{{ .Arch }}*/wn
-        dst: wn
 
 checksum:
   name_template: "wipnote_{{.Version}}_checksums.txt"

--- a/packages/homebrew/update-formula.sh
+++ b/packages/homebrew/update-formula.sh
@@ -18,7 +18,7 @@ if [ $# -ne 1 ]; then
 fi
 
 VERSION="$1"
-CHECKSUMS_URL="https://github.com/shakestzd/wipnote/releases/download/go/v${VERSION}/wipnote_${VERSION}_checksums.txt"
+CHECKSUMS_URL="https://github.com/shakestzd/wipnote/releases/download/v${VERSION}/wipnote_${VERSION}_checksums.txt"
 
 echo "Fetching checksums for v${VERSION}..."
 CHECKSUMS=$(curl -fsSL "$CHECKSUMS_URL") || {

--- a/plugin/hooks/bin/bootstrap.sh
+++ b/plugin/hooks/bin/bootstrap.sh
@@ -102,7 +102,7 @@ detect_platform() {
 # ---------------------------------------------------------------------------
 download_binary() {
     _version="$1"
-    _archive="wipnote-${PLATFORM_OS}-${PLATFORM_ARCH}.tar.gz"
+    _archive="wipnote_${_version}_${PLATFORM_OS}_${PLATFORM_ARCH}.tar.gz"
     _url="https://github.com/shakestzd/wipnote/releases/download/v${_version}/${_archive}"
 
     log_err "Downloading binary v${_version} for ${PLATFORM_OS}/${PLATFORM_ARCH}..."
@@ -131,18 +131,14 @@ download_binary() {
         bail
     fi
 
-    # Extract — archive contains binary named "wipnote-${os}-${arch}"
+    # Extract — goreleaser archive contains binary named "wipnote" at root.
     if ! tar xzf "${_tarball}" -C "${_tmpdir}" 2>/dev/null; then
         rm -rf "${_tmpdir}"
         log_err "Failed to extract archive."
         bail
     fi
 
-    # Move extracted binary into place (archive names it wipnote-${os}-${arch})
-    _extracted="${_tmpdir}/wipnote-${PLATFORM_OS}-${PLATFORM_ARCH}"
-    if [ -f "${_extracted}" ]; then
-        mv "${_extracted}" "${BINARY}"
-    elif [ -f "${_tmpdir}/wipnote" ]; then
+    if [ -f "${_tmpdir}/wipnote" ]; then
         mv "${_tmpdir}/wipnote" "${BINARY}"
     else
         rm -rf "${_tmpdir}"


### PR DESCRIPTION
## Summary

- Aligns `bootstrap.sh`, `update-formula.sh`, and `.goreleaser.yml` so every surface agrees on `wipnote_VERSION_OS_ARCH.tar.gz` as the release-artifact name (matching `install.sh` and `upgrade_cmd.go`, which were already correct).
- Removes dead config: the `ln -sfn wipnote wn` post-hook and the `dist/wipnote_*/wn` archives glob in `.goreleaser.yml`. The \`wn\` alias is created at install time by Homebrew/bootstrap/dev install — not shipped in the tarball.
- Fixes \`update-formula.sh\` checksum URL: \`releases/download/v\${VERSION}/…\` (not \`releases/download/go/v…\`, which came from confusion with the release-title template \`Go v{{.Version}}\`).

## Why

Three files disagreed on artifact naming, leaving \`wipnote upgrade\` silently broken on every released version since the htmlgraph→wipnote rename. Published v0.58.0 ships \`htmlgraph_0.58.0_*.tar.gz\`; this branch lands the \`.goreleaser.yml\` rename + all downstream alignment so the *next* tag publishes \`wipnote_VERSION_OS_ARCH.tar.gz\` and every install path resolves it correctly.

Validated locally with \`goreleaser release --snapshot --clean\`: archives contain \`wipnote\` binary at root, checksums file is \`wipnote_VERSION_checksums.txt\`. Matches install.sh, upgrade_cmd.go, and the new bootstrap.sh.

## Out of scope

- **Windows** — cross-compile blocked on \`syscall.Flock\`/\`Setpgid\`/\`Kill\`/\`Exec\` in 4 packages. Needs build-tagged \`*_unix.go\`/\`*_windows.go\` shims (~150–250 LOC). Future phase.
- **Cosign signing** — separate phase.

## Test plan

- [ ] CI green (existing release-go.yml continues to work)
- [ ] Cut next tag post-merge; verify \`gh release view\` shows \`wipnote_*\` artifacts
- [ ] Run \`wipnote upgrade\` on a deployed binary after the new tag — should succeed (currently 404s)
- [ ] Cold bootstrap on a clean machine: \`rm ~/.local/bin/wipnote ~/.local/share/wipnote/.binary-version && plugin/hooks/bin/bootstrap.sh version\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)