### PR TITLE
fix(hooks): skip Gemini AfterModel intermediate streaming chunks

### DIFF
--- a/.wipnote/bugs/bug-28a9d7a7.html
+++ b/.wipnote/bugs/bug-28a9d7a7.html
@@ -10,32 +10,20 @@
 <body>
     <article id="bug-28a9d7a7"
              data-type="bug"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="high"
              data-created="2026-04-26T12:39:31.284862"
-             data-updated="2026-05-07T19:27:29.687598" data-agent-assigned="claude-code" data-track-id="trk-c4615ad2">
+             data-updated="2026-05-14T17:34:45.545681" data-agent-assigned="claude-code" data-track-id="trk-c4615ad2">
 
         <header>
             <h1>Session OTel collector dies mid-session and is duplicated by _serve-child receiver</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-high">High Priority</span>
             </div>
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="caused_by">
-                <h3>Caused By:</h3>
-                <ul>
-                    <li><a href="bug-4697c62c.html" data-relationship="caused_by" data-since="2026-04-26T12:39:31.289337">bug-4697c62c</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="blocks">
-                <h3>Blocks:</h3>
-                <ul>
-                    <li><a href="feat-c40942d3.html" data-relationship="blocks" data-since="2026-05-07T19:27:05.117506">Tag v0.59.0, push origin/main, cut GitHub release</a></li>
-                </ul>
-            </section>
             <section data-edge-type="part_of">
                 <h3>Part Of:</h3>
                 <ul>
@@ -54,6 +42,19 @@
                 <ul>
                     <li><a href="bebc2f35-a728-46b6-9ec6-dc5822379ce0.html" data-relationship="implemented_in" data-since="2026-04-26T16:18:07.006318">session bebc2f35-a728-46b6-9ec6-dc5822379ce0</a></li>
                     <li><a href="7c4712e0-782f-415b-8614-a9affbfd7524.html" data-relationship="implemented_in" data-since="2026-04-26T18:20:17.557782">session 7c4712e0-782f-415b-8614-a9affbfd7524</a></li>
+                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:34:45.545148">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="caused_by">
+                <h3>Caused By:</h3>
+                <ul>
+                    <li><a href="bug-4697c62c.html" data-relationship="caused_by" data-since="2026-04-26T12:39:31.289337">bug-4697c62c</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocks">
+                <h3>Blocks:</h3>
+                <ul>
+                    <li><a href="feat-c40942d3.html" data-relationship="blocks" data-since="2026-05-07T19:27:05.117506">Tag v0.59.0, push origin/main, cut GitHub release</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/bugs/bug-55a17fc2.html
+++ b/.wipnote/bugs/bug-55a17fc2.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-55a17fc2"
              data-type="bug"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:59:20.204709"
-             data-updated="2026-05-14T17:59:20.2158" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-cli-version="0.59.1">
+             data-updated="2026-05-14T17:59:26.237856" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-cli-version="0.59.1">
 
         <header>
             <h1>Gemini AfterModel hook records per-chunk instead of per-turn</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -28,6 +28,12 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="trk-0677c709.html" data-relationship="part_of" data-since="2026-05-14T17:59:20.215249">trk-0677c709</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="019e232d18e11741c91180f21f87.html" data-relationship="implemented_in" data-since="2026-05-14T17:59:26.237449">session 019e232d18e11741c91180f21f87</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/bugs/bug-55a17fc2.html
+++ b/.wipnote/bugs/bug-55a17fc2.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Gemini AfterModel hook records per-chunk instead of per-turn</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-55a17fc2"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-05-14T17:59:20.204709"
+             data-updated="2026-05-14T17:59:20.2158" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-cli-version="0.59.1">
+
+        <header>
+            <h1>Gemini AfterModel hook records per-chunk instead of per-turn</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-0677c709.html" data-relationship="part_of" data-since="2026-05-14T17:59:20.215249">trk-0677c709</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Dashboard shows duplicated Gemini events: AfterModel hook fires once per streaming chunk (per geminicli.com docs), not once per LLM turn. 65% of AfterModel rows in agent_events lack token data (intermediate chunks). Tactical fix: guard at internal/hooks/gemini_model.go:82 to skip recordSimpleEvent when finishReason and totalTokens both zero. Durable follow-up: migrate hooks.json from AfterModel to AfterAgent once gemini-cli issue 15468 (premature-fire bug) is confirmed fixed in shipped versions.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-22fae741.html
+++ b/.wipnote/features/feat-22fae741.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>BLOCKER 1 — Add root LICENSE file (MIT)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-22fae741"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="medium"
+             data-created="2026-05-14T17:29:38.452328"
+             data-updated="2026-05-14T17:31:19.180081" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+
+        <header>
+            <h1>BLOCKER 1 — Add root LICENSE file (MIT)</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.456067">plan-cf1a6ae4</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.458264">trk-d78fd431</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:31:19.179863">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Add a root MIT LICENSE file using the canonical MIT text and the project copyright holder/year used for public release. Confirm packaging and docs point users at this license.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-22fae741.html
+++ b/.wipnote/features/feat-22fae741.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.452328"
-             data-updated="2026-05-14T17:31:19.180081" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:31:20.330179" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 1 — Add root LICENSE file (MIT)</h1>
@@ -24,6 +24,12 @@
         </header>
 
         <nav data-graph-edges>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:31:19.179863">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
             <section data-edge-type="planned_in">
                 <h3>Planned In:</h3>
                 <ul>
@@ -34,12 +40,6 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.458264">trk-d78fd431</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="implemented_in">
-                <h3>Implemented In:</h3>
-                <ul>
-                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:31:19.179863">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-22fae741.html
+++ b/.wipnote/features/feat-22fae741.html
@@ -10,15 +10,15 @@
 <body>
     <article id="feat-22fae741"
              data-type="feature"
-             data-status="in-progress"
+             data-status="done"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.452328"
-             data-updated="2026-05-14T17:31:20.330179" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:32:52.305781" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 1 — Add root LICENSE file (MIT)</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>

--- a/.wipnote/features/feat-290aa82d.html
+++ b/.wipnote/features/feat-290aa82d.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>BLOCKER 2 — Fix wipnote-aliases.sh (hg- to wn-)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-290aa82d"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="medium"
+             data-created="2026-05-14T17:29:38.465112"
+             data-updated="2026-05-14T17:34:21.631498" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+
+        <header>
+            <h1>BLOCKER 2 — Fix wipnote-aliases.sh (hg- to wn-)</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.470185">plan-cf1a6ae4</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:34:21.63081">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.474774">trk-d78fd431</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Update the shell aliases helper so public aliases use `wn`/`wipnote` names, not legacy `hg`/`htmlgraph` names. Include the canonical `wn` shortcut expected from install paths.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-290aa82d.html
+++ b/.wipnote/features/feat-290aa82d.html
@@ -10,15 +10,15 @@
 <body>
     <article id="feat-290aa82d"
              data-type="feature"
-             data-status="in-progress"
+             data-status="done"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.465112"
-             data-updated="2026-05-14T17:34:22.946981" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:35:34.550231" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 2 — Fix wipnote-aliases.sh (hg- to wn-)</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>

--- a/.wipnote/features/feat-290aa82d.html
+++ b/.wipnote/features/feat-290aa82d.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.465112"
-             data-updated="2026-05-14T17:34:21.631498" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:34:22.946981" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 2 — Fix wipnote-aliases.sh (hg- to wn-)</h1>

--- a/.wipnote/features/feat-38eb73aa.html
+++ b/.wipnote/features/feat-38eb73aa.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.490662"
-             data-updated="2026-05-14T17:34:45.180508" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:58:26.631918" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)</h1>

--- a/.wipnote/features/feat-38eb73aa.html
+++ b/.wipnote/features/feat-38eb73aa.html
@@ -10,32 +10,20 @@
 <body>
     <article id="feat-38eb73aa"
              data-type="feature"
-             data-status="in-progress"
+             data-status="done"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.490662"
-             data-updated="2026-05-14T18:01:45.638659" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T18:02:00.352371" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="blocked_by">
-                <h3>Blocked By:</h3>
-                <ul>
-                    <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="planned_in">
-                <h3>Planned In:</h3>
-                <ul>
-                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.49575">plan-cf1a6ae4</a></li>
-                </ul>
-            </section>
             <section data-edge-type="implemented_in">
                 <h3>Implemented In:</h3>
                 <ul>
@@ -46,6 +34,18 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.498766">trk-d78fd431</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.49575">plan-cf1a6ae4</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-38eb73aa.html
+++ b/.wipnote/features/feat-38eb73aa.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.490662"
-             data-updated="2026-05-14T17:58:27.397358" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T18:01:44.249888" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)</h1>

--- a/.wipnote/features/feat-38eb73aa.html
+++ b/.wipnote/features/feat-38eb73aa.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.490662"
-             data-updated="2026-05-14T18:01:44.249888" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T18:01:45.638659" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)</h1>

--- a/.wipnote/features/feat-38eb73aa.html
+++ b/.wipnote/features/feat-38eb73aa.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.490662"
-             data-updated="2026-05-14T17:34:21.105139" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:34:45.180508" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)</h1>
@@ -24,18 +24,6 @@
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="implemented_in">
-                <h3>Implemented In:</h3>
-                <ul>
-                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:34:21.104771">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="part_of">
-                <h3>Part Of:</h3>
-                <ul>
-                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.498766">trk-d78fd431</a></li>
-                </ul>
-            </section>
             <section data-edge-type="blocked_by">
                 <h3>Blocked By:</h3>
                 <ul>
@@ -46,6 +34,18 @@
                 <h3>Planned In:</h3>
                 <ul>
                     <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.49575">plan-cf1a6ae4</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:34:21.104771">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.498766">trk-d78fd431</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-38eb73aa.html
+++ b/.wipnote/features/feat-38eb73aa.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-38eb73aa"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="medium"
+             data-created="2026-05-14T17:29:38.490662"
+             data-updated="2026-05-14T17:34:21.105139" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+
+        <header>
+            <h1>BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:34:21.104771">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.498766">trk-d78fd431</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.49575">plan-cf1a6ae4</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Finish `bug-28a9d7a7`: remove the orphaned server-based OTel receiver path, preserve `ConvertAll` behavior for the session-scoped collector, and update stale comments/warnings that still describe the old embedded receiver.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-38eb73aa.html
+++ b/.wipnote/features/feat-38eb73aa.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.490662"
-             data-updated="2026-05-14T17:58:26.631918" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:58:27.397358" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)</h1>

--- a/.wipnote/features/feat-612fc215.html
+++ b/.wipnote/features/feat-612fc215.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.481489"
-             data-updated="2026-05-14T17:31:19.434303" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:31:20.881655" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 3 — Complete rename (feat-913bf7a6 &#43; feat-b02a559b)</h1>

--- a/.wipnote/features/feat-612fc215.html
+++ b/.wipnote/features/feat-612fc215.html
@@ -10,20 +10,26 @@
 <body>
     <article id="feat-612fc215"
              data-type="feature"
-             data-status="in-progress"
+             data-status="done"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.481489"
-             data-updated="2026-05-14T17:31:20.881655" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:34:07.262739" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 3 — Complete rename (feat-913bf7a6 &#43; feat-b02a559b)</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
 
         <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.48672">trk-d78fd431</a></li>
+                </ul>
+            </section>
             <section data-edge-type="implemented_in">
                 <h3>Implemented In:</h3>
                 <ul>
@@ -34,12 +40,6 @@
                 <h3>Planned In:</h3>
                 <ul>
                     <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.484307">plan-cf1a6ae4</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="part_of">
