### PR TITLE
feat(release): Phase A — bundle plugin + codex + gemini trees in release tarballs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,34 @@ archives:
       - wipnote
     name_template: "wipnote_{{.Version}}_{{.Os}}_{{.Arch}}"
     format: tar.gz
+    # Phase A of the marketplace-to-bundled-plugin migration: ship the plugin
+    # tree alongside the binary in every release tarball so the two stay
+    # atomically in sync. Phase B will flip `wipnote claude` to load from this
+    # bundled tree via --plugin-dir; until then this is purely additive.
+    files:
+      - src: "plugin/**/*"
+        dst: plugin
+        info:
+          mode: 0644
+      # Override mode for executable shell scripts under hooks/bin so they
+      # remain runnable after extraction. The previous entry would otherwise
+      # rewrite them as 0644.
+      - src: "plugin/hooks/bin/*.sh"
+        dst: plugin/hooks/bin
+        info:
+          mode: 0755
+      # Phase A also bundles the Codex CLI and Gemini CLI harness trees so
+      # all three harnesses ship in lockstep with the binary. Phase B will
+      # flip the `wipnote codex` and `wipnote gemini` launchers to load from
+      # these bundled trees; until then this is purely additive.
+      - src: "packages/codex-marketplace/**/*"
+        dst: codex-marketplace
+        info:
+          mode: 0644
+      - src: "packages/gemini-extension/**/*"
+        dst: gemini-extension
+        info:
+          mode: 0644
 
 checksum:
   name_template: "wipnote_{{.Version}}_checksums.txt"
@@ -68,6 +96,9 @@ brews:
     install: |
       bin.install "wipnote"
       bin.install_symlink "wipnote" => "wn"
+      (share/"wipnote").install "plugin"
+      (share/"wipnote").install "codex-marketplace"
+      (share/"wipnote").install "gemini-extension"
     test: |
       assert_match version.to_s, shell_output("#{bin}/wipnote version")
 

--- a/cmd/wipnote/build.go
+++ b/cmd/wipnote/build.go
@@ -81,8 +81,65 @@ func runBuild() error {
 		return fmt.Errorf("write %s: %w", versionFile, err)
 	}
 
+	// Mirror the source plugin tree into ~/.local/share/wipnote/plugin so a
+	// dev-built binary lays out the same bundle as a release-installed one.
+	// This is what Phase B will read from when `wipnote claude` (no --dev)
+	// flips to loading the bundled tree via --plugin-dir. `--dev` mode keeps
+	// using $(pwd)/plugin/ directly — unchanged.
+	srcPlugin := filepath.Join(projectRoot, "plugin")
+	destPlugin := filepath.Join(metaDir, "plugin")
+	if err := mirrorPluginTree(srcPlugin, destPlugin); err != nil {
+		return fmt.Errorf("mirror plugin tree: %w", err)
+	}
+
+	// Mirror the Codex CLI marketplace tree alongside the plugin tree. Phase B
+	// will flip `wipnote codex` to load from this bundled path; until then it
+	// just keeps dev and release layouts in sync.
+	srcCodex := filepath.Join(projectRoot, "packages", "codex-marketplace")
+	destCodex := filepath.Join(metaDir, "codex-marketplace")
+	if err := mirrorPluginTree(srcCodex, destCodex); err != nil {
+		return fmt.Errorf("mirror codex-marketplace tree: %w", err)
+	}
+
+	// Mirror the Gemini CLI extension tree alongside the plugin tree. Phase B
+	// will flip `wipnote gemini` to load from this bundled path; until then it
+	// just keeps dev and release layouts in sync.
+	srcGemini := filepath.Join(projectRoot, "packages", "gemini-extension")
+	destGemini := filepath.Join(metaDir, "gemini-extension")
+	if err := mirrorPluginTree(srcGemini, destGemini); err != nil {
+		return fmt.Errorf("mirror gemini-extension tree: %w", err)
+	}
+
 	fmt.Printf("Installed: %s (v%s)\n", binaryPath, version)
 	fmt.Printf("Alias:     %s -> wipnote\n", aliasPath)
