### PR TITLE
fix(release): bump manifest.json + deploy-all.sh dual-bump

### DIFF
--- a/packages/plugin-core/manifest.json
+++ b/packages/plugin-core/manifest.json
@@ -3,7 +3,7 @@
   "_comment": "Single source of truth for the wipnote CLI companion plugin. Both the Claude Code plugin (plugin/) and the Codex CLI marketplace (packages/codex-marketplace/) are generated from this file by `wipnote plugin build-ports`. Assets (commands, agents, skills, templates, static, config) are sourced from plugin/ verbatim — same markdown format works for both Claude and Codex.",
 
   "name": "wipnote",
-  "version": "0.55.5",
+  "version": "0.58.1",
   "description": "Local-first observability and coordination platform for AI-assisted development. Go binary hooks for near-zero cold start.",
   "author": {
     "name": "Shakes Dlamini",

--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PLUGIN_JSON="$PROJECT_ROOT/plugin/.claude-plugin/plugin.json"
+MANIFEST_JSON="$PROJECT_ROOT/packages/plugin-core/manifest.json"
 GO_DIR="$PROJECT_ROOT"
 
 # Colors
@@ -153,14 +154,16 @@ if [[ -n "$VERSION" && "$VERSION" != "$CURRENT_VERSION" ]]; then
     step "Bumping version: $CURRENT_VERSION → $VERSION"
 
     if $DRY_RUN; then
-        ok "[dry-run] Would update $PLUGIN_JSON"
+        ok "[dry-run] Would update $PLUGIN_JSON and $MANIFEST_JSON"
     else
         if [[ "$OSTYPE" == "darwin"* ]]; then
             sed -i '' "s/\"version\": \"$CURRENT_VERSION\"/\"version\": \"$VERSION\"/" "$PLUGIN_JSON"
+            sed -i '' "s/\"version\": \"$CURRENT_VERSION\"/\"version\": \"$VERSION\"/" "$MANIFEST_JSON"
         else
             sed -i "s/\"version\": \"$CURRENT_VERSION\"/\"version\": \"$VERSION\"/" "$PLUGIN_JSON"
+            sed -i "s/\"version\": \"$CURRENT_VERSION\"/\"version\": \"$VERSION\"/" "$MANIFEST_JSON"
         fi
-        ok "Updated plugin.json"
+        ok "Updated plugin.json + manifest.json"
     fi
 fi
 
@@ -174,8 +177,8 @@ if $DRY_RUN; then
         ok "[dry-run] Would tag v$VERSION"
     fi
 else
-    # Stage version file + any other tracked changes
-    git add "$PLUGIN_JSON"
+    # Stage version files + any other tracked changes
+    git add "$PLUGIN_JSON" "$MANIFEST_JSON"
 
     if git diff --cached --quiet; then
         ok "No changes to commit"


### PR DESCRIPTION
## Summary

- Bumps \`packages/plugin-core/manifest.json\` from 0.55.5 → 0.58.1 to match the just-published v0.58.1 release.
- Teaches \`scripts/deploy-all.sh\` to bump **both** \`plugin/.claude-plugin/plugin.json\` AND \`packages/plugin-core/manifest.json\` on every release, so they stay locked going forward.

## Why

\`packages/plugin-core/manifest.json\` is the documented source of truth from which \`plugin/.claude-plugin/plugin.json\` is generated by \`wipnote plugin build-ports\`. The htmlgraph→wipnote rename waves (\`a2d27c101\`, \`b3950684f\`, \`e5f97d219\`) reset manifest.json from 0.58.0 back to 0.55.5 — but \`deploy-all.sh\` only bumped plugin.json, so they kept drifting further on every release.

\`verify-versions.sh\` (added in #103) now correctly surfaces this drift; this PR fixes the underlying cause so the deploy script doesn't propagate it.

## Test plan

- [x] manifest.json and plugin.json both at 0.58.1
- [x] \`./scripts/deploy-all.sh X.Y.Z --dry-run\` mentions both files
- [ ] CI green on this PR (verify-versions.sh should now PASS since all three sources agree on 0.58.1)
- [ ] Next release deploy bumps both files cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)