### PR TITLE
fix(codex): use 'binary' for otel.exporter.protocol — fixes wn codex --dev parse error

### DIFF
--- a/cmd/wipnote/codex_launch.go
+++ b/cmd/wipnote/codex_launch.go
@@ -105,9 +105,9 @@ func buildCodexOtelConfigArgs(port int) []string {
 	base := fmt.Sprintf("http://127.0.0.1:%d", port)
 	return []string{
 		"-c", "otel.log_user_prompt=true",
-		"-c", fmt.Sprintf(`otel.exporter={ otlp-http = { endpoint = "%s/v1/logs", protocol = "http/protobuf" } }`, base),
-		"-c", fmt.Sprintf(`otel.trace_exporter={ otlp-http = { endpoint = "%s/v1/traces", protocol = "http/protobuf" } }`, base),
-		"-c", fmt.Sprintf(`otel.metrics_exporter={ otlp-http = { endpoint = "%s/v1/metrics", protocol = "http/protobuf" } }`, base),
+		"-c", fmt.Sprintf(`otel.exporter={ otlp-http = { endpoint = "%s/v1/logs", protocol = "binary" } }`, base),
+		"-c", fmt.Sprintf(`otel.trace_exporter={ otlp-http = { endpoint = "%s/v1/traces", protocol = "binary" } }`, base),
+		"-c", fmt.Sprintf(`otel.metrics_exporter={ otlp-http = { endpoint = "%s/v1/metrics", protocol = "binary" } }`, base),
 	}
 }
 

--- a/cmd/wipnote/codex_launch_test.go
+++ b/cmd/wipnote/codex_launch_test.go
@@ -139,9 +139,9 @@ func TestBuildCodexOtelConfigArgs_ConfiguresLogsTracesAndMetrics(t *testing.T) {
 	}
 	for _, want := range []string{
 		"otel.log_user_prompt=true",
-		`otel.exporter={ otlp-http = { endpoint = "http://127.0.0.1:43189/v1/logs", protocol = "http/protobuf" } }`,
-		`otel.trace_exporter={ otlp-http = { endpoint = "http://127.0.0.1:43189/v1/traces", protocol = "http/protobuf" } }`,
-		`otel.metrics_exporter={ otlp-http = { endpoint = "http://127.0.0.1:43189/v1/metrics", protocol = "http/protobuf" } }`,
+		`otel.exporter={ otlp-http = { endpoint = "http://127.0.0.1:43189/v1/logs", protocol = "binary" } }`,
+		`otel.trace_exporter={ otlp-http = { endpoint = "http://127.0.0.1:43189/v1/traces", protocol = "binary" } }`,
+		`otel.metrics_exporter={ otlp-http = { endpoint = "http://127.0.0.1:43189/v1/metrics", protocol = "binary" } }`,
 	} {
 		if !containsLine(joined, want) {
 			t.Errorf("Codex OTel config args missing %q in %v", want, got)


### PR DESCRIPTION
## Summary

\`wn codex --dev\` (and all \`wipnote codex\` modes with a live OTel collector) was failing at Codex startup:

\`\`\`
Error loading config.toml: unknown variant 'http/protobuf',
expected 'binary' or 'json' in 'otel.exporter.protocol'
\`\`\`

Codex's Rust config schema defines \`OtlpProtocol\` as the enum \`binary | json\`. \`binary\` maps to HTTP+protobuf internally. The OpenTelemetry spec uses \`http/protobuf\` as the wire-format string, but Codex doesn't deserialize that value at the TOML schema layer.

Commit \`e576f9f94\` ("fix(codex): use http/protobuf OTLP protocol") changed \`binary\` → \`http/protobuf\` thinking it was aligning to the OTel spec. Right at the wire level, wrong at Codex's schema layer. This PR reverts to \`binary\` across all three exporter blocks (logs, traces, metrics) in \`buildCodexOtelConfigArgs\`.

## Diagnosed via `/wipnote:diagnose` (bug-02972d40)

Root cause: \`cmd/wipnote/codex_launch.go:107-110\`, three occurrences of \`protocol = "http/protobuf"\`.

## Blast radius

Every \`wipnote codex\` invocation that spawns the per-session OTel collector — \`--dev\`, default, \`--continue\`, yolo. Hard failure at Codex startup before any user interaction. The env-var path (\`registry_codex.go\` setting \`OTEL_EXPORTER_OTLP_ENDPOINT\`) is unaffected.

## Test plan

- [x] \`TestBuildCodexOtelConfigArgs_ConfiguresLogsTracesAndMetrics\` updated and passes
- [x] \`go build ./... && go vet ./...\` clean
- [ ] CI green
- [ ] Verify: \`wipnote codex --dev\` starts Codex without the parse error

## References

- Codex config schema: https://github.com/openai/codex/blob/main/codex-rs/core/config.schema.json
- Grafana Cloud Codex integration docs (showing \`protocol = "binary"\` for HTTP/protobuf): https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-openai-codex/

🤖 Generated with [Claude Code](https://claude.com/claude-code)