+	fmt.Printf("Plugin:    %s\n", destPlugin)
+	fmt.Printf("Codex:     %s\n", destCodex)
+	fmt.Printf("Gemini:    %s\n", destGemini)
+	return nil
+}
+
+// mirrorPluginTree replaces dst with a fresh copy of src. Uses `cp -a` so
+// file modes (e.g. executable hooks/bin/*.sh) are preserved without us
+// reimplementing permission handling. Idempotent: removes dst first.
+func mirrorPluginTree(src, dst string) error {
+	if _, err := os.Stat(src); err != nil {
+		// Source plugin/ directory missing — surface a clear error rather
+		// than silently leaving the dest stale. This should never happen
+		// in a healthy worktree.
+		return fmt.Errorf("plugin source %s not found: %w", src, err)
+	}
+	if err := os.RemoveAll(dst); err != nil {
+		return fmt.Errorf("remove %s: %w", dst, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(dst), err)
+	}
+	cp := exec.Command("cp", "-a", src, dst)
+	cp.Stdout = os.Stdout
+	cp.Stderr = os.Stderr
+	if err := cp.Run(); err != nil {
+		return fmt.Errorf("cp -a %s %s: %w", src, dst, err)
+	}
 	return nil
 }
 

--- a/cmd/wipnote/build_mirror_test.go
+++ b/cmd/wipnote/build_mirror_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMirrorPluginTree_PreservesContentAndModes ensures `wipnote build` will
+// lay down a faithful copy of the source plugin/ tree under ~/.local/share,
+// including executable bits on hooks/bin/*.sh.
+func TestMirrorPluginTree_PreservesContentAndModes(t *testing.T) {
+	srcRoot := t.TempDir()
+	dstRoot := filepath.Join(t.TempDir(), "dst")
+
+	// Build a tiny source plugin tree mirroring the real layout.
+	files := map[string]struct {
+		body string
+		mode os.FileMode
+	}{
+		".claude-plugin/plugin.json": {`{"name":"wipnote","version":"0.0.0"}`, 0o644},
+		"hooks/bin/bootstrap.sh":     {"#!/bin/sh\nexit 0\n", 0o755},
+		"agents/researcher.md":       {"# researcher\n", 0o644},
+	}
+	for rel, f := range files {
+		full := filepath.Join(srcRoot, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, []byte(f.body), f.mode); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
+	}
+
+	// Pre-existing dst — mirrorPluginTree must replace it.
+	stale := filepath.Join(dstRoot, "stale.txt")
+	if err := os.MkdirAll(dstRoot, 0o755); err != nil {
+		t.Fatalf("mkdir dst: %v", err)
+	}
+	if err := os.WriteFile(stale, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("write stale: %v", err)
+	}
+
+	if err := mirrorPluginTree(srcRoot, dstRoot); err != nil {
+		t.Fatalf("mirrorPluginTree: %v", err)
+	}
+
+	// Stale file is gone.
+	if _, err := os.Stat(stale); err == nil {
+		t.Errorf("stale file %s was not removed", stale)
+	}
+
+	// Each source file is present in dst with correct mode/content.
+	for rel, f := range files {
+		out := filepath.Join(dstRoot, rel)
+		info, err := os.Stat(out)
+		if err != nil {
+			t.Errorf("missing %s in dst: %v", rel, err)
+			continue
+		}
+		if rel == "hooks/bin/bootstrap.sh" {
+			if info.Mode().Perm()&0o111 == 0 {
+				t.Errorf("bootstrap.sh lost executable bit: mode=%o", info.Mode().Perm())
+			}
+		} else {
+			if info.Mode().Perm()&0o111 != 0 {
+				t.Errorf("%s unexpectedly executable: mode=%o", rel, info.Mode().Perm())
+			}
+		}
+		body, _ := os.ReadFile(out)
+		if string(body) != f.body {
+			t.Errorf("%s body mismatch: got %q want %q", rel, body, f.body)
+		}
+	}
+}
+
+// TestMirrorPluginTree_MissingSourceFails ensures we surface a clear error
+// when the source plugin/ directory is missing (vs silently leaving dst stale).
+func TestMirrorPluginTree_MissingSourceFails(t *testing.T) {
+	dstRoot := filepath.Join(t.TempDir(), "dst")
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if err := mirrorPluginTree(missing, dstRoot); err == nil {
+		t.Fatal("expected error when src missing, got nil")
+	}
+}

--- a/cmd/wipnote/upgrade_cmd.go
+++ b/cmd/wipnote/upgrade_cmd.go
@@ -101,11 +101,20 @@ func runUpgrade(out io.Writer, checkOnly bool, pinVersion string) error {
 		return fmt.Errorf("verifying archive checksum: %w", err)
 	}
 