-                <h3>Part Of:</h3>
-                <ul>
-                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.48672">trk-d78fd431</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-612fc215.html
+++ b/.wipnote/features/feat-612fc215.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>BLOCKER 3 — Complete rename (feat-913bf7a6 &#43; feat-b02a559b)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-612fc215"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="medium"
+             data-created="2026-05-14T17:29:38.481489"
+             data-updated="2026-05-14T17:31:19.434303" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+
+        <header>
+            <h1>BLOCKER 3 — Complete rename (feat-913bf7a6 &#43; feat-b02a559b)</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:31:19.432179">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.484307">plan-cf1a6ae4</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.48672">trk-d78fd431</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Verify the completed htmlgraph→erinn and erinn→wipnote rename work across source, docs, release packaging, plugin manifests, generated ports, cache paths, env vars, and command examples. Close any remaining public-facing rename artifacts before release.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-a0c0025e.html
+++ b/.wipnote/features/feat-a0c0025e.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.50315"
-             data-updated="2026-05-14T17:58:27.607059" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T18:01:44.515818" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)</h1>

--- a/.wipnote/features/feat-a0c0025e.html
+++ b/.wipnote/features/feat-a0c0025e.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.50315"
-             data-updated="2026-05-14T17:34:21.350058" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:34:35.126145" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)</h1>
@@ -24,18 +24,6 @@
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="planned_in">
-                <h3>Planned In:</h3>
-                <ul>
-                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.505314">plan-cf1a6ae4</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="part_of">
-                <h3>Part Of:</h3>
-                <ul>
-                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.508605">trk-d78fd431</a></li>
-                </ul>
-            </section>
             <section data-edge-type="blocked_by">
                 <h3>Blocked By:</h3>
                 <ul>
@@ -46,6 +34,18 @@
                 <h3>Implemented In:</h3>
                 <ul>
                     <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:34:21.349841">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.505314">plan-cf1a6ae4</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.508605">trk-d78fd431</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-a0c0025e.html
+++ b/.wipnote/features/feat-a0c0025e.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.50315"
-             data-updated="2026-05-14T17:34:35.126145" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:58:26.902869" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)</h1>
@@ -24,18 +24,6 @@
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="blocked_by">
-                <h3>Blocked By:</h3>
-                <ul>
-                    <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="implemented_in">
-                <h3>Implemented In:</h3>
-                <ul>
-                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:34:21.349841">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
-                </ul>
-            </section>
             <section data-edge-type="planned_in">
                 <h3>Planned In:</h3>
                 <ul>
@@ -46,6 +34,18 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.508605">trk-d78fd431</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:34:21.349841">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-a0c0025e.html
+++ b/.wipnote/features/feat-a0c0025e.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.50315"
-             data-updated="2026-05-14T17:58:26.902869" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:58:27.607059" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)</h1>

--- a/.wipnote/features/feat-a0c0025e.html
+++ b/.wipnote/features/feat-a0c0025e.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.50315"
-             data-updated="2026-05-14T18:01:44.515818" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T18:01:46.273305" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)</h1>
@@ -24,12 +24,6 @@
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="planned_in">
-                <h3>Planned In:</h3>
-                <ul>
-                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.505314">plan-cf1a6ae4</a></li>
-                </ul>
-            </section>
             <section data-edge-type="part_of">
                 <h3>Part Of:</h3>
                 <ul>
@@ -46,6 +40,12 @@
                 <h3>Implemented In:</h3>
                 <ul>
                     <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:34:21.349841">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.505314">plan-cf1a6ae4</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-a0c0025e.html
+++ b/.wipnote/features/feat-a0c0025e.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-a0c0025e"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="medium"
+             data-created="2026-05-14T17:29:38.50315"
+             data-updated="2026-05-14T17:34:21.350058" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+
+        <header>
+            <h1>BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.505314">plan-cf1a6ae4</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.508605">trk-d78fd431</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:34:21.349841">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Implement the durable Gemini hook install path: `wipnote gemini --init` must write the required hooks into `~/.gemini/settings.json#hooks` or the dev-isolated equivalent, because hooks bundled only under the extension directory are not loaded by Gemini CLI.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-a1e427d6.html
+++ b/.wipnote/features/feat-a1e427d6.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>RELEASE — Fix gh-pages docs title (bug-3f5922c8)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-a1e427d6"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="medium"
+             data-created="2026-05-14T17:29:38.519823"
+             data-updated="2026-05-14T17:58:26.322047" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+
+        <header>
+            <h1>RELEASE — Fix gh-pages docs title (bug-3f5922c8)</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:58:26.32155">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.522208">plan-cf1a6ae4</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.523758">trk-d78fd431</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Fix the published documentation title and metadata so gh-pages no longer says "HtmlGraph - erinn" or other stale brand text.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-a1e427d6.html
+++ b/.wipnote/features/feat-a1e427d6.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.519823"
-             data-updated="2026-05-14T17:58:27.818203" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T18:01:44.747032" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>RELEASE — Fix gh-pages docs title (bug-3f5922c8)</h1>
@@ -24,12 +24,6 @@
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="part_of">
-                <h3>Part Of:</h3>
-                <ul>
-                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.523758">trk-d78fd431</a></li>
-                </ul>
-            </section>
             <section data-edge-type="implemented_in">
                 <h3>Implemented In:</h3>
                 <ul>
@@ -46,6 +40,12 @@
                 <h3>Planned In:</h3>
                 <ul>
                     <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.522208">plan-cf1a6ae4</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.523758">trk-d78fd431</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-a1e427d6.html
+++ b/.wipnote/features/feat-a1e427d6.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.519823"
-             data-updated="2026-05-14T17:58:26.322047" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:58:27.818203" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>RELEASE — Fix gh-pages docs title (bug-3f5922c8)</h1>
@@ -24,6 +24,12 @@
         </header>
 
         <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.523758">trk-d78fd431</a></li>
+                </ul>
+            </section>
             <section data-edge-type="implemented_in">
                 <h3>Implemented In:</h3>
                 <ul>
@@ -40,12 +46,6 @@
                 <h3>Planned In:</h3>
                 <ul>
                     <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.522208">plan-cf1a6ae4</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="part_of">
-                <h3>Part Of:</h3>
-                <ul>
-                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.523758">trk-d78fd431</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-a1e427d6.html
+++ b/.wipnote/features/feat-a1e427d6.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.519823"
-             data-updated="2026-05-14T18:01:44.747032" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T18:01:46.6136" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>RELEASE — Fix gh-pages docs title (bug-3f5922c8)</h1>
@@ -24,18 +24,6 @@
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="implemented_in">
-                <h3>Implemented In:</h3>
-                <ul>
-                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:58:26.32155">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="blocked_by">
-                <h3>Blocked By:</h3>
-                <ul>
-                    <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
-                </ul>
-            </section>
             <section data-edge-type="planned_in">
                 <h3>Planned In:</h3>
                 <ul>
@@ -46,6 +34,18 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.523758">trk-d78fd431</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:58:26.32155">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-d8fb9e42.html
+++ b/.wipnote/features/feat-d8fb9e42.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.512594"
-             data-updated="2026-05-14T17:58:25.753029" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T17:58:28.512619" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 6 — Fix claim-breaking bug: Yolo guard misfires (bug-c4e3551d)</h1>
@@ -24,18 +24,6 @@
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="part_of">
-                <h3>Part Of:</h3>
-                <ul>
-                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.516069">trk-d78fd431</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="blocked_by">
-                <h3>Blocked By:</h3>
-                <ul>
-                    <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
-                </ul>
-            </section>
             <section data-edge-type="planned_in">
                 <h3>Planned In:</h3>
                 <ul>
@@ -46,6 +34,18 @@
                 <h3>Implemented In:</h3>
                 <ul>
                     <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:58:25.751587">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.516069">trk-d78fd431</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-d8fb9e42.html
+++ b/.wipnote/features/feat-d8fb9e42.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>BLOCKER 6 — Fix claim-breaking bug: Yolo guard misfires (bug-c4e3551d)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-d8fb9e42"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="medium"
+             data-created="2026-05-14T17:29:38.512594"
+             data-updated="2026-05-14T17:58:25.753029" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+
+        <header>
+            <h1>BLOCKER 6 — Fix claim-breaking bug: Yolo guard misfires (bug-c4e3551d)</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="trk-d78fd431.html" data-relationship="part_of" data-since="2026-05-14T17:29:38.516069">trk-d78fd431</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.514054">plan-cf1a6ae4</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="11836a1a-43f9-4302-aeec-e35e472abd69.html" data-relationship="implemented_in" data-since="2026-05-14T17:58:25.751587">session 11836a1a-43f9-4302-aeec-e35e472abd69</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Fix the YOLO PreToolUse research-first guard so it does not block after real research has happened, and either make its source of truth resistant to direct SQLite row injection or explicitly downgrade it to advisory with visible warnings.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-d8fb9e42.html
+++ b/.wipnote/features/feat-d8fb9e42.html
@@ -10,26 +10,20 @@
 <body>
     <article id="feat-d8fb9e42"
              data-type="feature"
-             data-status="in-progress"
+             data-status="done"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.512594"
-             data-updated="2026-05-14T17:58:28.512619" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T18:01:24.849166" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 6 — Fix claim-breaking bug: Yolo guard misfires (bug-c4e3551d)</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="planned_in">
-                <h3>Planned In:</h3>
-                <ul>
-                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.514054">plan-cf1a6ae4</a></li>
-                </ul>
-            </section>
             <section data-edge-type="implemented_in">
                 <h3>Implemented In:</h3>
                 <ul>
@@ -46,6 +40,12 @@
                 <h3>Blocked By:</h3>
                 <ul>
                     <li><a href="feat-612fc215.html" data-relationship="blocked_by">feat-612fc215</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="plan-cf1a6ae4.html" data-relationship="planned_in" data-since="2026-05-14T17:29:38.514054">plan-cf1a6ae4</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-d8fb9e42.html
+++ b/.wipnote/features/feat-d8fb9e42.html
@@ -10,15 +10,15 @@
 <body>
     <article id="feat-d8fb9e42"
              data-type="feature"
-             data-status="done"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-05-14T17:29:38.512594"
-             data-updated="2026-05-14T18:01:24.849166" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
+             data-updated="2026-05-14T18:01:45.137512" data-agent-assigned="claude-code" data-track-id="trk-d78fd431">
 
         <header>
             <h1>BLOCKER 6 — Fix claim-breaking bug: Yolo guard misfires (bug-c4e3551d)</h1>
             <div class="metadata">
-                <span class="badge status-done">Done</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>

--- a/.wipnote/plans/plan-cf1a6ae4.html
+++ b/.wipnote/plans/plan-cf1a6ae4.html
@@ -400,86 +400,86 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
   <ul class="slice-nav-list" id="slice-nav-list">
     
     <li>
-      <a href="#slice-0" class="slice-nav-item" data-slice-nav="0">
-        <span class="slice-nav-dot" data-approval="pending" data-dot-for="0"></span>
-        <span>#0 BLOCKER 1 — Add root LICENSE file (MIT)</span>
+      <a href="#slice-1" class="slice-nav-item" data-slice-nav="1">
+        <span class="slice-nav-dot" data-approval="pending" data-dot-for="1"></span>
+        <span>#1 BLOCKER 1 — Add root LICENSE file (MIT)</span>
       </a>
     </li>
     
     <li>
-      <a href="#slice-0" class="slice-nav-item" data-slice-nav="0">
-        <span class="slice-nav-dot" data-approval="pending" data-dot-for="0"></span>
-        <span>#0 BLOCKER 2 — Fix wipnote-aliases.sh (hg- to wn-)</span>
+      <a href="#slice-2" class="slice-nav-item" data-slice-nav="2">
+        <span class="slice-nav-dot" data-approval="pending" data-dot-for="2"></span>
+        <span>#2 BLOCKER 2 — Fix wipnote-aliases.sh (hg- to wn-)</span>
       </a>
     </li>
     
     <li>
-      <a href="#slice-0" class="slice-nav-item" data-slice-nav="0">
-        <span class="slice-nav-dot" data-approval="pending" data-dot-for="0"></span>
-        <span>#0 BLOCKER 3 — Complete rename (feat-913bf7a6 + feat-b02a559b)</span>
+      <a href="#slice-3" class="slice-nav-item" data-slice-nav="3">
+        <span class="slice-nav-dot" data-approval="pending" data-dot-for="3"></span>
+        <span>#3 BLOCKER 3 — Complete rename (feat-913bf7a6 + feat-b02a559b)</span>
       </a>
     </li>
     
     <li>
-      <a href="#slice-0" class="slice-nav-item" data-slice-nav="0">
-        <span class="slice-nav-dot" data-approval="pending" data-dot-for="0"></span>
-        <span>#0 BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)</span>
+      <a href="#slice-4" class="slice-nav-item" data-slice-nav="4">
+        <span class="slice-nav-dot" data-approval="pending" data-dot-for="4"></span>
+        <span>#4 BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)</span>
       </a>
     </li>
     
     <li>
-      <a href="#slice-0" class="slice-nav-item" data-slice-nav="0">
-        <span class="slice-nav-dot" data-approval="pending" data-dot-for="0"></span>
-        <span>#0 BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)</span>
+      <a href="#slice-5" class="slice-nav-item" data-slice-nav="5">
+        <span class="slice-nav-dot" data-approval="pending" data-dot-for="5"></span>
+        <span>#5 BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)</span>
       </a>
     </li>
     
     <li>
-      <a href="#slice-0" class="slice-nav-item" data-slice-nav="0">
-        <span class="slice-nav-dot" data-approval="pending" data-dot-for="0"></span>
-        <span>#0 BLOCKER 6 — Fix claim-breaking bug: Yolo guard misfires (bug-c4e3551d)</span>
+      <a href="#slice-6" class="slice-nav-item" data-slice-nav="6">
+        <span class="slice-nav-dot" data-approval="pending" data-dot-for="6"></span>
+        <span>#6 BLOCKER 6 — Fix claim-breaking bug: Yolo guard misfires (bug-c4e3551d)</span>
       </a>
     </li>
     
     <li>
-      <a href="#slice-0" class="slice-nav-item" data-slice-nav="0">
-        <span class="slice-nav-dot" data-approval="pending" data-dot-for="0"></span>
-        <span>#0 RELEASE — Fix gh-pages docs title (bug-3f5922c8)</span>
+      <a href="#slice-7" class="slice-nav-item" data-slice-nav="7">
+        <span class="slice-nav-dot" data-approval="pending" data-dot-for="7"></span>
+        <span>#7 RELEASE — Fix gh-pages docs title (bug-3f5922c8)</span>
       </a>
     </li>
     
     <li>
-      <a href="#slice-0" class="slice-nav-item" data-slice-nav="0">
-        <span class="slice-nav-dot" data-approval="pending" data-dot-for="0"></span>
-        <span>#0 RELEASE — Update Homebrew formula to current version (feat-c8bb337e)</span>
+      <a href="#slice-8" class="slice-nav-item" data-slice-nav="8">
+        <span class="slice-nav-dot" data-approval="pending" data-dot-for="8"></span>
+        <span>#8 RELEASE — Update Homebrew formula to current version (feat-c8bb337e)</span>
       </a>
     </li>
     
     <li>
-      <a href="#slice-0" class="slice-nav-item" data-slice-nav="0">
-        <span class="slice-nav-dot" data-approval="pending" data-dot-for="0"></span>
-        <span>#0 RELEASE — Tag v0.59.0, push origin/main, cut GitHub release (feat-c40942d3)</span>
+      <a href="#slice-9" class="slice-nav-item" data-slice-nav="9">
+        <span class="slice-nav-dot" data-approval="pending" data-dot-for="9"></span>
+        <span>#9 RELEASE — Tag v0.59.0, push origin/main, cut GitHub release (feat-c40942d3)</span>
       </a>
     </li>
     
     <li>
-      <a href="#slice-0" class="slice-nav-item" data-slice-nav="0">
-        <span class="slice-nav-dot" data-approval="pending" data-dot-for="0"></span>
-        <span>#0 CONTENT — Record demo video (feat-4ae13f3c)</span>
+      <a href="#slice-10" class="slice-nav-item" data-slice-nav="10">
+        <span class="slice-nav-dot" data-approval="pending" data-dot-for="10"></span>
+        <span>#10 CONTENT — Record demo video (feat-4ae13f3c)</span>
       </a>
     </li>
     
     <li>
-      <a href="#slice-0" class="slice-nav-item" data-slice-nav="0">
-        <span class="slice-nav-dot" data-approval="pending" data-dot-for="0"></span>
-        <span>#0 CONTENT — Write blog post draft (feat-e505e51c)</span>
+      <a href="#slice-11" class="slice-nav-item" data-slice-nav="11">
+        <span class="slice-nav-dot" data-approval="pending" data-dot-for="11"></span>
+        <span>#11 CONTENT — Write blog post draft (feat-e505e51c)</span>
       </a>
     </li>
     
     <li>
-      <a href="#slice-0" class="slice-nav-item" data-slice-nav="0">
-        <span class="slice-nav-dot" data-approval="pending" data-dot-for="0"></span>
-        <span>#0 LAUNCH — LinkedIn post + HN submission (feat-ec81c370)</span>
+      <a href="#slice-12" class="slice-nav-item" data-slice-nav="12">
+        <span class="slice-nav-dot" data-approval="pending" data-dot-for="12"></span>
+        <span>#12 LAUNCH — LinkedIn post + HN submission (feat-ec81c370)</span>
       </a>
     </li>
     
@@ -492,15 +492,15 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 </nav>
 <div class="plan-layout">
 <div class="plan-content">
-<article id="plan-cf1a6ae4" data-plan-id="plan-cf1a6ae4" data-feature-id="" data-status="active">
+<article id="plan-cf1a6ae4" data-type="plan" data-plan-id="plan-cf1a6ae4" data-feature-id="" data-status="todo" data-priority="high">
 
 <!-- Plan Header -->
 <header class="plan-header">
   <h1>Plan: Launch readiness — wipnote public launch blockers</h1>
   <p style="color:var(--text-dim)">Ordered critical path to LinkedIn + HN launch. Audit performed 2026-05-07. Estimated 3–4 days of focused work.</p>
   <div class="meta">
-    <span class="badge badge-revision">Active</span>
-    <span style="font-size:.75rem;color:var(--text-muted)">v6 · 12 slices · Created 2026-05-07</span>
+    <span class="badge badge-pending">Draft</span>
+    <span style="font-size:.75rem;color:var(--text-muted)">v8 · 12 slices · Created 2026-05-07</span>
   </div>
 </header>
 <button id="themeToggle" style="position:fixed;top:16px;right:16px;z-index:100;background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:6px 12px;color:var(--text);font-family:var(--mono);font-size:0.75rem;cursor:pointer;">
@@ -520,18 +520,18 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 <section class="dep-graph" data-zone="dependency-graph">
   <h2>Dependency Graph</h2>
   <div id="graph-data" style="display:none">
-    <div data-node="0" data-name="BLOCKER 1 — Add root LICENSE file (MIT)" data-status="pending" data-deps=""></div>
-    <div data-node="0" data-name="BLOCKER 2 — Fix wipnote-aliases.sh (hg- to wn-)" data-status="pending" data-deps=""></div>
-    <div data-node="0" data-name="BLOCKER 3 — Complete rename (feat-913bf7a6 + feat-b02a559b)" data-status="pending" data-deps=""></div>
-    <div data-node="0" data-name="BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)" data-status="pending" data-deps=""></div>
-    <div data-node="0" data-name="BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)" data-status="pending" data-deps=""></div>
-    <div data-node="0" data-name="BLOCKER 6 — Fix claim-breaking bug: Yolo guard misfires (bug-c4e3551d)" data-status="pending" data-deps=""></div>
-    <div data-node="0" data-name="RELEASE — Fix gh-pages docs title (bug-3f5922c8)" data-status="pending" data-deps=""></div>
-    <div data-node="0" data-name="RELEASE — Update Homebrew formula to current version (feat-c8bb337e)" data-status="pending" data-deps=""></div>
-    <div data-node="0" data-name="RELEASE — Tag v0.59.0, push origin/main, cut GitHub release (feat-c40942d3)" data-status="pending" data-deps=""></div>
-    <div data-node="0" data-name="CONTENT — Record demo video (feat-4ae13f3c)" data-status="pending" data-deps=""></div>
-    <div data-node="0" data-name="CONTENT — Write blog post draft (feat-e505e51c)" data-status="pending" data-deps=""></div>
-    <div data-node="0" data-name="LAUNCH — LinkedIn post + HN submission (feat-ec81c370)" data-status="pending" data-deps=""></div>
+    <div data-node="1" data-name="BLOCKER 1 — Add root LICENSE file (MIT)" data-status="pending" data-deps="" data-files="3"></div>
+    <div data-node="2" data-name="BLOCKER 2 — Fix wipnote-aliases.sh (hg- to wn-)" data-status="pending" data-deps="3" data-files="4"></div>
+    <div data-node="3" data-name="BLOCKER 3 — Complete rename (feat-913bf7a6 + feat-b02a559b)" data-status="pending" data-deps="" data-files="12"></div>
+    <div data-node="4" data-name="BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)" data-status="pending" data-deps="3" data-files="7"></div>
+    <div data-node="5" data-name="BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)" data-status="pending" data-deps="3" data-files="5"></div>
+    <div data-node="6" data-name="BLOCKER 6 — Fix claim-breaking bug: Yolo guard misfires (bug-c4e3551d)" data-status="pending" data-deps="3" data-files="5"></div>
+    <div data-node="7" data-name="RELEASE — Fix gh-pages docs title (bug-3f5922c8)" data-status="pending" data-deps="3" data-files="4"></div>
+    <div data-node="8" data-name="RELEASE — Update Homebrew formula to current version (feat-c8bb337e)" data-status="pending" data-deps="1,2,3,7" data-files="5"></div>
+    <div data-node="9" data-name="RELEASE — Tag v0.59.0, push origin/main, cut GitHub release (feat-c40942d3)" data-status="pending" data-deps="1,2,3,4,5,6,7,8" data-files="6"></div>
+    <div data-node="10" data-name="CONTENT — Record demo video (feat-4ae13f3c)" data-status="pending" data-deps="9" data-files="3"></div>
+    <div data-node="11" data-name="CONTENT — Write blog post draft (feat-e505e51c)" data-status="pending" data-deps="9,10" data-files="4"></div>
+    <div data-node="12" data-name="LAUNCH — LinkedIn post + HN submission (feat-ec81c370)" data-status="pending" data-deps="9,10,11" data-files="4"></div>
     
     <!--PLAN_GRAPH_NODES-->
   </div>
@@ -574,33 +574,34 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 <details id="slices" class="section-card" open data-phase="slices" data-status="pending">
   <summary><span>Slices</span><span class="badge badge-pending" data-badge-for="slices">Pending</span></summary>
   <div class="section-body">
-    <details class="slice-card" id="slice-0" data-slice="0" data-slice-name="slice-001" data-status="pending" data-approval="pending">
-  <summary class="slice-summary" aria-label="Slice 0: BLOCKER 1 — Add root LICENSE file (MIT)">
-    <span class="slice-num">#0</span>
+    <details class="slice-card" id="slice-1" data-slice="1" data-slice-name="slice-001" data-status="pending" data-approval="pending">
+  <summary class="slice-summary" aria-label="Slice 1: BLOCKER 1 — Add root LICENSE file (MIT)">
+    <span class="slice-num">#1</span>
     <span class="slice-title-col">
       <span class="slice-name">BLOCKER 1 — Add root LICENSE file (MIT)</span>
-      
+      <span class="slice-preview">Add a root MIT LICENSE file using the canonical MIT text and the project copyright holder/year used for public release.</span>
       <span class="slice-meta-row">
         <span class="slice-summary-badges">
+          <span class="badge badge-pending badge-sm">S</span>
+          <span class="badge badge-pending badge-sm">Low</span>
           
           
-          
-          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-0">Pending</span>
+          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-1">Pending</span>
           
           
         </span>
         <span class="slice-actions" onclick="event.stopPropagation()">
           <span class="approval-segmented" role="group" aria-label="Approval action">
             <label class="seg-btn seg-approve" title="Approve">
-              <input type="radio" name="slice-0-approval" value="approved" data-section="slice-0" data-action="approve" aria-label="Approve slice 0">
+              <input type="radio" name="slice-1-approval" value="approved" data-section="slice-1" data-action="approve" aria-label="Approve slice 1">
               &#10003;
             </label>
             <label class="seg-btn seg-changes" title="Request changes">
-              <input type="radio" name="slice-0-approval" value="changes_requested" data-section="slice-0" data-action="approve" aria-label="Request changes for slice 0">
+              <input type="radio" name="slice-1-approval" value="changes_requested" data-section="slice-1" data-action="approve" aria-label="Request changes for slice 1">
               &#8635;
             </label>
             <label class="seg-btn seg-reject" title="Reject">
-              <input type="radio" name="slice-0-approval" value="rejected" data-section="slice-0" data-action="approve" aria-label="Reject slice 0">
+              <input type="radio" name="slice-1-approval" value="rejected" data-section="slice-1" data-action="approve" aria-label="Reject slice 1">
               &#10005;
             </label>
           </span>
@@ -612,11 +613,61 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 
   <div class="slice-body">
     
-      <div class="slice-meta"><span>slice-001</span></div>
       
+      <div class="slice-field slice-what">
+        <div class="slice-field-label">What</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Add a root MIT LICENSE file using the canonical MIT text and the project copyright holder/year used for public release. Confirm packaging and docs point users at this license.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field slice-why">
+        <div class="slice-field-label">Why</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>A public open-source launch without a license creates legal ambiguity for contributors, users, Homebrew packaging, and HN/LinkedIn readers who want to inspect or reuse the code.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Files</div>
+        <div class="slice-field-value"><code>LICENSE, README.md, docs/index.md</code></div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Done when</div>
+        <ul class="slice-done-list"><li>Root LICENSE exists and contains the standard MIT License text.</li><li>README/docs reference the MIT license without stale HtmlGraph/erinn naming.</li><li>No duplicate or conflicting license file remains under generated plugin ports.</li></ul>
+      </div>
       
     
 
+    
+
+    
+    <div class="slice-field slice-tests-field">
+      <div class="slice-field-label">Test Strategy</div>
+      <div class="slice-field-value">
+        
+        
+        <div class="test-strategy">
+          
+          <div class="test-group" data-kind="manual verification">
+            <span class="test-chip">MANUAL VERIFICATION &middot; 1</span>
+            <ul><li>inspect LICENSE and search for stale license references with `rg -n &#34;license|MIT|HtmlGraph|erinn&#34; README.md docs plugin packages`.</li></ul>
+          </div>
+          
+        </div>
+        
+      </div>
+    </div>
     
 
     
@@ -628,38 +679,39 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
     <details class="comment-collapse">
       <summary class="comment-collapse-trigger">+ Leave a comment</summary>
       <div class="comment-collapse-body">
-        <textarea data-section="slice-0" data-comment-for="slice-0" placeholder="Comments on slice 0..."></textarea>
+        <textarea data-section="slice-1" data-comment-for="slice-1" placeholder="Comments on slice 1..."></textarea>
       </div>
     </details>
   </div>
 </details>
-<details class="slice-card" id="slice-0" data-slice="0" data-slice-name="slice-002" data-status="pending" data-approval="pending">
-  <summary class="slice-summary" aria-label="Slice 0: BLOCKER 2 — Fix wipnote-aliases.sh (hg- to wn-)">
-    <span class="slice-num">#0</span>
+<details class="slice-card" id="slice-2" data-slice="2" data-slice-name="slice-002" data-status="pending" data-approval="pending">
+  <summary class="slice-summary" aria-label="Slice 2: BLOCKER 2 — Fix wipnote-aliases.sh (hg- to wn-)">
+    <span class="slice-num">#2</span>
     <span class="slice-title-col">
       <span class="slice-name">BLOCKER 2 — Fix wipnote-aliases.sh (hg- to wn-)</span>
-      
+      <span class="slice-preview">Update the shell aliases helper so public aliases use wn/wipnote names, not legacy hg/htmlgraph names.</span>
       <span class="slice-meta-row">
         <span class="slice-summary-badges">
+          <span class="badge badge-pending badge-sm">S</span>
+          <span class="badge badge-pending badge-sm">Low</span>
           
           
-          
-          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-0">Pending</span>
+          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-2">Pending</span>
           
           
         </span>
         <span class="slice-actions" onclick="event.stopPropagation()">
           <span class="approval-segmented" role="group" aria-label="Approval action">
             <label class="seg-btn seg-approve" title="Approve">
-              <input type="radio" name="slice-0-approval" value="approved" data-section="slice-0" data-action="approve" aria-label="Approve slice 0">
+              <input type="radio" name="slice-2-approval" value="approved" data-section="slice-2" data-action="approve" aria-label="Approve slice 2">
               &#10003;
             </label>
             <label class="seg-btn seg-changes" title="Request changes">
-              <input type="radio" name="slice-0-approval" value="changes_requested" data-section="slice-0" data-action="approve" aria-label="Request changes for slice 0">
+              <input type="radio" name="slice-2-approval" value="changes_requested" data-section="slice-2" data-action="approve" aria-label="Request changes for slice 2">
               &#8635;
             </label>
             <label class="seg-btn seg-reject" title="Reject">
-              <input type="radio" name="slice-0-approval" value="rejected" data-section="slice-0" data-action="approve" aria-label="Reject slice 0">
+              <input type="radio" name="slice-2-approval" value="rejected" data-section="slice-2" data-action="approve" aria-label="Reject slice 2">
               &#10005;
             </label>
           </span>
@@ -671,54 +723,99 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 
   <div class="slice-body">
     
-      <div class="slice-meta"><span>slice-002</span></div>
+      
+      <div class="slice-field slice-what">
+        <div class="slice-field-label">What</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Update the shell aliases helper so public aliases use <code>wn</code>/<code>wipnote</code> names, not legacy <code>hg</code>/<code>htmlgraph</code> names. Include the canonical <code>wn</code> shortcut expected from install paths.</p>
+</div>
+          
+        </div>
+      </div>
       
       
+      <div class="slice-field slice-why">
+        <div class="slice-field-label">Why</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>The alias file is a first-run affordance. Stale prefixes create immediate brand confusion and make install docs look unreliable.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Files</div>
+        <div class="slice-field-value"><code>wipnote-aliases.sh, install.sh, README.md, docs/index.md</code></div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Done when</div>
+        <ul class="slice-done-list"><li>`wipnote-aliases.sh` defines `wn` aliases and no user-facing `hg-` aliases.</li><li>Install/docs examples use `wipnote` or `wn`.</li><li>A shell syntax check passes for the alias file.</li></ul>
+      </div>
+      
+    
+
+    
+
+    
+    <div class="slice-field slice-tests-field">
+      <div class="slice-field-label">Test Strategy</div>
+      <div class="slice-field-value">
+        
+        
+        <div class="markdown-block slice-tests"><p>Run <code>zsh -n wipnote-aliases.sh</code> and <code>rg -n &#34;hg-|htmlgraph|erinn&#34; wipnote-aliases.sh install.sh README.md docs</code>.</p>
+</div>
+        
+      </div>
+    </div>
     
 
     
 
     
 
-    
-
-    <div class="slice-deps">Dependencies: none</div>
+    <div class="slice-deps">Dependencies: slices 3</div>
 
     <details class="comment-collapse">
       <summary class="comment-collapse-trigger">+ Leave a comment</summary>
       <div class="comment-collapse-body">
-        <textarea data-section="slice-0" data-comment-for="slice-0" placeholder="Comments on slice 0..."></textarea>
+        <textarea data-section="slice-2" data-comment-for="slice-2" placeholder="Comments on slice 2..."></textarea>
       </div>
     </details>
   </div>
 </details>
-<details class="slice-card" id="slice-0" data-slice="0" data-slice-name="slice-003" data-status="pending" data-approval="pending">
-  <summary class="slice-summary" aria-label="Slice 0: BLOCKER 3 — Complete rename (feat-913bf7a6 &#43; feat-b02a559b)">
-    <span class="slice-num">#0</span>
+<details class="slice-card" id="slice-3" data-slice="3" data-slice-name="slice-003" data-status="pending" data-approval="pending">
+  <summary class="slice-summary" aria-label="Slice 3: BLOCKER 3 — Complete rename (feat-913bf7a6 &#43; feat-b02a559b)">
+    <span class="slice-num">#3</span>
     <span class="slice-title-col">
       <span class="slice-name">BLOCKER 3 — Complete rename (feat-913bf7a6 &#43; feat-b02a559b)</span>
-      
+      <span class="slice-preview">Verify the completed htmlgraph→erinn and erinn→wipnote rename work across source, docs, release packaging, plugin manifests, generated ports…</span>
       <span class="slice-meta-row">
         <span class="slice-summary-badges">
+          <span class="badge badge-revision badge-sm">M</span>
+          <span class="badge badge-revision badge-sm">Med</span>
           
           
-          
-          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-0">Pending</span>
+          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-3">Pending</span>
           
           
         </span>
         <span class="slice-actions" onclick="event.stopPropagation()">
           <span class="approval-segmented" role="group" aria-label="Approval action">
             <label class="seg-btn seg-approve" title="Approve">
-              <input type="radio" name="slice-0-approval" value="approved" data-section="slice-0" data-action="approve" aria-label="Approve slice 0">
+              <input type="radio" name="slice-3-approval" value="approved" data-section="slice-3" data-action="approve" aria-label="Approve slice 3">
               &#10003;
             </label>
             <label class="seg-btn seg-changes" title="Request changes">
-              <input type="radio" name="slice-0-approval" value="changes_requested" data-section="slice-0" data-action="approve" aria-label="Request changes for slice 0">
+              <input type="radio" name="slice-3-approval" value="changes_requested" data-section="slice-3" data-action="approve" aria-label="Request changes for slice 3">
               &#8635;
             </label>
             <label class="seg-btn seg-reject" title="Reject">
-              <input type="radio" name="slice-0-approval" value="rejected" data-section="slice-0" data-action="approve" aria-label="Reject slice 0">
+              <input type="radio" name="slice-3-approval" value="rejected" data-section="slice-3" data-action="approve" aria-label="Reject slice 3">
               &#10005;
             </label>
           </span>
@@ -730,11 +827,55 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 
   <div class="slice-body">
     
-      <div class="slice-meta"><span>slice-003</span></div>
       
+      <div class="slice-field slice-what">
+        <div class="slice-field-label">What</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Verify the completed htmlgraph→erinn and erinn→wipnote rename work across source, docs, release packaging, plugin manifests, generated ports, cache paths, env vars, and command examples. Close any remaining public-facing rename artifacts before release.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field slice-why">
+        <div class="slice-field-label">Why</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>The rename features are marked done, but launch-readiness depends on the observable product surface being consistently <code>wipnote</code>/<code>wn</code>.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Files</div>
+        <div class="slice-field-value"><code>go.mod, cmd/wipnote, internal, plugin, packages/plugin-core/manifest.json, packages/codex-marketplace, packages/gemini-extension, packages/homebrew, .goreleaser.yml, mkdocs.yml, docs, README.md</code></div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Done when</div>
+        <ul class="slice-done-list"><li>`feat-913bf7a6` and `feat-b02a559b` remain done and have no reopen-worthy rename gaps.</li><li>Public docs, install scripts, Homebrew formula, GoReleaser config, and plugin manifests use wipnote naming.</li><li>Intentional historical references, if any, are clearly historical and not product instructions.</li><li>Generated Codex/Gemini ports are rebuilt after any plugin source-of-truth changes.</li></ul>
+      </div>
       
     
 
+    
+
+    
+    <div class="slice-field slice-tests-field">
+      <div class="slice-field-label">Test Strategy</div>
+      <div class="slice-field-value">
+        
+        
+        <div class="markdown-block slice-tests"><p>Run targeted stale-name searches, then <code>wipnote plugin build-ports</code> if plugin assets changed. Finish with Go quality gates before release.</p>
+</div>
+        
+      </div>
+    </div>
     
 
     
@@ -746,38 +887,39 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
     <details class="comment-collapse">
       <summary class="comment-collapse-trigger">+ Leave a comment</summary>
       <div class="comment-collapse-body">
-        <textarea data-section="slice-0" data-comment-for="slice-0" placeholder="Comments on slice 0..."></textarea>
+        <textarea data-section="slice-3" data-comment-for="slice-3" placeholder="Comments on slice 3..."></textarea>
       </div>
     </details>
   </div>
 </details>
-<details class="slice-card" id="slice-0" data-slice="0" data-slice-name="slice-004" data-status="pending" data-approval="pending">
-  <summary class="slice-summary" aria-label="Slice 0: BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)">
-    <span class="slice-num">#0</span>
+<details class="slice-card" id="slice-4" data-slice="4" data-slice-name="slice-004" data-status="pending" data-approval="pending">
+  <summary class="slice-summary" aria-label="Slice 4: BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)">
+    <span class="slice-num">#4</span>
     <span class="slice-title-col">
       <span class="slice-name">BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)</span>
-      
+      <span class="slice-preview">Finish bug-28a9d7a7: remove the orphaned server-based OTel receiver path, preserve ConvertAll behavior for the session-scoped collector, and…</span>
       <span class="slice-meta-row">
         <span class="slice-summary-badges">
+          <span class="badge badge-revision badge-sm">M</span>
+          <span class="badge badge-blocked badge-sm">High</span>
           
           
-          
-          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-0">Pending</span>
+          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-4">Pending</span>
           
           
         </span>
         <span class="slice-actions" onclick="event.stopPropagation()">
           <span class="approval-segmented" role="group" aria-label="Approval action">
             <label class="seg-btn seg-approve" title="Approve">
-              <input type="radio" name="slice-0-approval" value="approved" data-section="slice-0" data-action="approve" aria-label="Approve slice 0">
+              <input type="radio" name="slice-4-approval" value="approved" data-section="slice-4" data-action="approve" aria-label="Approve slice 4">
               &#10003;
             </label>
             <label class="seg-btn seg-changes" title="Request changes">
-              <input type="radio" name="slice-0-approval" value="changes_requested" data-section="slice-0" data-action="approve" aria-label="Request changes for slice 0">
+              <input type="radio" name="slice-4-approval" value="changes_requested" data-section="slice-4" data-action="approve" aria-label="Request changes for slice 4">
               &#8635;
             </label>
             <label class="seg-btn seg-reject" title="Reject">
-              <input type="radio" name="slice-0-approval" value="rejected" data-section="slice-0" data-action="approve" aria-label="Reject slice 0">
+              <input type="radio" name="slice-4-approval" value="rejected" data-section="slice-4" data-action="approve" aria-label="Reject slice 4">
               &#10005;
             </label>
           </span>
@@ -789,54 +931,99 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 
   <div class="slice-body">
     
-      <div class="slice-meta"><span>slice-004</span></div>
+      
+      <div class="slice-field slice-what">
+        <div class="slice-field-label">What</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Finish <code>bug-28a9d7a7</code>: remove the orphaned server-based OTel receiver path, preserve <code>ConvertAll</code> behavior for the session-scoped collector, and update stale comments/warnings that still describe the old embedded receiver.</p>
+</div>
+          
+        </div>
+      </div>
       
       
+      <div class="slice-field slice-why">
+        <div class="slice-field-label">Why</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Public launch copy depends on reliable live observability. A collector that dies mid-session or a duplicate receiver path causing SQLite contention is a claim-breaking defect.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Files</div>
+        <div class="slice-field-value"><code>cmd/wipnote/otel_collect_handler.go, cmd/wipnote/otel_collect.go, cmd/wipnote/serve.go, cmd/wipnote/claude_env.go, cmd/wipnote/claude_env_test.go, internal/otel, internal/otel/receiver</code></div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Done when</div>
+        <ul class="slice-done-list"><li>`internal/otel/receiver` is deleted or proven unreachable and harmless.</li><li>No production code imports the old receiver package.</li><li>`ConvertAll` behavior is preserved for OTLP ingestion.</li><li>Collector startup failure is visible and does not silently disable capture.</li><li>Manual smoke shows exactly one session-scoped collector and clean shutdown.</li></ul>
+      </div>
+      
+    
+
+    
+
+    
+    <div class="slice-field slice-tests-field">
+      <div class="slice-field-label">Test Strategy</div>
+      <div class="slice-field-value">
+        
+        
+        <div class="markdown-block slice-tests"><p><code>go build ./...</code>, <code>go vet ./...</code>, <code>go test -timeout 180s ./...</code>, plus targeted OTel collector tests and a scratch-session manual smoke.</p>
+</div>
+        
+      </div>
+    </div>
     
 
     
 
     
 
-    
-
-    <div class="slice-deps">Dependencies: none</div>
+    <div class="slice-deps">Dependencies: slices 3</div>
 
     <details class="comment-collapse">
       <summary class="comment-collapse-trigger">+ Leave a comment</summary>
       <div class="comment-collapse-body">
-        <textarea data-section="slice-0" data-comment-for="slice-0" placeholder="Comments on slice 0..."></textarea>
+        <textarea data-section="slice-4" data-comment-for="slice-4" placeholder="Comments on slice 4..."></textarea>
       </div>
     </details>
   </div>
 </details>
-<details class="slice-card" id="slice-0" data-slice="0" data-slice-name="slice-005" data-status="pending" data-approval="pending">
-  <summary class="slice-summary" aria-label="Slice 0: BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)">
-    <span class="slice-num">#0</span>
+<details class="slice-card" id="slice-5" data-slice="5" data-slice-name="slice-005" data-status="pending" data-approval="pending">
+  <summary class="slice-summary" aria-label="Slice 5: BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)">
+    <span class="slice-num">#5</span>
     <span class="slice-title-col">
       <span class="slice-name">BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)</span>
-      
+      <span class="slice-preview">Implement the durable Gemini hook install path: wipnote gemini --init must write the required hooks into ~/.gemini/settings.json#hooks or th…</span>
       <span class="slice-meta-row">
         <span class="slice-summary-badges">
+          <span class="badge badge-revision badge-sm">M</span>
+          <span class="badge badge-blocked badge-sm">High</span>
           
           
-          
-          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-0">Pending</span>
+          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-5">Pending</span>
           
           
         </span>
         <span class="slice-actions" onclick="event.stopPropagation()">
           <span class="approval-segmented" role="group" aria-label="Approval action">
             <label class="seg-btn seg-approve" title="Approve">
-              <input type="radio" name="slice-0-approval" value="approved" data-section="slice-0" data-action="approve" aria-label="Approve slice 0">
+              <input type="radio" name="slice-5-approval" value="approved" data-section="slice-5" data-action="approve" aria-label="Approve slice 5">
               &#10003;
             </label>
             <label class="seg-btn seg-changes" title="Request changes">
-              <input type="radio" name="slice-0-approval" value="changes_requested" data-section="slice-0" data-action="approve" aria-label="Request changes for slice 0">
+              <input type="radio" name="slice-5-approval" value="changes_requested" data-section="slice-5" data-action="approve" aria-label="Request changes for slice 5">
               &#8635;
             </label>
             <label class="seg-btn seg-reject" title="Reject">
-              <input type="radio" name="slice-0-approval" value="rejected" data-section="slice-0" data-action="approve" aria-label="Reject slice 0">
+              <input type="radio" name="slice-5-approval" value="rejected" data-section="slice-5" data-action="approve" aria-label="Reject slice 5">
               &#10005;
             </label>
           </span>
@@ -848,54 +1035,99 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 
   <div class="slice-body">
     
-      <div class="slice-meta"><span>slice-005</span></div>
+      
+      <div class="slice-field slice-what">
+        <div class="slice-field-label">What</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Implement the durable Gemini hook install path: <code>wipnote gemini --init</code> must write the required hooks into <code>~/.gemini/settings.json#hooks</code> or the dev-isolated equivalent, because hooks bundled only under the extension directory are not loaded by Gemini CLI.</p>
+</div>
+          
+        </div>
+      </div>
       
       
+      <div class="slice-field slice-why">
+        <div class="slice-field-label">Why</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Gemini support is part of the cross-harness launch story. If Gemini hooks never fire, work tracking and observability claims are false for that harness.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Files</div>
+        <div class="slice-field-value"><code>cmd/wipnote/gemini.go, cmd/wipnote/gemini_launch.go, packages/gemini-extension, packages/plugin-core/manifest.json, plugin/hooks</code></div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Done when</div>
+        <ul class="slice-done-list"><li>`wipnote gemini --init` installs hooks into the Gemini settings location Gemini CLI actually reads.</li><li>Existing user hooks are preserved/merged rather than overwritten.</li><li>Dev/isolate mode writes to the intended isolated settings path.</li><li>A Gemini smoke run emits expected wipnote hook events.</li></ul>
+      </div>
+      
+    
+
+    
+
+    
+    <div class="slice-field slice-tests-field">
+      <div class="slice-field-label">Test Strategy</div>
+      <div class="slice-field-value">
+        
+        
+        <div class="markdown-block slice-tests"><p>Unit-test settings merge behavior, run generated-port rebuild if plugin source changes, then smoke Gemini hook execution in an isolated home/config dir.</p>
+</div>
+        
+      </div>
+    </div>
     
 
     
 
     
 
-    
-
-    <div class="slice-deps">Dependencies: none</div>
+    <div class="slice-deps">Dependencies: slices 3</div>
 
     <details class="comment-collapse">
       <summary class="comment-collapse-trigger">+ Leave a comment</summary>
       <div class="comment-collapse-body">
-        <textarea data-section="slice-0" data-comment-for="slice-0" placeholder="Comments on slice 0..."></textarea>
+        <textarea data-section="slice-5" data-comment-for="slice-5" placeholder="Comments on slice 5..."></textarea>
       </div>
     </details>
   </div>
 </details>
-<details class="slice-card" id="slice-0" data-slice="0" data-slice-name="slice-006" data-status="pending" data-approval="pending">
-  <summary class="slice-summary" aria-label="Slice 0: BLOCKER 6 — Fix claim-breaking bug: Yolo guard misfires (bug-c4e3551d)">
-    <span class="slice-num">#0</span>
+<details class="slice-card" id="slice-6" data-slice="6" data-slice-name="slice-006" data-status="pending" data-approval="pending">
+  <summary class="slice-summary" aria-label="Slice 6: BLOCKER 6 — Fix claim-breaking bug: Yolo guard misfires (bug-c4e3551d)">
+    <span class="slice-num">#6</span>
     <span class="slice-title-col">
       <span class="slice-name">BLOCKER 6 — Fix claim-breaking bug: Yolo guard misfires (bug-c4e3551d)</span>
-      
+      <span class="slice-preview">Fix the YOLO PreToolUse research-first guard so it does not block after real research has happened, and either make its source of truth resi…</span>
       <span class="slice-meta-row">
         <span class="slice-summary-badges">
+          <span class="badge badge-revision badge-sm">M</span>
+          <span class="badge badge-blocked badge-sm">High</span>
           
           
-          
-          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-0">Pending</span>
+          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-6">Pending</span>
           
           
         </span>
         <span class="slice-actions" onclick="event.stopPropagation()">
           <span class="approval-segmented" role="group" aria-label="Approval action">
             <label class="seg-btn seg-approve" title="Approve">
-              <input type="radio" name="slice-0-approval" value="approved" data-section="slice-0" data-action="approve" aria-label="Approve slice 0">
+              <input type="radio" name="slice-6-approval" value="approved" data-section="slice-6" data-action="approve" aria-label="Approve slice 6">
               &#10003;
             </label>
             <label class="seg-btn seg-changes" title="Request changes">
-              <input type="radio" name="slice-0-approval" value="changes_requested" data-section="slice-0" data-action="approve" aria-label="Request changes for slice 0">
+              <input type="radio" name="slice-6-approval" value="changes_requested" data-section="slice-6" data-action="approve" aria-label="Request changes for slice 6">
               &#8635;
             </label>
             <label class="seg-btn seg-reject" title="Reject">
-              <input type="radio" name="slice-0-approval" value="rejected" data-section="slice-0" data-action="approve" aria-label="Reject slice 0">
+              <input type="radio" name="slice-6-approval" value="rejected" data-section="slice-6" data-action="approve" aria-label="Reject slice 6">
               &#10005;
             </label>
           </span>
@@ -907,54 +1139,99 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 
   <div class="slice-body">
     
-      <div class="slice-meta"><span>slice-006</span></div>
+      
+      <div class="slice-field slice-what">
+        <div class="slice-field-label">What</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Fix the YOLO PreToolUse research-first guard so it does not block after real research has happened, and either make its source of truth resistant to direct SQLite row injection or explicitly downgrade it to advisory with visible warnings.</p>
+</div>
+          
+        </div>
+      </div>
       
       
+      <div class="slice-field slice-why">
+        <div class="slice-field-label">Why</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>A guard that both misfires and can be bypassed by inserting fake events is worse than no guard: it creates friction, encourages unsafe workarounds, and undermines launch claims about coordinated agent safety.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Files</div>
+        <div class="slice-field-value"><code>internal/hooks, internal/db, cmd/wipnote/yolo.go, plugin/hooks, packages/plugin-core/manifest.json</code></div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Done when</div>
+        <ul class="slice-done-list"><li>Integration test reproduces the yolo misfire and passes with the fix.</li><li>Guard counts reliable research signals across Read/Grep/Glob/Bash inspection flows.</li><li>Direct SQLite insertion no longer trivially satisfies the guard, or the guard clearly logs that it is advisory-only.</li><li>Failure-open and failure-closed behavior is documented in hook output/tests.</li></ul>
+      </div>
+      
+    
+
+    
+
+    
+    <div class="slice-field slice-tests-field">
+      <div class="slice-field-label">Test Strategy</div>
+      <div class="slice-field-value">
+        
+        
+        <div class="markdown-block slice-tests"><p>Add integration tests for the misfire and bypass scenarios, then run hook package tests and full Go quality gates.</p>
+</div>
+        
+      </div>
+    </div>
     
 
     
 
     
 
-    
-
-    <div class="slice-deps">Dependencies: none</div>
+    <div class="slice-deps">Dependencies: slices 3</div>
 
     <details class="comment-collapse">
       <summary class="comment-collapse-trigger">+ Leave a comment</summary>
       <div class="comment-collapse-body">
-        <textarea data-section="slice-0" data-comment-for="slice-0" placeholder="Comments on slice 0..."></textarea>
+        <textarea data-section="slice-6" data-comment-for="slice-6" placeholder="Comments on slice 6..."></textarea>
       </div>
     </details>
   </div>
 </details>
-<details class="slice-card" id="slice-0" data-slice="0" data-slice-name="slice-007" data-status="pending" data-approval="pending">
-  <summary class="slice-summary" aria-label="Slice 0: RELEASE — Fix gh-pages docs title (bug-3f5922c8)">
-    <span class="slice-num">#0</span>
+<details class="slice-card" id="slice-7" data-slice="7" data-slice-name="slice-007" data-status="pending" data-approval="pending">
+  <summary class="slice-summary" aria-label="Slice 7: RELEASE — Fix gh-pages docs title (bug-3f5922c8)">
+    <span class="slice-num">#7</span>
     <span class="slice-title-col">
       <span class="slice-name">RELEASE — Fix gh-pages docs title (bug-3f5922c8)</span>
-      
+      <span class="slice-preview">Fix the published documentation title and metadata so gh-pages no longer says &#34;HtmlGraph - erinn&#34; or other stale brand text.</span>
       <span class="slice-meta-row">
         <span class="slice-summary-badges">
+          <span class="badge badge-pending badge-sm">S</span>
+          <span class="badge badge-pending badge-sm">Low</span>
           
           
-          
-          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-0">Pending</span>
+          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-7">Pending</span>
           
           
         </span>
         <span class="slice-actions" onclick="event.stopPropagation()">
           <span class="approval-segmented" role="group" aria-label="Approval action">
             <label class="seg-btn seg-approve" title="Approve">
-              <input type="radio" name="slice-0-approval" value="approved" data-section="slice-0" data-action="approve" aria-label="Approve slice 0">
+              <input type="radio" name="slice-7-approval" value="approved" data-section="slice-7" data-action="approve" aria-label="Approve slice 7">
               &#10003;
             </label>
             <label class="seg-btn seg-changes" title="Request changes">
-              <input type="radio" name="slice-0-approval" value="changes_requested" data-section="slice-0" data-action="approve" aria-label="Request changes for slice 0">
+              <input type="radio" name="slice-7-approval" value="changes_requested" data-section="slice-7" data-action="approve" aria-label="Request changes for slice 7">
               &#8635;
             </label>
             <label class="seg-btn seg-reject" title="Reject">
-              <input type="radio" name="slice-0-approval" value="rejected" data-section="slice-0" data-action="approve" aria-label="Reject slice 0">
+              <input type="radio" name="slice-7-approval" value="rejected" data-section="slice-7" data-action="approve" aria-label="Reject slice 7">
               &#10005;
             </label>
           </span>
@@ -966,54 +1243,99 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 
   <div class="slice-body">
     
-      <div class="slice-meta"><span>slice-007</span></div>
+      
+      <div class="slice-field slice-what">
+        <div class="slice-field-label">What</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Fix the published documentation title and metadata so gh-pages no longer says &#34;HtmlGraph - erinn&#34; or other stale brand text.</p>
+</div>
+          
+        </div>
+      </div>
       
       
+      <div class="slice-field slice-why">
+        <div class="slice-field-label">Why</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Docs are a first-impression surface. A stale title immediately tells launch readers the rename/release was rushed.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Files</div>
+        <div class="slice-field-value"><code>mkdocs.yml, docs, README.md, packages/plugin-core/manifest.json</code></div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Done when</div>
+        <ul class="slice-done-list"><li>Site title, nav title, meta description, and docs landing page use wipnote.</li><li>Local docs build has no stale HtmlGraph/erinn title.</li><li>gh-pages publish input is ready for the release commit.</li></ul>
+      </div>
+      
+    
+
+    
+
+    
+    <div class="slice-field slice-tests-field">
+      <div class="slice-field-label">Test Strategy</div>
+      <div class="slice-field-value">
+        
+        
+        <div class="markdown-block slice-tests"><p>Run docs build if available, and search generated/site sources for <code>HtmlGraph</code>, <code>Erinn</code>, and <code>erinn</code> before release.</p>
+</div>
+        
+      </div>
+    </div>
     
 
     
 
     
 
-    
-
-    <div class="slice-deps">Dependencies: none</div>
+    <div class="slice-deps">Dependencies: slices 3</div>
 
     <details class="comment-collapse">
       <summary class="comment-collapse-trigger">+ Leave a comment</summary>
       <div class="comment-collapse-body">
-        <textarea data-section="slice-0" data-comment-for="slice-0" placeholder="Comments on slice 0..."></textarea>
+        <textarea data-section="slice-7" data-comment-for="slice-7" placeholder="Comments on slice 7..."></textarea>
       </div>
     </details>
   </div>
 </details>
-<details class="slice-card" id="slice-0" data-slice="0" data-slice-name="slice-008" data-status="pending" data-approval="pending">
-  <summary class="slice-summary" aria-label="Slice 0: RELEASE — Update Homebrew formula to current version (feat-c8bb337e)">
-    <span class="slice-num">#0</span>
+<details class="slice-card" id="slice-8" data-slice="8" data-slice-name="slice-008" data-status="pending" data-approval="pending">
+  <summary class="slice-summary" aria-label="Slice 8: RELEASE — Update Homebrew formula to current version (feat-c8bb337e)">
+    <span class="slice-num">#8</span>
     <span class="slice-title-col">
       <span class="slice-name">RELEASE — Update Homebrew formula to current version (feat-c8bb337e)</span>
-      
+      <span class="slice-preview">Update the Homebrew formula and release packaging so brew install exposes the wipnote binary and wn symlink at the intended launch version.</span>
       <span class="slice-meta-row">
         <span class="slice-summary-badges">
+          <span class="badge badge-pending badge-sm">S</span>
+          <span class="badge badge-revision badge-sm">Med</span>
           
           
-          
-          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-0">Pending</span>
+          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-8">Pending</span>
           
           
         </span>
         <span class="slice-actions" onclick="event.stopPropagation()">
           <span class="approval-segmented" role="group" aria-label="Approval action">
             <label class="seg-btn seg-approve" title="Approve">
-              <input type="radio" name="slice-0-approval" value="approved" data-section="slice-0" data-action="approve" aria-label="Approve slice 0">
+              <input type="radio" name="slice-8-approval" value="approved" data-section="slice-8" data-action="approve" aria-label="Approve slice 8">
               &#10003;
             </label>
             <label class="seg-btn seg-changes" title="Request changes">
-              <input type="radio" name="slice-0-approval" value="changes_requested" data-section="slice-0" data-action="approve" aria-label="Request changes for slice 0">
+              <input type="radio" name="slice-8-approval" value="changes_requested" data-section="slice-8" data-action="approve" aria-label="Request changes for slice 8">
               &#8635;
             </label>
             <label class="seg-btn seg-reject" title="Reject">
-              <input type="radio" name="slice-0-approval" value="rejected" data-section="slice-0" data-action="approve" aria-label="Reject slice 0">
+              <input type="radio" name="slice-8-approval" value="rejected" data-section="slice-8" data-action="approve" aria-label="Reject slice 8">
               &#10005;
             </label>
           </span>
@@ -1025,54 +1347,99 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 
   <div class="slice-body">
     
-      <div class="slice-meta"><span>slice-008</span></div>
+      
+      <div class="slice-field slice-what">
+        <div class="slice-field-label">What</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Update the Homebrew formula and release packaging so <code>brew install</code> exposes the <code>wipnote</code> binary and <code>wn</code> symlink at the intended launch version.</p>
+</div>
+          
+        </div>
+      </div>
       
       
+      <div class="slice-field slice-why">
+        <div class="slice-field-label">Why</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Homebrew is the default macOS install path for many launch readers. A stale formula or old binary name makes the launch post non-actionable.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Files</div>
+        <div class="slice-field-value"><code>packages/homebrew, .goreleaser.yml, install.sh, README.md, docs</code></div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Done when</div>
+        <ul class="slice-done-list"><li>Formula name, binary name, symlink, version, URL, and checksum match the release artifact plan.</li><li>Install docs show the current tap/formula command.</li><li>Formula does not reference htmlgraph or erinn except in intentional migration notes.</li><li>Local formula audit/test plan is documented for the release cut.</li></ul>
+      </div>
+      
+    
+
+    
+
+    
+    <div class="slice-field slice-tests-field">
+      <div class="slice-field-label">Test Strategy</div>
+      <div class="slice-field-value">
+        
+        
+        <div class="markdown-block slice-tests"><p>Run formula syntax/audit locally where available, inspect generated release archive names, and verify install docs match formula behavior.</p>
+</div>
+        
+      </div>
+    </div>
     
 
     
 
     
 
-    
-
-    <div class="slice-deps">Dependencies: none</div>
+    <div class="slice-deps">Dependencies: slices 1,2,3,7</div>
 
     <details class="comment-collapse">
       <summary class="comment-collapse-trigger">+ Leave a comment</summary>
       <div class="comment-collapse-body">
-        <textarea data-section="slice-0" data-comment-for="slice-0" placeholder="Comments on slice 0..."></textarea>
+        <textarea data-section="slice-8" data-comment-for="slice-8" placeholder="Comments on slice 8..."></textarea>
       </div>
     </details>
   </div>
 </details>
-<details class="slice-card" id="slice-0" data-slice="0" data-slice-name="slice-009" data-status="pending" data-approval="pending">
-  <summary class="slice-summary" aria-label="Slice 0: RELEASE — Tag v0.59.0, push origin/main, cut GitHub release (feat-c40942d3)">
-    <span class="slice-num">#0</span>
+<details class="slice-card" id="slice-9" data-slice="9" data-slice-name="slice-009" data-status="pending" data-approval="pending">
+  <summary class="slice-summary" aria-label="Slice 9: RELEASE — Tag v0.59.0, push origin/main, cut GitHub release (feat-c40942d3)">
+    <span class="slice-num">#9</span>
     <span class="slice-title-col">
       <span class="slice-name">RELEASE — Tag v0.59.0, push origin/main, cut GitHub release (feat-c40942d3)</span>
-      
+      <span class="slice-preview">Execute the release only after blockers are closed: final quality gates, version/tag verification, push to origin/main, create GitHub releas…</span>
       <span class="slice-meta-row">
         <span class="slice-summary-badges">
+          <span class="badge badge-revision badge-sm">M</span>
+          <span class="badge badge-blocked badge-sm">High</span>
           
           
-          
-          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-0">Pending</span>
+          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-9">Pending</span>
           
           
         </span>
         <span class="slice-actions" onclick="event.stopPropagation()">
           <span class="approval-segmented" role="group" aria-label="Approval action">
             <label class="seg-btn seg-approve" title="Approve">
-              <input type="radio" name="slice-0-approval" value="approved" data-section="slice-0" data-action="approve" aria-label="Approve slice 0">
+              <input type="radio" name="slice-9-approval" value="approved" data-section="slice-9" data-action="approve" aria-label="Approve slice 9">
               &#10003;
             </label>
             <label class="seg-btn seg-changes" title="Request changes">
-              <input type="radio" name="slice-0-approval" value="changes_requested" data-section="slice-0" data-action="approve" aria-label="Request changes for slice 0">
+              <input type="radio" name="slice-9-approval" value="changes_requested" data-section="slice-9" data-action="approve" aria-label="Request changes for slice 9">
               &#8635;
             </label>
             <label class="seg-btn seg-reject" title="Reject">
-              <input type="radio" name="slice-0-approval" value="rejected" data-section="slice-0" data-action="approve" aria-label="Reject slice 0">
+              <input type="radio" name="slice-9-approval" value="rejected" data-section="slice-9" data-action="approve" aria-label="Reject slice 9">
               &#10005;
             </label>
           </span>
@@ -1084,54 +1451,99 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 
   <div class="slice-body">
     
-      <div class="slice-meta"><span>slice-009</span></div>
+      
+      <div class="slice-field slice-what">
+        <div class="slice-field-label">What</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Execute the release only after blockers are closed: final quality gates, version/tag verification, push to origin/main, create GitHub release, and confirm generated packages/docs/Homebrew artifacts are correct.</p>
+</div>
+          
+        </div>
+      </div>
       
       
+      <div class="slice-field slice-why">
+        <div class="slice-field-label">Why</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>This is the irreversible launch gate. Tagging before blocker closure bakes broken install paths, stale docs, or claim-breaking bugs into the public release.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Files</div>
+        <div class="slice-field-value"><code>cmd/wipnote/main.go, packages/plugin-core/manifest.json, packages/homebrew, .goreleaser.yml, docs, CHANGELOG.md</code></div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Done when</div>
+        <ul class="slice-done-list"><li>All release blockers are done or explicitly waived in the plan.</li><li>Working tree contains only intentional release changes.</li><li>`go build`, `go vet`, and `go test` pass with repo-local temp/cache dirs.</li><li>Version references agree across CLI, plugin manifest, docs, Homebrew, and release notes.</li><li>GitHub release and docs publish are verified after tag.</li></ul>
+      </div>
+      
+    
+
+    
+
+    
+    <div class="slice-field slice-tests-field">
+      <div class="slice-field-label">Test Strategy</div>
+      <div class="slice-field-value">
+        
+        
+        <div class="markdown-block slice-tests"><p>Full Go quality gates, release dry-run if available, Homebrew formula check, docs build, and post-release install smoke.</p>
+</div>
+        
+      </div>
+    </div>
     
 
     
 
     
 
-    
-
-    <div class="slice-deps">Dependencies: none</div>
+    <div class="slice-deps">Dependencies: slices 1,2,3,4,5,6,7,8</div>
 
     <details class="comment-collapse">
       <summary class="comment-collapse-trigger">+ Leave a comment</summary>
       <div class="comment-collapse-body">
-        <textarea data-section="slice-0" data-comment-for="slice-0" placeholder="Comments on slice 0..."></textarea>
+        <textarea data-section="slice-9" data-comment-for="slice-9" placeholder="Comments on slice 9..."></textarea>
       </div>
     </details>
   </div>
 </details>
-<details class="slice-card" id="slice-0" data-slice="0" data-slice-name="slice-010" data-status="pending" data-approval="pending">
-  <summary class="slice-summary" aria-label="Slice 0: CONTENT — Record demo video (feat-4ae13f3c)">
-    <span class="slice-num">#0</span>
+<details class="slice-card" id="slice-10" data-slice="10" data-slice-name="slice-010" data-status="pending" data-approval="pending">
+  <summary class="slice-summary" aria-label="Slice 10: CONTENT — Record demo video (feat-4ae13f3c)">
+    <span class="slice-num">#10</span>
     <span class="slice-title-col">
       <span class="slice-name">CONTENT — Record demo video (feat-4ae13f3c)</span>
-      
+      <span class="slice-preview">Record a 3-4 minute technical demo showing the launch story: why agent coordination matters, the dashboard, plan/session/graph navigation, a…</span>
       <span class="slice-meta-row">
         <span class="slice-summary-badges">
+          <span class="badge badge-revision badge-sm">M</span>
+          <span class="badge badge-revision badge-sm">Med</span>
           
           
-          
-          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-0">Pending</span>
+          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-10">Pending</span>
           
           
         </span>
         <span class="slice-actions" onclick="event.stopPropagation()">
           <span class="approval-segmented" role="group" aria-label="Approval action">
             <label class="seg-btn seg-approve" title="Approve">
-              <input type="radio" name="slice-0-approval" value="approved" data-section="slice-0" data-action="approve" aria-label="Approve slice 0">
+              <input type="radio" name="slice-10-approval" value="approved" data-section="slice-10" data-action="approve" aria-label="Approve slice 10">
               &#10003;
             </label>
             <label class="seg-btn seg-changes" title="Request changes">
-              <input type="radio" name="slice-0-approval" value="changes_requested" data-section="slice-0" data-action="approve" aria-label="Request changes for slice 0">
+              <input type="radio" name="slice-10-approval" value="changes_requested" data-section="slice-10" data-action="approve" aria-label="Request changes for slice 10">
               &#8635;
             </label>
             <label class="seg-btn seg-reject" title="Reject">
-              <input type="radio" name="slice-0-approval" value="rejected" data-section="slice-0" data-action="approve" aria-label="Reject slice 0">
+              <input type="radio" name="slice-10-approval" value="rejected" data-section="slice-10" data-action="approve" aria-label="Reject slice 10">
               &#10005;
             </label>
           </span>
@@ -1143,54 +1555,105 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 
   <div class="slice-body">
     
-      <div class="slice-meta"><span>slice-010</span></div>
+      
+      <div class="slice-field slice-what">
+        <div class="slice-field-label">What</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Record a 3-4 minute technical demo showing the launch story: why agent coordination matters, the dashboard, plan/session/graph navigation, and real hook activity. Use current wipnote branding and release-ready install paths.</p>
+</div>
+          
+        </div>
+      </div>
       
       
+      <div class="slice-field slice-why">
+        <div class="slice-field-label">Why</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>The launch needs a concrete artifact that proves the product works and lets readers understand the value without installing first.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Files</div>
+        <div class="slice-field-value"><code>private/htmlgraph-blog/assets, docs, README.md</code></div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Done when</div>
+        <ul class="slice-done-list"><li>Demo script uses wipnote/wn naming only.</li><li>Recording shows a real project/session with dashboard and CLI graph navigation.</li><li>Video is reviewed once for audio, pacing, stale branding, and broken claims.</li><li>Final MP4 path/URL is ready for the blog and LinkedIn post.</li></ul>
+      </div>
+      
+    
+
+    
+
+    
+    <div class="slice-field slice-tests-field">
+      <div class="slice-field-label">Test Strategy</div>
+      <div class="slice-field-value">
+        
+        
+        <div class="test-strategy">
+          
+          <div class="test-group" data-kind="manual review checklist">
+            <span class="test-chip">MANUAL REVIEW CHECKLIST &middot; 1</span>
+            <ul><li>branding, install commands, dashboard accuracy, audio/video quality, and no secrets or private data visible.</li></ul>
+          </div>
+          
+        </div>
+        
+      </div>
+    </div>
     
 
     
 
     
 
-    
-
-    <div class="slice-deps">Dependencies: none</div>
+    <div class="slice-deps">Dependencies: slices 9</div>
 
     <details class="comment-collapse">
       <summary class="comment-collapse-trigger">+ Leave a comment</summary>
       <div class="comment-collapse-body">
-        <textarea data-section="slice-0" data-comment-for="slice-0" placeholder="Comments on slice 0..."></textarea>
+        <textarea data-section="slice-10" data-comment-for="slice-10" placeholder="Comments on slice 10..."></textarea>
       </div>
     </details>
   </div>
 </details>
-<details class="slice-card" id="slice-0" data-slice="0" data-slice-name="slice-011" data-status="pending" data-approval="pending">
-  <summary class="slice-summary" aria-label="Slice 0: CONTENT — Write blog post draft (feat-e505e51c)">
-    <span class="slice-num">#0</span>
+<details class="slice-card" id="slice-11" data-slice="11" data-slice-name="slice-011" data-status="pending" data-approval="pending">
+  <summary class="slice-summary" aria-label="Slice 11: CONTENT — Write blog post draft (feat-e505e51c)">
+    <span class="slice-num">#11</span>
     <span class="slice-title-col">
       <span class="slice-name">CONTENT — Write blog post draft (feat-e505e51c)</span>
-      
+      <span class="slice-preview">Write the launch blog post around the MVP-to-canonical-sessions arc, updated for final wipnote naming, current release version, install comm…</span>
       <span class="slice-meta-row">
         <span class="slice-summary-badges">
+          <span class="badge badge-revision badge-sm">M</span>
+          <span class="badge badge-revision badge-sm">Med</span>
           
           
-          
-          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-0">Pending</span>
+          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-11">Pending</span>
           
           
         </span>
         <span class="slice-actions" onclick="event.stopPropagation()">
           <span class="approval-segmented" role="group" aria-label="Approval action">
             <label class="seg-btn seg-approve" title="Approve">
-              <input type="radio" name="slice-0-approval" value="approved" data-section="slice-0" data-action="approve" aria-label="Approve slice 0">
+              <input type="radio" name="slice-11-approval" value="approved" data-section="slice-11" data-action="approve" aria-label="Approve slice 11">
               &#10003;
             </label>
             <label class="seg-btn seg-changes" title="Request changes">
-              <input type="radio" name="slice-0-approval" value="changes_requested" data-section="slice-0" data-action="approve" aria-label="Request changes for slice 0">
+              <input type="radio" name="slice-11-approval" value="changes_requested" data-section="slice-11" data-action="approve" aria-label="Request changes for slice 11">
               &#8635;
             </label>
             <label class="seg-btn seg-reject" title="Reject">
-              <input type="radio" name="slice-0-approval" value="rejected" data-section="slice-0" data-action="approve" aria-label="Reject slice 0">
+              <input type="radio" name="slice-11-approval" value="rejected" data-section="slice-11" data-action="approve" aria-label="Reject slice 11">
               &#10005;
             </label>
           </span>
@@ -1202,54 +1665,99 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 
   <div class="slice-body">
     
-      <div class="slice-meta"><span>slice-011</span></div>
+      
+      <div class="slice-field slice-what">
+        <div class="slice-field-label">What</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Write the launch blog post around the MVP-to-canonical-sessions arc, updated for final wipnote naming, current release version, install commands, and the repaired launch blockers.</p>
+</div>
+          
+        </div>
+      </div>
       
       
+      <div class="slice-field slice-why">
+        <div class="slice-field-label">Why</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>The blog post is the deep-link for HN and the substance behind the LinkedIn announcement. It must be accurate, technical, and aligned with the shipped product.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Files</div>
+        <div class="slice-field-value"><code>private/htmlgraph-blog/posts, private/htmlgraph-blog/assets, README.md, docs</code></div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Done when</div>
+        <ul class="slice-done-list"><li>Draft explains the problem, architecture arc, failure/recovery story, and current install path.</li><li>All product names, screenshots/video links, and version references are current.</li><li>Claims about Claude/Codex/Gemini support match verified behavior.</li><li>Draft has a final HN-friendly title and LinkedIn excerpt.</li></ul>
+      </div>
+      
+    
+
+    
+
+    
+    <div class="slice-field slice-tests-field">
+      <div class="slice-field-label">Test Strategy</div>
+      <div class="slice-field-value">
+        
+        
+        <div class="markdown-block slice-tests"><p>Editorial pass for stale branding, unsupported claims, broken links, and consistency with the release notes/demo video.</p>
+</div>
+        
+      </div>
+    </div>
     
 
     
 
     
 
-    
-
-    <div class="slice-deps">Dependencies: none</div>
+    <div class="slice-deps">Dependencies: slices 9,10</div>
 
     <details class="comment-collapse">
       <summary class="comment-collapse-trigger">+ Leave a comment</summary>
       <div class="comment-collapse-body">
-        <textarea data-section="slice-0" data-comment-for="slice-0" placeholder="Comments on slice 0..."></textarea>
+        <textarea data-section="slice-11" data-comment-for="slice-11" placeholder="Comments on slice 11..."></textarea>
       </div>
     </details>
   </div>
 </details>
-<details class="slice-card" id="slice-0" data-slice="0" data-slice-name="slice-012" data-status="pending" data-approval="pending">
-  <summary class="slice-summary" aria-label="Slice 0: LAUNCH — LinkedIn post &#43; HN submission (feat-ec81c370)">
-    <span class="slice-num">#0</span>
+<details class="slice-card" id="slice-12" data-slice="12" data-slice-name="slice-012" data-status="pending" data-approval="pending">
+  <summary class="slice-summary" aria-label="Slice 12: LAUNCH — LinkedIn post &#43; HN submission (feat-ec81c370)">
+    <span class="slice-num">#12</span>
     <span class="slice-title-col">
       <span class="slice-name">LAUNCH — LinkedIn post &#43; HN submission (feat-ec81c370)</span>
-      
+      <span class="slice-preview">Publish the launch: LinkedIn post with native video and HN submission pointing at the blog post.</span>
       <span class="slice-meta-row">
         <span class="slice-summary-badges">
+          <span class="badge badge-pending badge-sm">S</span>
+          <span class="badge badge-revision badge-sm">Med</span>
           
           
-          
-          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-0">Pending</span>
+          <span class="badge badge-pending badge-sm slice-approval-badge" data-badge-for="slice-12">Pending</span>
           
           
         </span>
         <span class="slice-actions" onclick="event.stopPropagation()">
           <span class="approval-segmented" role="group" aria-label="Approval action">
             <label class="seg-btn seg-approve" title="Approve">
-              <input type="radio" name="slice-0-approval" value="approved" data-section="slice-0" data-action="approve" aria-label="Approve slice 0">
+              <input type="radio" name="slice-12-approval" value="approved" data-section="slice-12" data-action="approve" aria-label="Approve slice 12">
               &#10003;
             </label>
             <label class="seg-btn seg-changes" title="Request changes">
-              <input type="radio" name="slice-0-approval" value="changes_requested" data-section="slice-0" data-action="approve" aria-label="Request changes for slice 0">
+              <input type="radio" name="slice-12-approval" value="changes_requested" data-section="slice-12" data-action="approve" aria-label="Request changes for slice 12">
               &#8635;
             </label>
             <label class="seg-btn seg-reject" title="Reject">
-              <input type="radio" name="slice-0-approval" value="rejected" data-section="slice-0" data-action="approve" aria-label="Reject slice 0">
+              <input type="radio" name="slice-12-approval" value="rejected" data-section="slice-12" data-action="approve" aria-label="Reject slice 12">
               &#10005;
             </label>
           </span>
@@ -1261,23 +1769,67 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 
   <div class="slice-body">
     
-      <div class="slice-meta"><span>slice-012</span></div>
+      
+      <div class="slice-field slice-what">
+        <div class="slice-field-label">What</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>Publish the launch: LinkedIn post with native video and HN submission pointing at the blog post. Keep the copy plain, technical, and grounded in the shipped release.</p>
+</div>
+          
+        </div>
+      </div>
       
       
+      <div class="slice-field slice-why">
+        <div class="slice-field-label">Why</div>
+        <div class="slice-field-value">
+          
+          <div class="markdown-block serif-prose"><p>This is the public announcement moment. It should happen only after the product, install path, docs, demo, and blog are all credible.</p>
+</div>
+          
+        </div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Files</div>
+        <div class="slice-field-value"><code>private/htmlgraph-blog/posts, private/htmlgraph-blog/assets, docs, README.md</code></div>
+      </div>
+      
+      
+      <div class="slice-field">
+        <div class="slice-field-label">Done when</div>
+        <ul class="slice-done-list"><li>Blog post is live and reachable.</li><li>Demo video is uploaded and linked from the post or LinkedIn copy.</li><li>LinkedIn post is published with current wipnote positioning.</li><li>HN submission uses a plain technical title and links to the blog post.</li><li>First 30-60 minutes of comments/questions are monitored for install/doc issues.</li></ul>
+      </div>
+      
+    
+
+    
+
+    
+    <div class="slice-field slice-tests-field">
+      <div class="slice-field-label">Test Strategy</div>
+      <div class="slice-field-value">
+        
+        
+        <div class="markdown-block slice-tests"><p>Preflight all public links in an incognito browser, run one fresh install smoke, and keep release/docs rollback notes nearby during the launch window.</p>
+</div>
+        
+      </div>
+    </div>
     
 
     
 
     
 
-    
-
-    <div class="slice-deps">Dependencies: none</div>
+    <div class="slice-deps">Dependencies: slices 9,10,11</div>
 
     <details class="comment-collapse">
       <summary class="comment-collapse-trigger">+ Leave a comment</summary>
       <div class="comment-collapse-body">
-        <textarea data-section="slice-0" data-comment-for="slice-0" placeholder="Comments on slice 0..."></textarea>
+        <textarea data-section="slice-12" data-comment-for="slice-12" placeholder="Comments on slice 12..."></textarea>
       </div>
     </details>
   </div>
@@ -1390,7 +1942,7 @@ var planId=(function(){var a=document.querySelector('article[id]');return a?a.id
 
 (function(){
   'use strict';
-  var SECTIONS=/*PLAN_SECTIONS_JSON*/["design","slice-0","slice-0","slice-0","slice-0","slice-0","slice-0","slice-0","slice-0","slice-0","slice-0","slice-0","slice-0"]/*END_PLAN_SECTIONS_JSON*/;
+  var SECTIONS=/*PLAN_SECTIONS_JSON*/["design","slice-1","slice-2","slice-3","slice-4","slice-5","slice-6","slice-7","slice-8","slice-9","slice-10","slice-11","slice-12"]/*END_PLAN_SECTIONS_JSON*/;
 
   function setBadge(el,ok){
     el.className='badge badge-'+(ok?'approved':'pending');

--- a/.wipnote/plans/plan-cf1a6ae4.html
+++ b/.wipnote/plans/plan-cf1a6ae4.html
@@ -492,15 +492,15 @@ body.right-rail-collapsed .sidebar-reopen{display:flex}
 </nav>
 <div class="plan-layout">
 <div class="plan-content">
-<article id="plan-cf1a6ae4" data-type="plan" data-plan-id="plan-cf1a6ae4" data-feature-id="" data-status="todo" data-priority="high">
+<article id="plan-cf1a6ae4" data-type="plan" data-plan-id="plan-cf1a6ae4" data-feature-id="trk-d78fd431" data-status="finalized" data-priority="high">
 
 <!-- Plan Header -->
 <header class="plan-header">
   <h1>Plan: Launch readiness — wipnote public launch blockers</h1>
   <p style="color:var(--text-dim)">Ordered critical path to LinkedIn + HN launch. Audit performed 2026-05-07. Estimated 3–4 days of focused work.</p>
   <div class="meta">
-    <span class="badge badge-pending">Draft</span>
-    <span style="font-size:.75rem;color:var(--text-muted)">v8 · 12 slices · Created 2026-05-07</span>
+    <span class="badge badge-approved">Done</span>
+    <span style="font-size:.75rem;color:var(--text-muted)">v9 · 12 slices · Created 2026-05-07</span>
   </div>
 </header>
 <button id="themeToggle" style="position:fixed;top:16px;right:16px;z-index:100;background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:6px 12px;color:var(--text);font-family:var(--mono);font-size:0.75rem;cursor:pointer;">

--- a/.wipnote/plans/plan-cf1a6ae4.yaml
+++ b/.wipnote/plans/plan-cf1a6ae4.yaml
@@ -3,9 +3,9 @@ meta:
     title: Launch readiness — wipnote public launch blockers
     description: Ordered critical path to LinkedIn + HN launch. Audit performed 2026-05-07. Estimated 3–4 days of focused work.
     created_at: "2026-05-07"
-    status: active
+    status: todo
     priority: high
-    version: 6
+    version: 8
 design:
     problem: 'Audit on 2026-05-07 found 4 blocker categories before public launch: missing LICENSE, incomplete rename artifacts, claim-breaking bugs (OTel, Gemini hooks, Yolo guard), stale docs/release, and missing content.'
     goals:
@@ -22,14 +22,8 @@ slices:
     - id: slice-001
       num: 1
       title: BLOCKER 1 — Add root LICENSE file (MIT)
-      what: >-
-        Add a root MIT LICENSE file using the canonical MIT text and the project
-        copyright holder/year used for public release. Confirm packaging and docs
-        point users at this license.
-      why: >-
-        A public open-source launch without a license creates legal ambiguity for
-        contributors, users, Homebrew packaging, and HN/LinkedIn readers who want
-        to inspect or reuse the code.
+      what: Add a root MIT LICENSE file using the canonical MIT text and the project copyright holder/year used for public release. Confirm packaging and docs point users at this license.
+      why: A public open-source launch without a license creates legal ambiguity for contributors, users, Homebrew packaging, and HN/LinkedIn readers who want to inspect or reuse the code.
       files:
         - LICENSE
         - README.md
@@ -41,21 +35,14 @@ slices:
         - No duplicate or conflicting license file remains under generated plugin ports.
       effort: S
       risk: Low
-      tests: >-
-        Manual verification: inspect LICENSE and search for stale license references
-        with `rg -n "license|MIT|HtmlGraph|erinn" README.md docs plugin packages`.
+      tests: 'Manual verification: inspect LICENSE and search for stale license references with `rg -n "license|MIT|HtmlGraph|erinn" README.md docs plugin packages`.'
       approved: false
       comment: ""
     - id: slice-002
       num: 2
       title: BLOCKER 2 — Fix wipnote-aliases.sh (hg- to wn-)
-      what: >-
-        Update the shell aliases helper so public aliases use `wn`/`wipnote`
-        names, not legacy `hg`/`htmlgraph` names. Include the canonical `wn`
-        shortcut expected from install paths.
-      why: >-
-        The alias file is a first-run affordance. Stale prefixes create immediate
-        brand confusion and make install docs look unreliable.
+      what: Update the shell aliases helper so public aliases use `wn`/`wipnote` names, not legacy `hg`/`htmlgraph` names. Include the canonical `wn` shortcut expected from install paths.
+      why: The alias file is a first-run affordance. Stale prefixes create immediate brand confusion and make install docs look unreliable.
       files:
         - wipnote-aliases.sh
         - install.sh
@@ -64,27 +51,19 @@ slices:
       deps:
         - 3
       done_when:
-        - "`wipnote-aliases.sh` defines `wn` aliases and no user-facing `hg-` aliases."
+        - '`wipnote-aliases.sh` defines `wn` aliases and no user-facing `hg-` aliases.'
         - Install/docs examples use `wipnote` or `wn`.
         - A shell syntax check passes for the alias file.
       effort: S
       risk: Low
-      tests: >-
-        Run `zsh -n wipnote-aliases.sh` and `rg -n "hg-|htmlgraph|erinn"
-        wipnote-aliases.sh install.sh README.md docs`.
+      tests: Run `zsh -n wipnote-aliases.sh` and `rg -n "hg-|htmlgraph|erinn" wipnote-aliases.sh install.sh README.md docs`.
       approved: false
       comment: ""
     - id: slice-003
       num: 3
       title: BLOCKER 3 — Complete rename (feat-913bf7a6 + feat-b02a559b)
-      what: >-
-        Verify the completed htmlgraph→erinn and erinn→wipnote rename work across
-        source, docs, release packaging, plugin manifests, generated ports, cache
-        paths, env vars, and command examples. Close any remaining public-facing
-        rename artifacts before release.
-      why: >-
-        The rename features are marked done, but launch-readiness depends on the
-        observable product surface being consistently `wipnote`/`wn`.
+      what: Verify the completed htmlgraph→erinn and erinn→wipnote rename work across source, docs, release packaging, plugin manifests, generated ports, cache paths, env vars, and command examples. Close any remaining public-facing rename artifacts before release.
+      why: The rename features are marked done, but launch-readiness depends on the observable product surface being consistently `wipnote`/`wn`.
       files:
         - go.mod
         - cmd/wipnote
@@ -100,28 +79,20 @@ slices:
         - README.md
       deps: []
       done_when:
-        - "`feat-913bf7a6` and `feat-b02a559b` remain done and have no reopen-worthy rename gaps."
+        - '`feat-913bf7a6` and `feat-b02a559b` remain done and have no reopen-worthy rename gaps.'
         - Public docs, install scripts, Homebrew formula, GoReleaser config, and plugin manifests use wipnote naming.
         - Intentional historical references, if any, are clearly historical and not product instructions.
         - Generated Codex/Gemini ports are rebuilt after any plugin source-of-truth changes.
       effort: M
       risk: Med
-      tests: >-
-        Run targeted stale-name searches, then `wipnote plugin build-ports` if
-        plugin assets changed. Finish with Go quality gates before release.
+      tests: Run targeted stale-name searches, then `wipnote plugin build-ports` if plugin assets changed. Finish with Go quality gates before release.
       approved: false
       comment: ""
     - id: slice-004
       num: 4
       title: 'BLOCKER 4 — Fix claim-breaking bug: OTel collector dies mid-session (bug-28a9d7a7)'
-      what: >-
-        Finish `bug-28a9d7a7`: remove the orphaned server-based OTel receiver path,
-        preserve `ConvertAll` behavior for the session-scoped collector, and update
-        stale comments/warnings that still describe the old embedded receiver.
-      why: >-
-        Public launch copy depends on reliable live observability. A collector that
-        dies mid-session or a duplicate receiver path causing SQLite contention is a
-        claim-breaking defect.
+      what: 'Finish `bug-28a9d7a7`: remove the orphaned server-based OTel receiver path, preserve `ConvertAll` behavior for the session-scoped collector, and update stale comments/warnings that still describe the old embedded receiver.'
+      why: Public launch copy depends on reliable live observability. A collector that dies mid-session or a duplicate receiver path causing SQLite contention is a claim-breaking defect.
       files:
         - cmd/wipnote/otel_collect_handler.go
         - cmd/wipnote/otel_collect.go
@@ -133,29 +104,21 @@ slices:
       deps:
         - 3
       done_when:
-        - "`internal/otel/receiver` is deleted or proven unreachable and harmless."
+        - '`internal/otel/receiver` is deleted or proven unreachable and harmless.'
         - No production code imports the old receiver package.
-        - "`ConvertAll` behavior is preserved for OTLP ingestion."
+        - '`ConvertAll` behavior is preserved for OTLP ingestion.'
         - Collector startup failure is visible and does not silently disable capture.
         - Manual smoke shows exactly one session-scoped collector and clean shutdown.
       effort: M
       risk: High
-      tests: >-
-        `go build ./...`, `go vet ./...`, `go test -timeout 180s ./...`, plus
-        targeted OTel collector tests and a scratch-session manual smoke.
+      tests: '`go build ./...`, `go vet ./...`, `go test -timeout 180s ./...`, plus targeted OTel collector tests and a scratch-session manual smoke.'
       approved: false
       comment: ""
     - id: slice-005
       num: 5
       title: 'BLOCKER 5 — Fix claim-breaking bug: Gemini hooks never fire (bug-4a3a27ee)'
-      what: >-
-        Implement the durable Gemini hook install path: `wipnote gemini --init`
-        must write the required hooks into `~/.gemini/settings.json#hooks` or the
-        dev-isolated equivalent, because hooks bundled only under the extension
-        directory are not loaded by Gemini CLI.
-      why: >-
-        Gemini support is part of the cross-harness launch story. If Gemini hooks
-        never fire, work tracking and observability claims are false for that harness.
+      what: 'Implement the durable Gemini hook install path: `wipnote gemini --init` must write the required hooks into `~/.gemini/settings.json#hooks` or the dev-isolated equivalent, because hooks bundled only under the extension directory are not loaded by Gemini CLI.'
+      why: Gemini support is part of the cross-harness launch story. If Gemini hooks never fire, work tracking and observability claims are false for that harness.
       files:
         - cmd/wipnote/gemini.go
         - cmd/wipnote/gemini_launch.go
@@ -165,29 +128,20 @@ slices:
       deps:
         - 3
       done_when:
-        - "`wipnote gemini --init` installs hooks into the Gemini settings location Gemini CLI actually reads."
+        - '`wipnote gemini --init` installs hooks into the Gemini settings location Gemini CLI actually reads.'
         - Existing user hooks are preserved/merged rather than overwritten.
         - Dev/isolate mode writes to the intended isolated settings path.
         - A Gemini smoke run emits expected wipnote hook events.
       effort: M
       risk: High
-      tests: >-
-        Unit-test settings merge behavior, run generated-port rebuild if plugin
-        source changes, then smoke Gemini hook execution in an isolated home/config dir.
+      tests: Unit-test settings merge behavior, run generated-port rebuild if plugin source changes, then smoke Gemini hook execution in an isolated home/config dir.
       approved: false
       comment: ""
     - id: slice-006
       num: 6
       title: 'BLOCKER 6 — Fix claim-breaking bug: Yolo guard misfires (bug-c4e3551d)'
-      what: >-
-        Fix the YOLO PreToolUse research-first guard so it does not block after
-        real research has happened, and either make its source of truth resistant
-        to direct SQLite row injection or explicitly downgrade it to advisory with
-        visible warnings.
-      why: >-
-        A guard that both misfires and can be bypassed by inserting fake events is
-        worse than no guard: it creates friction, encourages unsafe workarounds, and
-        undermines launch claims about coordinated agent safety.
+      what: Fix the YOLO PreToolUse research-first guard so it does not block after real research has happened, and either make its source of truth resistant to direct SQLite row injection or explicitly downgrade it to advisory with visible warnings.
+      why: 'A guard that both misfires and can be bypassed by inserting fake events is worse than no guard: it creates friction, encourages unsafe workarounds, and undermines launch claims about coordinated agent safety.'
       files:
         - internal/hooks
         - internal/db
@@ -203,20 +157,14 @@ slices:
         - Failure-open and failure-closed behavior is documented in hook output/tests.
       effort: M
       risk: High
-      tests: >-
-        Add integration tests for the misfire and bypass scenarios, then run hook
-        package tests and full Go quality gates.
+      tests: Add integration tests for the misfire and bypass scenarios, then run hook package tests and full Go quality gates.
       approved: false
       comment: ""
     - id: slice-007
       num: 7
       title: RELEASE — Fix gh-pages docs title (bug-3f5922c8)
-      what: >-
-        Fix the published documentation title and metadata so gh-pages no longer
-        says "HtmlGraph - erinn" or other stale brand text.
-      why: >-
-        Docs are a first-impression surface. A stale title immediately tells launch
-        readers the rename/release was rushed.
+      what: Fix the published documentation title and metadata so gh-pages no longer says "HtmlGraph - erinn" or other stale brand text.
+      why: Docs are a first-impression surface. A stale title immediately tells launch readers the rename/release was rushed.
       files:
         - mkdocs.yml
         - docs
@@ -230,20 +178,14 @@ slices:
         - gh-pages publish input is ready for the release commit.
       effort: S
       risk: Low
-      tests: >-
-        Run docs build if available, and search generated/site sources for
-        `HtmlGraph`, `Erinn`, and `erinn` before release.
+      tests: Run docs build if available, and search generated/site sources for `HtmlGraph`, `Erinn`, and `erinn` before release.
       approved: false
       comment: ""
     - id: slice-008
       num: 8
       title: RELEASE — Update Homebrew formula to current version (feat-c8bb337e)
-      what: >-
-        Update the Homebrew formula and release packaging so `brew install` exposes
-        the `wipnote` binary and `wn` symlink at the intended launch version.
-      why: >-
-        Homebrew is the default macOS install path for many launch readers. A stale
-        formula or old binary name makes the launch post non-actionable.
+      what: Update the Homebrew formula and release packaging so `brew install` exposes the `wipnote` binary and `wn` symlink at the intended launch version.
+      why: Homebrew is the default macOS install path for many launch readers. A stale formula or old binary name makes the launch post non-actionable.
       files:
         - packages/homebrew
         - .goreleaser.yml
@@ -262,21 +204,14 @@ slices:
         - Local formula audit/test plan is documented for the release cut.
       effort: S
       risk: Med
-      tests: >-
-        Run formula syntax/audit locally where available, inspect generated release
-        archive names, and verify install docs match formula behavior.
+      tests: Run formula syntax/audit locally where available, inspect generated release archive names, and verify install docs match formula behavior.
       approved: false
       comment: ""
     - id: slice-009
       num: 9
       title: RELEASE — Tag v0.59.0, push origin/main, cut GitHub release (feat-c40942d3)
-      what: >-
-        Execute the release only after blockers are closed: final quality gates,
-        version/tag verification, push to origin/main, create GitHub release, and
-        confirm generated packages/docs/Homebrew artifacts are correct.
-      why: >-
-        This is the irreversible launch gate. Tagging before blocker closure bakes
-        broken install paths, stale docs, or claim-breaking bugs into the public release.
+      what: 'Execute the release only after blockers are closed: final quality gates, version/tag verification, push to origin/main, create GitHub release, and confirm generated packages/docs/Homebrew artifacts are correct.'
+      why: This is the irreversible launch gate. Tagging before blocker closure bakes broken install paths, stale docs, or claim-breaking bugs into the public release.
       files:
         - cmd/wipnote/main.go
         - packages/plugin-core/manifest.json
@@ -296,26 +231,19 @@ slices:
       done_when:
         - All release blockers are done or explicitly waived in the plan.
         - Working tree contains only intentional release changes.
-        - "`go build`, `go vet`, and `go test` pass with repo-local temp/cache dirs."
+        - '`go build`, `go vet`, and `go test` pass with repo-local temp/cache dirs.'
         - Version references agree across CLI, plugin manifest, docs, Homebrew, and release notes.
         - GitHub release and docs publish are verified after tag.
       effort: M
       risk: High
-      tests: >-
-        Full Go quality gates, release dry-run if available, Homebrew formula check,
-        docs build, and post-release install smoke.
+      tests: Full Go quality gates, release dry-run if available, Homebrew formula check, docs build, and post-release install smoke.
       approved: false
       comment: ""
     - id: slice-010
       num: 10
       title: CONTENT — Record demo video (feat-4ae13f3c)
-      what: >-
-        Record a 3-4 minute technical demo showing the launch story: why agent
-        coordination matters, the dashboard, plan/session/graph navigation, and
-        real hook activity. Use current wipnote branding and release-ready install paths.
-      why: >-
-        The launch needs a concrete artifact that proves the product works and lets
-        readers understand the value without installing first.
+      what: 'Record a 3-4 minute technical demo showing the launch story: why agent coordination matters, the dashboard, plan/session/graph navigation, and real hook activity. Use current wipnote branding and release-ready install paths.'
+      why: The launch needs a concrete artifact that proves the product works and lets readers understand the value without installing first.
       files:
         - private/htmlgraph-blog/assets
         - docs
@@ -329,21 +257,14 @@ slices:
         - Final MP4 path/URL is ready for the blog and LinkedIn post.
       effort: M
       risk: Med
-      tests: >-
-        Manual review checklist: branding, install commands, dashboard accuracy,
-        audio/video quality, and no secrets or private data visible.
+      tests: 'Manual review checklist: branding, install commands, dashboard accuracy, audio/video quality, and no secrets or private data visible.'
       approved: false
       comment: ""
     - id: slice-011
       num: 11
       title: CONTENT — Write blog post draft (feat-e505e51c)
-      what: >-
-        Write the launch blog post around the MVP-to-canonical-sessions arc,
-        updated for final wipnote naming, current release version, install commands,
-        and the repaired launch blockers.
-      why: >-
-        The blog post is the deep-link for HN and the substance behind the LinkedIn
-        announcement. It must be accurate, technical, and aligned with the shipped product.
+      what: Write the launch blog post around the MVP-to-canonical-sessions arc, updated for final wipnote naming, current release version, install commands, and the repaired launch blockers.
+      why: The blog post is the deep-link for HN and the substance behind the LinkedIn announcement. It must be accurate, technical, and aligned with the shipped product.
       files:
         - private/htmlgraph-blog/posts
         - private/htmlgraph-blog/assets
@@ -359,21 +280,14 @@ slices:
         - Draft has a final HN-friendly title and LinkedIn excerpt.
       effort: M
       risk: Med
-      tests: >-
-        Editorial pass for stale branding, unsupported claims, broken links, and
-        consistency with the release notes/demo video.
+      tests: Editorial pass for stale branding, unsupported claims, broken links, and consistency with the release notes/demo video.
       approved: false
       comment: ""
     - id: slice-012
       num: 12
       title: LAUNCH — LinkedIn post + HN submission (feat-ec81c370)
-      what: >-
-        Publish the launch: LinkedIn post with native video and HN submission
-        pointing at the blog post. Keep the copy plain, technical, and grounded in
-        the shipped release.
-      why: >-
-        This is the public announcement moment. It should happen only after the
-        product, install path, docs, demo, and blog are all credible.
+      what: 'Publish the launch: LinkedIn post with native video and HN submission pointing at the blog post. Keep the copy plain, technical, and grounded in the shipped release.'
+      why: This is the public announcement moment. It should happen only after the product, install path, docs, demo, and blog are all credible.
       files:
         - private/htmlgraph-blog/posts
         - private/htmlgraph-blog/assets
@@ -391,9 +305,7 @@ slices:
         - First 30-60 minutes of comments/questions are monitored for install/doc issues.
       effort: S
       risk: Med
-      tests: >-
-        Preflight all public links in an incognito browser, run one fresh install
-        smoke, and keep release/docs rollback notes nearby during the launch window.
+      tests: Preflight all public links in an incognito browser, run one fresh install smoke, and keep release/docs rollback notes nearby during the launch window.
       approved: false
       comment: ""
 questions: []

--- a/.wipnote/plans/plan-cf1a6ae4.yaml
+++ b/.wipnote/plans/plan-cf1a6ae4.yaml
@@ -1,11 +1,12 @@
 meta:
     id: plan-cf1a6ae4
+    track_id: trk-d78fd431
     title: Launch readiness — wipnote public launch blockers
     description: Ordered critical path to LinkedIn + HN launch. Audit performed 2026-05-07. Estimated 3–4 days of focused work.
     created_at: "2026-05-07"
-    status: todo
+    status: finalized
     priority: high
-    version: 8
+    version: 9
 design:
     problem: 'Audit on 2026-05-07 found 4 blocker categories before public launch: missing LICENSE, incomplete rename artifacts, claim-breaking bugs (OTel, Gemini hooks, Yolo guard), stale docs/release, and missing content.'
     goals:
@@ -36,7 +37,7 @@ slices:
       effort: S
       risk: Low
       tests: 'Manual verification: inspect LICENSE and search for stale license references with `rg -n "license|MIT|HtmlGraph|erinn" README.md docs plugin packages`.'
-      approved: false
+      approved: true
       comment: ""
     - id: slice-002
       num: 2
@@ -57,7 +58,7 @@ slices:
       effort: S
       risk: Low
       tests: Run `zsh -n wipnote-aliases.sh` and `rg -n "hg-|htmlgraph|erinn" wipnote-aliases.sh install.sh README.md docs`.
-      approved: false
+      approved: true
       comment: ""
     - id: slice-003
       num: 3
@@ -86,7 +87,7 @@ slices:
       effort: M
       risk: Med
       tests: Run targeted stale-name searches, then `wipnote plugin build-ports` if plugin assets changed. Finish with Go quality gates before release.
-      approved: false
+      approved: true
       comment: ""
     - id: slice-004
       num: 4
@@ -112,7 +113,7 @@ slices:
       effort: M
       risk: High
       tests: '`go build ./...`, `go vet ./...`, `go test -timeout 180s ./...`, plus targeted OTel collector tests and a scratch-session manual smoke.'
-      approved: false
+      approved: true
       comment: ""
     - id: slice-005
       num: 5
@@ -135,7 +136,7 @@ slices:
       effort: M
       risk: High
       tests: Unit-test settings merge behavior, run generated-port rebuild if plugin source changes, then smoke Gemini hook execution in an isolated home/config dir.
-      approved: false
+      approved: true
       comment: ""
     - id: slice-006
       num: 6
@@ -158,7 +159,7 @@ slices:
       effort: M
       risk: High
       tests: Add integration tests for the misfire and bypass scenarios, then run hook package tests and full Go quality gates.
-      approved: false
+      approved: true
       comment: ""
     - id: slice-007
       num: 7
@@ -179,7 +180,7 @@ slices:
       effort: S
       risk: Low
       tests: Run docs build if available, and search generated/site sources for `HtmlGraph`, `Erinn`, and `erinn` before release.
-      approved: false
+      approved: true
       comment: ""
     - id: slice-008
       num: 8
@@ -205,7 +206,7 @@ slices:
       effort: S
       risk: Med
       tests: Run formula syntax/audit locally where available, inspect generated release archive names, and verify install docs match formula behavior.
-      approved: false
+      approved: true
       comment: ""
     - id: slice-009
       num: 9
@@ -237,7 +238,7 @@ slices:
       effort: M
       risk: High
       tests: Full Go quality gates, release dry-run if available, Homebrew formula check, docs build, and post-release install smoke.
-      approved: false
+      approved: true
       comment: ""
     - id: slice-010
       num: 10
@@ -258,7 +259,7 @@ slices:
       effort: M
       risk: Med
       tests: 'Manual review checklist: branding, install commands, dashboard accuracy, audio/video quality, and no secrets or private data visible.'
-      approved: false
+      approved: true
       comment: ""
     - id: slice-011
       num: 11
@@ -281,7 +282,7 @@ slices:
       effort: M
       risk: Med
       tests: Editorial pass for stale branding, unsupported claims, broken links, and consistency with the release notes/demo video.
-      approved: false
+      approved: true
       comment: ""
     - id: slice-012
       num: 12
@@ -306,6 +307,6 @@ slices:
       effort: S
       risk: Med
       tests: Preflight all public links in an incognito browser, run one fresh install smoke, and keep release/docs rollback notes nearby during the launch window.
-      approved: false
+      approved: true
       comment: ""
 questions: []

--- a/internal/hooks/gemini_model.go
+++ b/internal/hooks/gemini_model.go
@@ -79,6 +79,17 @@ func AfterModel(event *CloudEvent, database *sql.DB) (*HookResult, error) {
 		insertAssistantTextSignalFromHookPayload(database, projectDir, sessionID, event, responseText, "after_model")
 	}
 
+	// Skip intermediate streaming chunks. Per geminicli.com docs, AfterModel
+	// fires "for every chunk" — only the final chunk carries finishReason and
+	// usageMetadata.totalTokenCount. Recording every chunk produces ~65% noise
+	// in agent_events (bug-55a17fc2). The durable fix is to migrate hooks.json
+	// from AfterModel to AfterAgent (the docs-canonical turn-level hook) once
+	// gemini-cli issue #15468 (AfterAgent premature-fire) is confirmed fixed
+	// in shipped versions; until then this guard keeps the timeline clean.
+	if finishReason == "" && totalTokens == 0 {
+		return &HookResult{Continue: true}, nil
+	}
+
 	// Record a lightweight agent_event so model+token info appears in the timeline.
 	summary := buildAfterModelSummary(model, totalTokens, finishReason)
 	return recordSimpleEvent(models.EventCheckPoint, "AfterModel", summary, "recorded", event, database)

--- a/internal/hooks/gemini_model_test.go
+++ b/internal/hooks/gemini_model_test.go
@@ -1,0 +1,65 @@
+package hooks
+
+import (
+	"testing"
+)
+
+// TestAfterModel_SkipsIntermediateStreamingChunks verifies the guard at
+// gemini_model.go:82: AfterModel hooks that lack finishReason AND totalTokens
+// are intermediate streaming chunks (per geminicli.com docs) and must not
+// produce agent_events rows. Only the final chunk (carrying finishReason+
+// usageMetadata.totalTokenCount) is recorded. bug-55a17fc2.
+func TestAfterModel_SkipsIntermediateStreamingChunks(t *testing.T) {
+	td := setupTestDB(t)
+
+	// Intermediate chunk: no finishReason, no usageMetadata.
+	intermediate := &CloudEvent{
+		SessionID: "test-sess",
+		Model:     "gemini-3-flash",
+		LLMResponse: map[string]any{
+			"candidates": []any{
+				map[string]any{
+					"content": map[string]any{
+						"parts": []any{map[string]any{"text": "partial chunk text"}},
+					},
+				},
+			},
+		},
+	}
+	if _, err := AfterModel(intermediate, td.DB); err != nil {
+		t.Fatalf("AfterModel intermediate: %v", err)
+	}
+
+	// Final chunk: carries finishReason and totalTokenCount.
+	final := &CloudEvent{
+		SessionID: "test-sess",
+		Model:     "gemini-3-flash",
+		LLMResponse: map[string]any{
+			"candidates": []any{
+				map[string]any{
+					"finishReason": "STOP",
+					"content": map[string]any{
+						"parts": []any{map[string]any{"text": "final chunk text"}},
+					},
+				},
+			},
+			"usageMetadata": map[string]any{
+				"totalTokenCount": float64(1234),
+			},
+		},
+	}
+	if _, err := AfterModel(final, td.DB); err != nil {
+		t.Fatalf("AfterModel final: %v", err)
+	}
+
+	var count int
+	if err := td.DB.QueryRow(
+		`SELECT COUNT(*) FROM agent_events WHERE session_id = ? AND tool_name = 'AfterModel'`,
+		"test-sess",
+	).Scan(&count); err != nil {
+		t.Fatalf("count AfterModel events: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 AfterModel row (final chunk only); got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a one-line guard in \`internal/hooks/gemini_model.go\` to skip recording \`agent_events\` rows for AfterModel hooks that lack both \`finishReason\` and \`usageMetadata.totalTokenCount\`. Those are intermediate streaming chunks, not turn-level events.

## Why

[Gemini CLI docs](https://geminicli.com/docs/hooks/reference/): AfterModel "Fired for every chunk generated by the model." Of 855 AfterModel rows in observed captures, 560 (65%) lacked token data — they were intermediate chunks with no telemetry value. They surface as duplicates on the wipnote dashboard.

The Claude "duplicates" reported separately turned out to be legitimate distinct tool calls (different \`taskId\` values fired in the same second); no Claude-specific bug.

## Tactical vs durable

This is the **tactical** fix. The durable architecture per Gemini docs is to switch from \`AfterModel\` (chunk-level) to \`AfterAgent\` (turn-level) in \`hooks.json\`. Tracked as a follow-up in \`bug-55a17fc2\` — blocked on verifying [gemini-cli#15468](https://github.com/google-gemini/gemini-cli/issues/15468) (AfterAgent premature-fire bug) is fixed in shipped versions.

## Test plan

- [x] \`internal/hooks/gemini_model_test.go\` — locks in both branches: intermediate chunk records 0 rows, final chunk records 1 row
- [x] Full \`./internal/hooks/...\` suite green
- [x] \`go build ./... && go vet ./...\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)