### PR TITLE
fix(ci): clear 3 pre-existing test failures blocking main

### DIFF
--- a/cmd/wipnote/sqlite_write_boundary_test.go
+++ b/cmd/wipnote/sqlite_write_boundary_test.go
@@ -317,7 +317,7 @@ var approvedWriteSites = []writeSite{
 	},
 	{
 		File:           "cmd/wipnote/migrate.go",
-		Line:           57,
+		Line:           59,
 		Function:       "runMigrateSessions",
 		OpenExpr:       "dbpkg.Open",
 		Classification: migrationOnly,
@@ -330,6 +330,14 @@ var approvedWriteSites = []writeSite{
 		OpenExpr:       "dbpkg.Open",
 		Classification: migrationOnly,
 		Note:           "`wipnote migrate attribution-fix` schema upgrade command.",
+	},
+	{
+		File:           "cmd/wipnote/migrate_normalize.go",
+		Line:           88,
+		Function:       "runMigrateNormalize",
+		OpenExpr:       "dbpkg.Open",
+		Classification: migrationOnly,
+		Note:           "`wipnote migrate normalize-paths` (feat-39b81fa6): one-shot data migration that rewrites absolute host paths in .wipnote/ artefacts to repo-relative form. Run-once foreground CLI command; same shape as the other migration entries.",
 	},
 }
 

--- a/internal/hooks/yolo_guard.go
+++ b/internal/hooks/yolo_guard.go
@@ -455,11 +455,6 @@ func bashCommandTargetsExternalPath(cmd, projectRoot string) bool {
 			return true
 		}
 		if strings.HasPrefix(field, "/") {
-			// Whitelist /tmp/: allowed for ephemeral artifacts.
-			if strings.HasPrefix(field, "/tmp/") {
-				continue
-			}
-
 			// Resolve against project root: if the path is inside the project,
 			// it is internal — not an external write.
 			if projectRoot != "" {

--- a/internal/hooks/yolo_guard.go
+++ b/internal/hooks/yolo_guard.go
@@ -809,11 +809,17 @@ func buildToolCallQuery(inClause string, inArgs []any, useAgentID bool, agentID,
 
 // sessionOrAgentFilter builds a SQL WHERE fragment that matches rows belonging
 // to any of the related sessions OR (optionally) to the specific agentID.
-// When agentID is used, additional scoping constraints are applied:
+// When agentID is used (i.e. useAgentID is true), additional scoping
+// constraints are applied to ALL matched rows — including those matched via
+// session_id IN (...):
 //  1. Time window: only match events from the last 24 hours
-//  2. Project scope: only match events whose session_id belongs to the same project
-// The session_id IN (...) branch (lineage-resolved sessions) is NOT filtered by
-// these constraints — lineage is authoritative.
+//  2. Project scope (agent_id branch only): only match agent_id events whose
+//     session_id belongs to the same project
+//
+// The 24h window is applied as an outer AND so that stale Reads in the
+// current session don't bypass the freshness check just because the session
+// happens to be long-running. The project scope is only enforced on the
+// agent_id fallback branch — session lineage is project-authoritative.
 func sessionOrAgentFilter(inClause string, inArgs []any, useAgentID bool, agentID, projectDir string) (string, []any) {
 	if !useAgentID {
 		return fmt.Sprintf("session_id IN %s", inClause), inArgs
@@ -822,21 +828,23 @@ func sessionOrAgentFilter(inClause string, inArgs []any, useAgentID bool, agentI
 	// Build time window: 24 hours ago
 	cutoffTime := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
 
-	// Build the agent_id branch with time and project scoping
-	filter := fmt.Sprintf(
-		"(session_id IN %s OR (agent_id IS NOT NULL AND agent_id != '' AND agent_id = ? AND created_at > ?",
-		inClause,
-	)
-
-	// Add project scope if projectDir is not empty
-	args := append(append([]any{}, inArgs...), agentID, cutoffTime)
+	// Build the agent_id branch with project scoping. The 24h time window is
+	// applied as an outer AND below so it constrains both branches.
+	agentBranch := "(agent_id IS NOT NULL AND agent_id != '' AND agent_id = ?"
+	args := append([]any{}, inArgs...)
+	args = append(args, agentID)
 	if projectDir != "" {
 		normalizedDir := paths.NormalizeProjectDir(projectDir)
-		filter += " AND session_id IN (SELECT session_id FROM sessions WHERE project_dir = ?)"
+		agentBranch += " AND session_id IN (SELECT session_id FROM sessions WHERE project_dir = ?)"
 		args = append(args, normalizedDir)
 	}
+	agentBranch += ")"
 
-	filter += "))"
+	filter := fmt.Sprintf(
+		"((session_id IN %s OR %s) AND created_at > ?)",
+		inClause, agentBranch,
+	)
+	args = append(args, cutoffTime)
 	return filter, args
 }
 


### PR DESCRIPTION
## Summary

Three independent test failures on `main` (red for ~4 days) that block unrelated PRs from going green on CI. All small, surgical fixes — no behavioral change beyond what each test asserts.

### Commits

1. **`fix(hooks): correct external-path message for /tmp/ writes`** — removes a `/tmp/` whitelist in `bashCommandTargetsExternalPath` that caused the function to fall through to the in-project message ("use Read, Grep, or Glob") for writes to `/tmp/y`. Those tools can't reach paths outside the project root. The function only chooses error wording; the whitelist was misplaced for that purpose. Fixes `TestCheckYoloBashResearchGuard_ExternalPathMessage/write_to_absolute_path`.

2. **`fix(sqlite-boundary): register or refactor 2 new direct writable opens`** — `TestWritableDBOpenBoundary` is a code-hygiene gate over direct SQLite writable opens. Commit `4ad19bb60` shifted one existing approved entry (line drift) and added one genuinely new migration-only call site (`runMigrateNormalize` in `cmd/wipnote/migrate_normalize.go:88`). Both are one-shot user-driven CLI commands, not hook/indexer/receiver paths, so they're registered in `approvedWriteSites` rather than routed through the slice-6 writer service. Fixes `TestWritableDBOpenBoundary`.

3. **`fix(yolo-guard): enforce 24h window on hasRecentResearch agent_id fallback`** — in `sessionOrAgentFilter` the `created_at > ?` 24h cutoff was nested inside the `agent_id` OR-branch of the WHERE clause, so a 48h-old event with a matching `session_id` matched via the left branch unconditionally — completely bypassing the freshness window. Moved the time predicate to an outer `AND` constraining both branches. Fixes `TestHasRecentResearch_AgentIDIgnoresOldEvents`. Side-benefit: `buildResearchQuery` and `buildToolCallQuery` (which share the helper) are now also correctly 24h-scoped on the agent_id path.

## Why one PR

All three are pre-existing failures on `main`. Landing them as separate PRs means three CI cycles before `main` is green; combined PR clears CI in one merge.

## Test plan

- [x] `go test ./internal/hooks/ ./cmd/wipnote/ -run "TestCheckYoloBashResearchGuard_ExternalPathMessage|TestHasRecentResearch_AgentIDIgnoresOldEvents|TestWritableDBOpenBoundary|TestWriteSiteInventoryComplete"` — all pass
- [x] `go build ./... && go vet ./...` — clean
- [ ] Full CI on PR — quality-gates expected green

🤖 Generated with [Claude Code](https://claude.com/claude-code)