-	// Extract binary from tarball.
+	// Extract archive into an "extracted" subdir of the temp dir. This gives
+	// us both the wipnote binary and the bundled plugin tree (since v0.59).
+	extractRoot := filepath.Join(tmpDir, "extracted")
+	if err := os.MkdirAll(extractRoot, 0o755); err != nil {
+		return fmt.Errorf("creating extract dir: %w", err)
+	}
+	if err := extractArchive(tarballPath, extractRoot); err != nil {
+		return fmt.Errorf("extracting archive: %w", err)
+	}
+
 	binaryName := "wipnote"
-	extractedPath := filepath.Join(tmpDir, binaryName)
-	if err := extractBinary(tarballPath, binaryName, extractedPath); err != nil {
-		return fmt.Errorf("extracting binary: %w", err)
+	extractedPath := filepath.Join(extractRoot, binaryName)
+	if _, err := os.Stat(extractedPath); err != nil {
+		return fmt.Errorf("binary %q not found in archive: %w", binaryName, err)
 	}
 
 	// Determine install destination.
@@ -129,6 +138,42 @@ func runUpgrade(out io.Writer, checkOnly bool, pinVersion string) error {
 	// Atomic replace: try os.Rename; fall back to copy on cross-device.
 	if err := atomicReplace(extractedPath, currentBin); err != nil {
 		return fmt.Errorf("replacing binary: %w", err)
+	}
+
+	// Install the bundled plugin tree, if present, to keep the binary and
+	// plugin assets in lockstep. Older release archives (< v0.59) had no
+	// plugin/ subdirectory; in that case we silently skip.
+	extractedPlugin := filepath.Join(extractRoot, "plugin")
+	if info, err := os.Stat(extractedPlugin); err == nil && info.IsDir() {
+		if err := installPluginTree(extractedPlugin); err != nil {
+			fmt.Fprintf(out, "warning: failed to install bundled plugin tree: %v\n", err)
+		} else {
+			fmt.Fprintln(out, "Installed bundled plugin tree to ~/.local/share/wipnote/plugin")
+		}
+	}
+
+	// Install the bundled Codex CLI marketplace tree, if present. Same Phase A
+	// rationale: keep binary and harness assets in lockstep. Older archives
+	// (< v0.59) had no codex-marketplace/ subdirectory; silently skip.
+	extractedCodex := filepath.Join(extractRoot, "codex-marketplace")
+	if info, err := os.Stat(extractedCodex); err == nil && info.IsDir() {
+		if err := installCodexTree(extractedCodex); err != nil {
+			fmt.Fprintf(out, "warning: failed to install bundled codex-marketplace tree: %v\n", err)
+		} else {
+			fmt.Fprintln(out, "Installed bundled codex-marketplace tree to ~/.local/share/wipnote/codex-marketplace")
+		}
+	}
+
+	// Install the bundled Gemini CLI extension tree, if present. Same Phase A
+	// rationale: keep binary and harness assets in lockstep. Older archives
+	// (< v0.59) had no gemini-extension/ subdirectory; silently skip.
+	extractedGemini := filepath.Join(extractRoot, "gemini-extension")
+	if info, err := os.Stat(extractedGemini); err == nil && info.IsDir() {
+		if err := installGeminiTree(extractedGemini); err != nil {
+			fmt.Fprintf(out, "warning: failed to install bundled gemini-extension tree: %v\n", err)
+		} else {
+			fmt.Fprintln(out, "Installed bundled gemini-extension tree to ~/.local/share/wipnote/gemini-extension")
+		}
 	}
 
 	// Update ~/.local/share/wipnote/.binary-version so bootstrap fast-path works.
@@ -221,8 +266,16 @@ func downloadFile(url, dest string) error {
 	return err
 }
 
-// extractBinary extracts a single named file from a .tar.gz archive.
-func extractBinary(tarball, binaryName, dest string) error {
+// extractArchive extracts a .tar.gz archive into destRoot, preserving the
+// archive's internal directory layout. Used to lift out both the top-level
+// wipnote binary and the bundled plugin/ tree (since v0.59) in a single pass.
+//
+// Hardens against path-traversal entries ("../") by rejecting any name that
+// escapes destRoot. Regular files inherit the tar header's mode (with 0o600
+// minimum so we can still read what we write). Directories are created with
+// 0o755. Other entry types (symlinks, devices) are ignored — we control the
+// archive and don't produce them.
+func extractArchive(tarball, destRoot string) error {
 	f, err := os.Open(tarball)
 	if err != nil {
 		return err
@@ -235,6 +288,11 @@ func extractBinary(tarball, binaryName, dest string) error {
 	}
 	defer gr.Close()
 
+	absRoot, err := filepath.Abs(destRoot)
+	if err != nil {
+		return fmt.Errorf("resolving extract root: %w", err)
+	}
+
 	tr := tar.NewReader(gr)
 	for {
 		hdr, err := tr.Next()
@@ -244,19 +302,161 @@ func extractBinary(tarball, binaryName, dest string) error {
 		if err != nil {
 			return fmt.Errorf("reading tar: %w", err)
 		}
-		if filepath.Base(hdr.Name) == binaryName {
-			out, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+
+		// Skip entries with absolute paths or "../" traversal.
+		clean := filepath.Clean(hdr.Name)
+		if filepath.IsAbs(clean) || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || clean == ".." {
+			continue
+		}
+		target := filepath.Join(absRoot, clean)
+		// Defense in depth: confirm the resolved target is under destRoot.
+		if !strings.HasPrefix(target+string(filepath.Separator), absRoot+string(filepath.Separator)) && target != absRoot {
+			continue
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", target, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("mkdir parent of %s: %w", target, err)
+			}
+			mode := os.FileMode(hdr.Mode) & 0o777
+			if mode == 0 {
+				mode = 0o644
+			}
+			out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+			if err != nil {
+				return fmt.Errorf("creating %s: %w", target, err)
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return fmt.Errorf("writing %s: %w", target, err)
+			}
+			if err := out.Close(); err != nil {
+				return fmt.Errorf("closing %s: %w", target, err)
+			}
+		default:
+			// Symlinks/devices: not produced by goreleaser for this archive.
+		}
+	}
+	return nil
+}
+
+// installPluginTree replaces ~/.local/share/wipnote/plugin atomically by
+// moving srcPluginDir into place after removing any prior contents. Mirrors
+// the bootstrap.sh logic so that upgrades via either path leave identical
+// on-disk state.
+func installPluginTree(srcPluginDir string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home dir: %w", err)
+	}
+	metaDir := filepath.Join(home, ".local", "share", "wipnote")
+	destPlugin := filepath.Join(metaDir, "plugin")
+
+	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", metaDir, err)
+	}
+	if err := os.RemoveAll(destPlugin); err != nil {
+		return fmt.Errorf("remove existing %s: %w", destPlugin, err)
+	}
+	// Try rename first (atomic on same filesystem). Fall back to recursive
+	// copy on cross-device — temp dirs and ~/.local/share can live on
+	// different volumes (e.g. inside containers).
+	if err := os.Rename(srcPluginDir, destPlugin); err == nil {
+		return nil
+	}
+	return copyDirRecursive(srcPluginDir, destPlugin)
+}
+
+// installCodexTree replaces ~/.local/share/wipnote/codex-marketplace atomically
+// by moving srcCodexDir into place after removing any prior contents. Mirrors
+// installPluginTree so the upgrade and bootstrap paths leave identical on-disk
+// state across all three harness trees.
+func installCodexTree(srcCodexDir string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home dir: %w", err)
+	}
+	metaDir := filepath.Join(home, ".local", "share", "wipnote")
+	destCodex := filepath.Join(metaDir, "codex-marketplace")
+
+	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", metaDir, err)
+	}
+	if err := os.RemoveAll(destCodex); err != nil {
+		return fmt.Errorf("remove existing %s: %w", destCodex, err)
+	}
+	if err := os.Rename(srcCodexDir, destCodex); err == nil {
+		return nil
+	}
+	return copyDirRecursive(srcCodexDir, destCodex)
+}
+
+// installGeminiTree replaces ~/.local/share/wipnote/gemini-extension atomically
+// by moving srcGeminiDir into place after removing any prior contents. Mirrors
+// installPluginTree so the upgrade and bootstrap paths leave identical on-disk
+// state across all three harness trees.
+func installGeminiTree(srcGeminiDir string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home dir: %w", err)
+	}
+	metaDir := filepath.Join(home, ".local", "share", "wipnote")
+	destGemini := filepath.Join(metaDir, "gemini-extension")
+
+	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", metaDir, err)
+	}
+	if err := os.RemoveAll(destGemini); err != nil {
+		return fmt.Errorf("remove existing %s: %w", destGemini, err)
+	}
+	if err := os.Rename(srcGeminiDir, destGemini); err == nil {
+		return nil
+	}
+	return copyDirRecursive(srcGeminiDir, destGemini)
+}
+
+// copyDirRecursive walks src and copies every entry into dst, preserving file
+// modes. Symlinks are skipped (the plugin tree doesn't contain any).
+func copyDirRecursive(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		switch {
+		case info.IsDir():
+			return os.MkdirAll(target, info.Mode().Perm()|0o700)
+		case info.Mode().IsRegular():
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			in, err := os.Open(path)
 			if err != nil {
 				return err
 			}
-			if _, err = io.Copy(out, tr); err != nil {
+			defer in.Close()
+			out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, in); err != nil {
 				out.Close()
 				return err
 			}
 			return out.Close()
+		default:
+			return nil
 		}
-	}
-	return fmt.Errorf("binary %q not found in archive", binaryName)
+	})
 }
 
 // atomicReplace replaces dest with src. Tries os.Rename first (atomic on same

--- a/cmd/wipnote/upgrade_extract_test.go
+++ b/cmd/wipnote/upgrade_extract_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestExtractArchive_BinaryAndPlugin builds a synthetic tar.gz containing the
+// post-Phase-A layout (wipnote binary at root, plugin/ subtree alongside) and
+// verifies that extractArchive lays both out under destRoot with the right
+// modes and content. Covers the contract that upgrade_cmd.go now relies on.
+func TestExtractArchive_BinaryAndPlugin(t *testing.T) {
+	// Build the archive in memory.
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	entries := []struct {
+		name     string
+		mode     int64
+		typeflag byte
+		body     string
+	}{
+		{"wipnote", 0o755, tar.TypeReg, "fake-binary-bytes"},
+		{"plugin/", 0o755, tar.TypeDir, ""},
+		{"plugin/.claude-plugin/plugin.json", 0o644, tar.TypeReg, `{"name":"wipnote"}`},
+		{"plugin/hooks/bin/bootstrap.sh", 0o755, tar.TypeReg, "#!/bin/sh\nexit 0\n"},
+		{"plugin/agents/researcher.md", 0o644, tar.TypeReg, "# researcher\n"},
+	}
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Name:     e.name,
+			Mode:     e.mode,
+			Size:     int64(len(e.body)),
+			Typeflag: e.typeflag,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write header %s: %v", e.name, err)
+		}
+		if e.typeflag == tar.TypeReg {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatalf("write body %s: %v", e.name, err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+
+	dir := t.TempDir()
+	tarballPath := filepath.Join(dir, "release.tar.gz")
+	if err := os.WriteFile(tarballPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write tarball: %v", err)
+	}
+
+	destRoot := filepath.Join(dir, "extracted")
+	if err := os.MkdirAll(destRoot, 0o755); err != nil {
+		t.Fatalf("mkdir destRoot: %v", err)
+	}
+	if err := extractArchive(tarballPath, destRoot); err != nil {
+		t.Fatalf("extractArchive: %v", err)
+	}
+
+	// Binary lifted to destRoot/wipnote with mode 0o755.
+	binPath := filepath.Join(destRoot, "wipnote")
+	binInfo, err := os.Stat(binPath)
+	if err != nil {
+		t.Fatalf("stat binary: %v", err)
+	}
+	if got := binInfo.Mode().Perm(); got != 0o755 {
+		t.Errorf("binary mode = %o, want 0755", got)
+	}
+	body, _ := os.ReadFile(binPath)
+	if string(body) != "fake-binary-bytes" {
+		t.Errorf("binary body = %q", body)
+	}
+
+	// plugin.json is present.
+	pluginJSON := filepath.Join(destRoot, "plugin", ".claude-plugin", "plugin.json")
+	if _, err := os.Stat(pluginJSON); err != nil {
+		t.Errorf("plugin.json missing: %v", err)
+	}
+
+	// bootstrap.sh keeps executable bit.
+	bsPath := filepath.Join(destRoot, "plugin", "hooks", "bin", "bootstrap.sh")
+	bsInfo, err := os.Stat(bsPath)
+	if err != nil {
+		t.Fatalf("stat bootstrap.sh: %v", err)
+	}
+	if bsInfo.Mode().Perm()&0o111 == 0 {
+		t.Errorf("bootstrap.sh not executable: mode=%o", bsInfo.Mode().Perm())
+	}
+
+	// Agent markdown is plain.
+	agentPath := filepath.Join(destRoot, "plugin", "agents", "researcher.md")
+	if _, err := os.Stat(agentPath); err != nil {
+		t.Errorf("researcher.md missing: %v", err)
+	}
+}
+
+// TestExtractArchive_RejectsPathTraversal verifies that "../" entries cannot
+// escape destRoot — a defensive check against malicious tarballs.
+func TestExtractArchive_RejectsPathTraversal(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{
+		Name:     "../escape.txt",
+		Mode:     0o644,
+		Size:     5,
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	if _, err := tw.Write([]byte("hello")); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+	tw.Close()
+	gz.Close()
+
+	dir := t.TempDir()
+	tarballPath := filepath.Join(dir, "bad.tar.gz")
+	if err := os.WriteFile(tarballPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write tarball: %v", err)
+	}
+	destRoot := filepath.Join(dir, "extracted")
+	if err := os.MkdirAll(destRoot, 0o755); err != nil {
+		t.Fatalf("mkdir destRoot: %v", err)
+	}
+
+	if err := extractArchive(tarballPath, destRoot); err != nil {
+		t.Fatalf("extractArchive: %v", err)
+	}
+
+	// Nothing should have been written.
+	if _, err := os.Stat(filepath.Join(dir, "escape.txt")); err == nil {
+		t.Fatal("path-traversal entry should not have been written outside destRoot")
+	}
+	if _, err := os.Stat(filepath.Join(destRoot, "..", "escape.txt")); err == nil {
+		t.Fatal("path-traversal entry should not have been written above destRoot")
+	}
+}
+
+// TestCopyDirRecursive_PreservesModes ensures that the cross-device fallback
+// in installPluginTree preserves executable permissions (e.g. for hooks/bin/*.sh).
+func TestCopyDirRecursive_PreservesModes(t *testing.T) {
+	srcRoot := t.TempDir()
+	dstRoot := filepath.Join(t.TempDir(), "dst")
+
+	exe := filepath.Join(srcRoot, "hooks", "bin", "run.sh")
+	if err := os.MkdirAll(filepath.Dir(exe), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write exe: %v", err)
+	}
+	plain := filepath.Join(srcRoot, "plugin.json")
+	if err := os.WriteFile(plain, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write plain: %v", err)
+	}
+
+	if err := copyDirRecursive(srcRoot, dstRoot); err != nil {
+		t.Fatalf("copyDirRecursive: %v", err)
+	}
+
+	exeOut, err := os.Stat(filepath.Join(dstRoot, "hooks", "bin", "run.sh"))
+	if err != nil {
+		t.Fatalf("stat exe out: %v", err)
+	}
+	if exeOut.Mode().Perm()&0o111 == 0 {
+		t.Errorf("executable bit lost: mode=%o", exeOut.Mode().Perm())
+	}
+
+	plainOut, err := os.Stat(filepath.Join(dstRoot, "plugin.json"))
+	if err != nil {
+		t.Fatalf("stat plain out: %v", err)
+	}
+	body, _ := os.ReadFile(filepath.Join(dstRoot, "plugin.json"))
+	if !strings.Contains(string(body), "{}") {
+		t.Errorf("plain copy body = %q", body)
+	}
+	if plainOut.Mode().Perm() != 0o644 {
+		t.Errorf("plain mode = %o, want 0644", plainOut.Mode().Perm())
+	}
+}

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,9 @@ set -e
 REPO="shakestzd/wipnote"
 DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
 BINARY_NAME="wipnote"
+# Plugin tree from the release tarball is laid out under this directory.
+# Phase B will flip `wipnote claude` to load from here via --plugin-dir.
+DEFAULT_DATA_DIR="${HOME}/.local/share/wipnote"
 
 # ---------------------------------------------------------------------------
 # Logging helpers
@@ -321,6 +324,34 @@ download_and_install() {
 
     ln -sfn "${INSTALL_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/wn"
     log_info "Created alias: wn -> wipnote"
+
+    # Lay down the bundled plugin tree at ~/.local/share/wipnote/plugin so
+    # the binary and its plugin assets stay in lockstep. Releases >= v0.59
+    # ship plugin/ at the archive root; older releases simply skip this step.
+    if [ -d "${_tmpdir}/plugin" ]; then
+        mkdir -p "${DEFAULT_DATA_DIR}"
+        rm -rf "${DEFAULT_DATA_DIR}/plugin"
+        mv "${_tmpdir}/plugin" "${DEFAULT_DATA_DIR}/plugin"
+        log_info "Installed plugin tree to ${DEFAULT_DATA_DIR}/plugin"
+    fi
+
+    # Same pattern for the Codex CLI marketplace tree. Releases >= v0.59 ship
+    # codex-marketplace/ at the archive root; older releases simply skip.
+    if [ -d "${_tmpdir}/codex-marketplace" ]; then
+        mkdir -p "${DEFAULT_DATA_DIR}"
+        rm -rf "${DEFAULT_DATA_DIR}/codex-marketplace"
+        mv "${_tmpdir}/codex-marketplace" "${DEFAULT_DATA_DIR}/codex-marketplace"
+        log_info "Installed codex-marketplace tree to ${DEFAULT_DATA_DIR}/codex-marketplace"
+    fi
+
+    # Same pattern for the Gemini CLI extension tree. Releases >= v0.59 ship
+    # gemini-extension/ at the archive root; older releases simply skip.
+    if [ -d "${_tmpdir}/gemini-extension" ]; then
+        mkdir -p "${DEFAULT_DATA_DIR}"
+        rm -rf "${DEFAULT_DATA_DIR}/gemini-extension"
+        mv "${_tmpdir}/gemini-extension" "${DEFAULT_DATA_DIR}/gemini-extension"
+        log_info "Installed gemini-extension tree to ${DEFAULT_DATA_DIR}/gemini-extension"
+    fi
 
     log_info "Installed ${BINARY_NAME} to ${INSTALL_DIR}/${BINARY_NAME}"
 }

--- a/plugin/hooks/bin/bootstrap.sh
+++ b/plugin/hooks/bin/bootstrap.sh
@@ -176,7 +176,8 @@ download_binary() {
         bail
     fi
 
-    # Extract — goreleaser archive contains binary named "wipnote" at root.
+    # Extract — goreleaser archive contains the binary "wipnote" at root and
+    # (since v0.59) the plugin tree under plugin/.
     if ! tar xzf "${_tarball}" -C "${_tmpdir}" 2>/dev/null; then
         rm -rf "${_tmpdir}"
         log_err "Failed to extract archive."
@@ -192,6 +193,41 @@ download_binary() {
     mv "${_tmpdir}/wipnote" "${BINARY}"
     chmod +x "${BINARY}"
     echo "${_version}" > "${VERSION_FILE}"
+
+    # Lay down the bundled plugin tree at ~/.local/share/wipnote/plugin so the
+    # binary and its plugin assets stay in lockstep. Phase B will flip
+    # `wipnote claude` to load from this path via --plugin-dir.
+    #
+    # We extracted into ${_tmpdir} (not the destination) precisely so we never
+    # delete the directory we may currently be running from — bootstrap.sh in
+    # the legacy marketplace flow lives at
+    #   ~/.claude/plugins/marketplaces/wipnote/plugin/hooks/bin/bootstrap.sh
+    # and in the new bundled flow lives at
+    #   ~/.local/share/wipnote/plugin/hooks/bin/bootstrap.sh
+    # Removing the destination here is fine because tarball contents are
+    # already fully extracted to ${_tmpdir} before the swap.
+    if [ -d "${_tmpdir}/plugin" ]; then
+        rm -rf "${META_DIR}/plugin"
+        mv "${_tmpdir}/plugin" "${META_DIR}/plugin"
+        log_err "Installed plugin tree v${_version} to ${META_DIR}/plugin."
+    fi
+
+    # Same pattern for the Codex CLI marketplace tree. bootstrap.sh runs from
+    # the Claude hooks path so Codex/Gemini sessions don't normally trigger it,
+    # but extracting all three trees on Claude's first run is harmless (disk
+    # cost is negligible) and keeps the layout identical to install.sh.
+    if [ -d "${_tmpdir}/codex-marketplace" ]; then
+        rm -rf "${META_DIR}/codex-marketplace"
+        mv "${_tmpdir}/codex-marketplace" "${META_DIR}/codex-marketplace"
+        log_err "Installed codex-marketplace tree v${_version} to ${META_DIR}/codex-marketplace."
+    fi
+
+    # Same pattern for the Gemini CLI extension tree.
+    if [ -d "${_tmpdir}/gemini-extension" ]; then
+        rm -rf "${META_DIR}/gemini-extension"
+        mv "${_tmpdir}/gemini-extension" "${META_DIR}/gemini-extension"
+        log_err "Installed gemini-extension tree v${_version} to ${META_DIR}/gemini-extension."
+    fi
 
     rm -rf "${_tmpdir}"
     log_err "Installed wipnote v${_version} to ${BINARY}."


### PR DESCRIPTION
## Summary

Phase A of the marketplace-to-bundled-plugin migration. Every release tarball now ships the wipnote binary **plus** all three harness trees together:

\`\`\`
wipnote_VERSION_OS_ARCH.tar.gz
├── wipnote                      # CLI binary
├── plugin/                      # Claude Code tree (61 files)
├── codex-marketplace/           # Codex CLI tree (56 files)
└── gemini-extension/            # Gemini CLI tree (53 files)
\`\`\`

Installer paths (binary → \`~/.local/bin/wipnote\`; trees → \`~/.local/share/wipnote/{plugin,codex-marketplace,gemini-extension}/\`). Homebrew lays out the same shape under \`$(brew --prefix)/share/wipnote/\`.

**Plugin and binary cannot drift anymore** — they travel together in one atomic artifact. This is the root-cause fix for the drift problem Wave 1 papered over with \`verify-versions.sh\`.

## Behavior change

**None yet.** This PR is purely additive. The marketplace install path continues to work; \`wipnote claude\` still uses whatever Claude Code's plugin manager resolves. Phase B (next PR) flips the launchers to use the bundled trees via \`--plugin-dir\` (and Codex/Gemini equivalents), making per-project opt-in the default.

## Why this approach

Per investigation (\`code.claude.com/docs/en/plugins\`): \`--plugin-dir <path>\` is a fully supported production flag for Claude Code (not just \`--dev\`), accepts directories or zips, takes precedence over marketplace installs of the same name, and can be repeated. Codex/Gemini have similar local-load mechanisms. So a bundled-tree-via-launcher architecture is on-supported-rails for all three harnesses.

## What's in this PR

- **\`.goreleaser.yml\`** — \`archives.files\` adds three tree globs (0644 baseline, 0755 override for \`plugin/hooks/bin/*.sh\`). \`brews:\` \`install:\` extended with three \`(share/"wipnote").install\` lines.
- **\`install.sh\`** — extracts all three trees from the downloaded tarball, idempotently.
- **\`plugin/hooks/bin/bootstrap.sh\`** — extracts to a tempdir first, then renames into place (never deletes the directory it's running from).
- **\`cmd/wipnote/upgrade_cmd.go\`** — replaced single-file \`extractBinary\` with \`extractArchive\` (full tar walker with path-traversal hardening); added \`installPluginTree\` / \`installCodexTree\` / \`installGeminiTree\` (atomic rename + cross-device \`copyDirRecursive\` fallback); cleaned up deprecated \`tar.TypeRegA\`.
- **\`cmd/wipnote/build.go\`** — \`wipnote build\` now also mirrors all three trees to \`~/.local/share/wipnote/\` so dev builds work with Phase B's launcher changes.
- **New tests** — \`upgrade_extract_test.go\` (extractArchive, path-traversal rejection, copyDirRecursive mode preservation) + \`build_mirror_test.go\` (mirror content/mode preservation, missing-source error).

## Test plan

- [x] \`goreleaser release --snapshot --clean --skip=publish,sign\` produces correct archives (plugin/61 + codex-marketplace/56 + gemini-extension/53 files)
- [x] Generated \`dist/homebrew/wipnote.rb\` contains all three \`(share/"wipnote").install\` lines
- [x] \`go build ./... && go vet ./...\` clean
- [x] New unit tests pass; pre-existing sandbox-related test failures unchanged
- [ ] Full CI green
- [ ] First release after merge: \`wipnote upgrade\` extracts all three trees

## What's NOT in this PR

- Launcher changes (\`cmd/wipnote/claude.go\`, \`codex.go\`, \`gemini.go\`) — Phase B
- Retiring marketplace install dance in \`scripts/deploy-all.sh\` — Phase C
- Marketplace listing rewrites — Phase C

🤖 Generated with [Claude Code](https://claude.com/claude-code)