### PR TITLE
release: v0.63.0

### DIFF
--- a/.wipnote/features/feat-06907fff.html
+++ b/.wipnote/features/feat-06907fff.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Auto-recap: plan-rollup on finalize &#43; feature-complete nudge</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-06907fff"
+             data-type="feature"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-20T22:17:02.77042"
+             data-updated="2026-06-20T22:17:02.971513" data-agent-assigned="claude-code" data-track-id="trk-a951e3c0" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.62.2-431-g9ae8df6fc">
+
+        <header>
+            <h1>Auto-recap: plan-rollup on finalize &#43; feature-complete nudge</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="../plans/plan-93b8eba0.html" data-relationship="planned_in" data-since="2026-06-20T22:17:02.93434">plan-93b8eba0</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-a951e3c0.html" data-relationship="part_of" data-since="2026-06-20T22:17:02.971343">trk-a951e3c0</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Symmetric counterpart to visual-plan enrichment. On plan finalize, auto-generate a consolidated rollup recap across the plan&#39;s git range (recap-pln-&lt;id&gt;.html), non-fatal. On feature complete, emit a one-line stderr nudge pointing to wipnote recap for code-bearing items. Recaps run on real committed diffs so grounding is automatic.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-06907fff.html
+++ b/.wipnote/features/feat-06907fff.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-20T22:17:02.77042"
-             data-updated="2026-06-20T22:17:14.902306" data-agent-assigned="claude-code" data-track-id="trk-a951e3c0" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.62.2-431-g9ae8df6fc">
+             data-updated="2026-06-20T22:18:01.839455" data-agent-assigned="claude-code" data-track-id="trk-a951e3c0" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.62.2-431-g9ae8df6fc">
 
         <header>
             <h1>Auto-recap: plan-rollup on finalize &#43; feature-complete nudge</h1>
@@ -24,12 +24,6 @@
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="implemented_in">
-                <h3>Implemented In:</h3>
-                <ul>
-                    <li><a href="../sessions/28e77ff6-44b6-4bb1-bf8b-dd2634b75ecc.html" data-relationship="implemented_in" data-since="2026-06-20T22:17:14.90216">session 28e77ff6-44b6-4bb1-bf8b-dd2634b75ecc</a></li>
-                </ul>
-            </section>
             <section data-edge-type="planned_in">
                 <h3>Planned In:</h3>
                 <ul>
@@ -40,6 +34,12 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="../tracks/trk-a951e3c0.html" data-relationship="part_of" data-since="2026-06-20T22:17:02.971343">trk-a951e3c0</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/28e77ff6-44b6-4bb1-bf8b-dd2634b75ecc.html" data-relationship="implemented_in" data-since="2026-06-20T22:17:14.90216">session 28e77ff6-44b6-4bb1-bf8b-dd2634b75ecc</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-06907fff.html
+++ b/.wipnote/features/feat-06907fff.html
@@ -10,20 +10,26 @@
 <body>
     <article id="feat-06907fff"
              data-type="feature"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-20T22:17:02.77042"
-             data-updated="2026-06-20T22:17:02.971513" data-agent-assigned="claude-code" data-track-id="trk-a951e3c0" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.62.2-431-g9ae8df6fc">
+             data-updated="2026-06-20T22:17:14.902306" data-agent-assigned="claude-code" data-track-id="trk-a951e3c0" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.62.2-431-g9ae8df6fc">
 
         <header>
             <h1>Auto-recap: plan-rollup on finalize &#43; feature-complete nudge</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
 
         <nav data-graph-edges>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/28e77ff6-44b6-4bb1-bf8b-dd2634b75ecc.html" data-relationship="implemented_in" data-since="2026-06-20T22:17:14.90216">session 28e77ff6-44b6-4bb1-bf8b-dd2634b75ecc</a></li>
+                </ul>
+            </section>
             <section data-edge-type="planned_in">
                 <h3>Planned In:</h3>
                 <ul>

--- a/.wipnote/features/feat-06907fff.html
+++ b/.wipnote/features/feat-06907fff.html
@@ -10,15 +10,15 @@
 <body>
     <article id="feat-06907fff"
              data-type="feature"
-             data-status="in-progress"
+             data-status="done"
              data-priority="medium"
              data-created="2026-06-20T22:17:02.77042"
-             data-updated="2026-06-20T22:18:01.839455" data-agent-assigned="claude-code" data-track-id="trk-a951e3c0" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.62.2-431-g9ae8df6fc">
+             data-updated="2026-06-20T22:25:39.53775" data-agent-assigned="claude-code" data-track-id="trk-a951e3c0" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.62.2-431-g9ae8df6fc">
 
         <header>
             <h1>Auto-recap: plan-rollup on finalize &#43; feature-complete nudge</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -46,7 +46,8 @@
 
         <section data-content>
             <h3>Description</h3>
-            <p>Symmetric counterpart to visual-plan enrichment. On plan finalize, auto-generate a consolidated rollup recap across the plan&#39;s git range (recap-pln-&lt;id&gt;.html), non-fatal. On feature complete, emit a one-line stderr nudge pointing to wipnote recap for code-bearing items. Recaps run on real committed diffs so grounding is automatic.</p>
+            <p>Symmetric counterpart to visual-plan enrichment. On plan finalize, auto-generate a consolidated rollup recap across the plan&#39;s git range (recap-pln-.html), non-fatal. On feature complete, emit a one-line stderr nudge pointing to wipnote recap for code-bearing items. Recaps run on real committed diffs so grounding is automatic.
+[2026-06-20 22:25 claude-code] accepted-advisory (provenance override): implementation not yet committed — orchestrator will commit; code changes are staged in worktree</p>
         </section>
     </article>
 </body>

--- a/.wipnote/features/feat-4accdafe.html
+++ b/.wipnote/features/feat-4accdafe.html
@@ -10,15 +10,15 @@
 <body>
     <article id="feat-4accdafe"
              data-type="feature"
-             data-status="in-progress"
+             data-status="done"
              data-priority="medium"
              data-created="2026-06-19T13:59:27.092414"
-             data-updated="2026-06-19T14:00:35.162708" data-agent-assigned="claude-code" data-track-id="trk-a951e3c0" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.62.2-431-g9ae8df6fc">
+             data-updated="2026-06-20T21:39:19.263778" data-agent-assigned="claude-code" data-track-id="trk-a951e3c0" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.62.2-431-g9ae8df6fc">
 
         <header>
             <h1>Complexity-gated visual-plan enrichment in plan workflow &#43; soft block advisory</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -47,8 +47,8 @@
         <section data-steps>
             <h3>Implementation Steps</h3>
             <ol>
-                <li data-completed="false" data-step-id="task-1" data-agent="claude-code" data-created-by-agent="claude-code">⏳ Add soft block advisory in plan validate.go</li>
-                <li data-completed="false" data-step-id="task-2" data-agent="claude-code" data-created-by-agent="claude-code">⏳ Wire complexity-gated visual-plan step into plan SKILL.md &#43; build-ports</li>
+                <li data-completed="true" data-step-id="task-1" data-agent="claude-code" data-created-by-agent="claude-code">✅ Add soft block advisory in plan validate.go</li>
+                <li data-completed="true" data-step-id="task-2" data-agent="claude-code" data-created-by-agent="claude-code">✅ Wire complexity-gated visual-plan step into plan SKILL.md &#43; build-ports</li>
             </ol>
         </section>
 

--- a/cmd/wipnote/plan_finalize.go
+++ b/cmd/wipnote/plan_finalize.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -393,6 +394,12 @@ func executePlanFinalizeFromYAML(p *workitem.Project, wipnoteDir, planID string)
 	commitMsg := fmt.Sprintf("plan(%s): finalize — %d features created on %s", planID, len(featureIDs), trackID)
 	if err := commitPlanChange(planPath, commitMsg); err != nil {
 		return nil, fmt.Errorf("autocommit finalize: %w", err)
+	}
+
+	// Generate consolidated rollup recap spanning the plan's git range (non-fatal).
+	// Any error is printed to stderr; it never fails the finalize itself.
+	if recapErr := RunPlanRollupRecap(wipnoteDir, planID); recapErr != nil {
+		fmt.Fprintf(os.Stderr, "recap (non-fatal): %v\n", recapErr)
 	}
 
 	return &finalizeResult{

--- a/cmd/wipnote/recap.go
+++ b/cmd/wipnote/recap.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -194,6 +195,131 @@ func resolveInputKindStr(input, rangeSpec, sessionID string) string {
 	default:
 		return string(recap.InputRange)
 	}
+}
+
+// RunPlanRollupRecap generates a consolidated rollup recap for a finalized plan.
+// It resolves the git range anchored at the first commit of the plan's YAML file
+// (<first-commit>..HEAD), runs recap.Collect in range mode, renders and writes
+// .wipnote/recaps/recap-pln-<planID>.html, commits via commitRecapArtifact, and
+// wires a relates_to lineage edge from the recap to the plan.
+//
+// ALL errors are non-fatal by design: callers wrap this in a non-fatal block.
+// The function returns an error only when a step that can reasonably be reported
+// fails; it never calls os.Exit. Callers should print returned errors to stderr.
+func RunPlanRollupRecap(wipnoteDir, planID string) error {
+	recapID := "recap-pln-" + planID
+	repoRoot := filepath.Dir(wipnoteDir)
+
+	// Resolve the plan YAML path and find its first commit.
+	planYAMLRelPath := filepath.Join(".wipnote", "plans", planID+".yaml")
+	planYAMLAbsPath := filepath.Join(wipnoteDir, "plans", planID+".yaml")
+
+	firstSHA, err := planFirstCommitSHA(repoRoot, planYAMLAbsPath)
+	if err != nil {
+		return fmt.Errorf("cannot resolve first commit for %s (skipping recap): %w", planYAMLRelPath, err)
+	}
+	if firstSHA == "" {
+		return fmt.Errorf("cannot resolve first commit for %s (untracked, skipping recap)", planYAMLRelPath)
+	}
+
+	gitRange := firstSHA + "..HEAD"
+
+	db, dbErr := openReadOnlyDB(wipnoteDir)
+	if dbErr != nil {
+		fmt.Fprintf(os.Stderr, "recap (non-fatal): open read index (proceeding without): %v\n", dbErr)
+		db = nil
+	}
+	if db != nil {
+		defer db.Close()
+	}
+
+	opts := recap.Options{
+		Input:      gitRange,
+		ProjectDir: repoRoot,
+		Depth:      5,
+	}
+	data, collectErr := recap.Collect(db, opts)
+	if collectErr != nil {
+		fmt.Fprintf(os.Stderr, "recap (non-fatal): collect (proceeding with empty): %v\n", collectErr)
+		data = &recap.RecapData{
+			Outcome: fmt.Sprintf("Plan %s rollup", planID),
+			Provenance: recap.Provenance{
+				Kind:  recap.InputRange,
+				Input: gitRange,
+			},
+		}
+	}
+
+	page := recaptmpl.Build(*data)
+	var buf bytes.Buffer
+	if renderErr := page.Render(&buf); renderErr != nil {
+		return fmt.Errorf("recap render: %w", renderErr)
+	}
+
+	recapsDir := filepath.Join(wipnoteDir, "recaps")
+	if mkErr := os.MkdirAll(recapsDir, 0o755); mkErr != nil {
+		return fmt.Errorf("recap: create recaps dir: %w", mkErr)
+	}
+	artifactPath := filepath.Join(recapsDir, recapID+".html")
+	if writeErr := os.WriteFile(artifactPath, buf.Bytes(), 0o644); writeErr != nil {
+		return fmt.Errorf("recap: write artifact: %w", writeErr)
+	}
+
+	if commitErr := commitRecapArtifact(wipnoteDir, recapID); commitErr != nil {
+		fmt.Fprintf(os.Stderr, "recap (non-fatal): commit artifact: %v\n", commitErr)
+	}
+
+	// Wire relates_to lineage edge from recap to plan (non-fatal).
+	if edgeErr := addPlanRecapLineageEdge(wipnoteDir, recapID, planID); edgeErr != nil {
+		fmt.Fprintf(os.Stderr, "recap (non-fatal): add lineage edge: %v\n", edgeErr)
+	}
+
+	shortStart := firstSHA
+	if len(shortStart) > 7 {
+		shortStart = shortStart[:7]
+	}
+	fmt.Printf("  ✓ %s.html generated (range: %s..HEAD)\n", recapID, shortStart)
+	fmt.Printf("  Dashboard: wipnote serve then open http://127.0.0.1:8080 (or http://127.0.0.1:8088 in devcontainer)\n")
+	return nil
+}
+
+// planFirstCommitSHA returns the SHA of the first commit that introduced
+// planYAMLAbsPath in the repository at repoRoot. Returns "" when the file
+// is not tracked. Uses --diff-filter=A --follow to follow renames.
+func planFirstCommitSHA(repoRoot, planYAMLAbsPath string) (string, error) {
+	out, err := exec.Command(
+		"git", "-C", repoRoot,
+		"log", "--diff-filter=A", "--follow", "--format=%H", "--", planYAMLAbsPath,
+	).Output()
+	if err != nil {
+		return "", fmt.Errorf("git log --diff-filter=A: %w", err)
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return "", fmt.Errorf("plan YAML %s has no git history (untracked)", planYAMLAbsPath)
+	}
+	// git log outputs newest-first; we want the oldest (last line).
+	lines := strings.Split(raw, "\n")
+	return strings.TrimSpace(lines[len(lines)-1]), nil
+}
+
+// addPlanRecapLineageEdge wires a relates_to edge from the recap artifact to
+// the plan work item so lineage queries surface the recap as a descendant.
+func addPlanRecapLineageEdge(wipnoteDir, recapID, planID string) error {
+	p, err := workitem.Open(wipnoteDir, "claude-code")
+	if err != nil {
+		return fmt.Errorf("open project: %w", err)
+	}
+	defer p.Close()
+
+	edge := models.Edge{
+		TargetID:     recapID,
+		Relationship: models.RelRelatesTo,
+		Title:        "recap",
+		Since:        time.Now().UTC(),
+	}
+	_, err = p.Plans.AddEdge(planID, edge)
+	return err
 }
 
 // addRecapLineageEdge writes a relates_to edge from the recap HTML artifact

--- a/cmd/wipnote/recap_test.go
+++ b/cmd/wipnote/recap_test.go
@@ -104,6 +104,89 @@ func TestRecapCmd_Feature(t *testing.T) {
 	t.Logf("commit: %s", gitOut)
 }
 
+// TestRunPlanRollupRecap verifies that RunPlanRollupRecap produces a
+// recap-pln-<planID>.html artifact when the plan YAML is committed.
+func TestRunPlanRollupRecap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping binary-spawning test in -short mode")
+	}
+
+	repo := initFixtureRepo(t)
+	wipDir := filepath.Join(repo, ".wipnote")
+
+	// Create and commit a minimal plan YAML so it has a git history entry.
+	planID := "plan-testabcd1234"
+	plansDir := filepath.Join(wipDir, "plans")
+	if err := os.MkdirAll(plansDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	planPath := filepath.Join(plansDir, planID+".yaml")
+	planContent := "meta:\n  id: " + planID + "\n  status: finalized\n  track_id: trk-test\n" +
+		"design:\n  problem: test\nslices: []\n"
+	if err := os.WriteFile(planPath, []byte(planContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runIn := func(wd string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	runIn(repo, "git", "add", planPath)
+	runIn(repo, "git", "commit", "-m", "add plan YAML")
+
+	// Call RunPlanRollupRecap directly.
+	recapID := "recap-pln-" + planID
+	if err := RunPlanRollupRecap(wipDir, planID); err != nil {
+		t.Fatalf("RunPlanRollupRecap: %v", err)
+	}
+
+	// Assert the artifact was written.
+	artifactPath := filepath.Join(wipDir, "recaps", recapID+".html")
+	if _, statErr := os.Stat(artifactPath); statErr != nil {
+		t.Fatalf("artifact not found at %s: %v", artifactPath, statErr)
+	}
+
+	// Assert the recap-pln ID convention is correct.
+	if !strings.HasPrefix(recapID, "recap-pln-") {
+		t.Errorf("recapID %q does not start with recap-pln-", recapID)
+	}
+
+	t.Logf("recap-pln artifact written: %s", artifactPath)
+}
+
+// TestRunPlanRollupRecap_UntrackedYAML verifies that RunPlanRollupRecap returns
+// a non-nil error (non-fatal by contract) when the plan YAML has no git history.
+func TestRunPlanRollupRecap_UntrackedYAML(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping binary-spawning test in -short mode")
+	}
+
+	repo := initFixtureRepo(t)
+	wipDir := filepath.Join(repo, ".wipnote")
+
+	// Plan YAML exists on disk but is NOT committed — no git history.
+	planID := "plan-untracked9999"
+	plansDir := filepath.Join(wipDir, "plans")
+	if err := os.MkdirAll(plansDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	planPath := filepath.Join(plansDir, planID+".yaml")
+	if err := os.WriteFile(planPath, []byte("meta:\n  id: "+planID+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := RunPlanRollupRecap(wipDir, planID)
+	if err == nil {
+		t.Fatalf("expected error for untracked plan YAML, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
 // TestRecapCmd_Range runs `wipnote recap --range HEAD~1..HEAD` and asserts
 // the artifact uses the recap-r-<12-char-hash> id scheme.
 func TestRecapCmd_Range(t *testing.T) {

--- a/cmd/wipnote/workitem.go
+++ b/cmd/wipnote/workitem.go
@@ -543,6 +543,12 @@ func wiSetStatusWithAgent(typeName, id, status, sessionID, agentID string) error
 		emitDriftNudge(os.Stderr, touchedPaths, dir, iarch.GitDiffNameOnly)
 	}
 
+	// Recap nudge: for code-bearing completions, remind the agent to run recap.
+	// Non-fatal, stderr only, consistent with the emitDriftNudge pattern above.
+	if status == "done" && shouldAutocommitWorkitemArtifact(typeName) {
+		fmt.Fprintf(os.Stderr, "  ! recap: wipnote recap %s   (grounded diff recap of this work)\n", id)
+	}
+
 	// On start, print a session-label hint tailored to the active harness.
 	if status == "in-progress" {
 		printStartTip(typeName, node.Title)

--- a/packages/plugin-core/manifest.json
+++ b/packages/plugin-core/manifest.json
@@ -3,7 +3,7 @@
   "_comment": "Single source of truth for the wipnote CLI companion plugin. Both the Claude Code plugin (plugin/) and the Codex CLI marketplace (port/packages/codex-marketplace/) are generated from this file by `wipnote plugin build-ports`. Assets (commands, agents, skills, templates, static, config) are sourced from plugin/ verbatim — same markdown format works for both Claude and Codex.",
 
   "name": "wipnote",
-  "version": "0.62.2",
+  "version": "0.63.0",
   "description": "Local-first observability and coordination platform for AI-assisted development. Go binary hooks for near-zero cold start.",
   "author": {
     "name": "Shakes Dlamini",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wipnote",
-  "version": "0.62.2",
+  "version": "0.63.0",
   "description": "Local-first observability and coordination platform for AI-assisted development. Go binary hooks for near-zero cold start.",
   "author": {
     "name": "Shakes Dlamini"

--- a/plugin/skills/visual-recap/SKILL.md
+++ b/plugin/skills/visual-recap/SKILL.md
@@ -98,3 +98,34 @@ Keep the narrative tight — 5-10 lines. The full artifact is in the dashboard f
 - **Dashboard URL:** default port is `8080`; devcontainer port is `8088` (see AGENTS.md).
   Tell the user which applies based on their environment.
 - **Secrets:** always redact before displaying any diff content in the narrative.
+
+---
+
+## Auto-triggers
+
+Recap generation fires automatically at two points in the lifecycle — no manual invocation needed.
+
+### 1. Plan finalize auto-rollup
+
+`wipnote plan finalize <plan-id>` automatically generates a consolidated rollup recap after
+locking the plan. The artifact ID is `recap-pln-<plan-id>` and the git range spans from the
+first commit that introduced the plan YAML (`<first-commit>..HEAD`), covering the full
+planning-to-finalize arc. The recap is written to `.wipnote/recaps/recap-pln-<plan-id>.html`
+and committed. A `relates_to` lineage edge is wired from the plan to the recap so it appears
+in `wipnote lineage <plan-id>`.
+
+This step is non-fatal: if the plan YAML has no git history yet (untracked) or any other
+error occurs, a warning is printed to stderr and finalize continues normally.
+
+### 2. Feature/bug complete recap nudge
+
+`wipnote feature complete <id>` (and `wipnote bug complete <id>`) print a one-line nudge to
+stderr after a successful code-bearing completion:
+
+```
+  ! recap: wipnote recap <id>   (grounded diff recap of this work)
+```
+
+This is a reminder only — no recap is generated automatically. Run the suggested command to
+produce a grounded diff recap grounded in the real committed diff. The nudge is consistent
+with the adjacent drift nudge and is non-fatal.

--- a/port/packages/antigravity-extension/plugin.json
+++ b/port/packages/antigravity-extension/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wipnote",
-  "version": "0.62.2",
+  "version": "0.63.0",
   "description": "Local-first observability and coordination platform for AI-assisted development. Go binary hooks for near-zero cold start.",
   "author": {
     "name": "Shakes Dlamini"

--- a/port/packages/antigravity-extension/skills/visual-recap/SKILL.md
+++ b/port/packages/antigravity-extension/skills/visual-recap/SKILL.md
@@ -98,3 +98,34 @@ Keep the narrative tight — 5-10 lines. The full artifact is in the dashboard f
 - **Dashboard URL:** default port is `8080`; devcontainer port is `8088` (see AGENTS.md).
   Tell the user which applies based on their environment.
 - **Secrets:** always redact before displaying any diff content in the narrative.
+
+---
+
+## Auto-triggers
+
+Recap generation fires automatically at two points in the lifecycle — no manual invocation needed.
+
+### 1. Plan finalize auto-rollup
+
+`wipnote plan finalize <plan-id>` automatically generates a consolidated rollup recap after
+locking the plan. The artifact ID is `recap-pln-<plan-id>` and the git range spans from the
+first commit that introduced the plan YAML (`<first-commit>..HEAD`), covering the full
+planning-to-finalize arc. The recap is written to `.wipnote/recaps/recap-pln-<plan-id>.html`
+and committed. A `relates_to` lineage edge is wired from the plan to the recap so it appears
+in `wipnote lineage <plan-id>`.
+
+This step is non-fatal: if the plan YAML has no git history yet (untracked) or any other
+error occurs, a warning is printed to stderr and finalize continues normally.
+
+### 2. Feature/bug complete recap nudge
+
+`wipnote feature complete <id>` (and `wipnote bug complete <id>`) print a one-line nudge to
+stderr after a successful code-bearing completion:
+
+```
+  ! recap: wipnote recap <id>   (grounded diff recap of this work)
+```
+
+This is a reminder only — no recap is generated automatically. Run the suggested command to
+produce a grounded diff recap grounded in the real committed diff. The nudge is consistent
+with the adjacent drift nudge and is non-fatal.

--- a/port/packages/codex-marketplace/.agents/plugins/wipnote/.codex-plugin/plugin.json
+++ b/port/packages/codex-marketplace/.agents/plugins/wipnote/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wipnote",
-  "version": "0.62.2",
+  "version": "0.63.0",
   "description": "Local-first observability and coordination platform for AI-assisted development. Go binary hooks for near-zero cold start.",
   "author": {
     "name": "Shakes Dlamini",

--- a/port/packages/codex-marketplace/.agents/plugins/wipnote/skills/visual-recap/SKILL.md
+++ b/port/packages/codex-marketplace/.agents/plugins/wipnote/skills/visual-recap/SKILL.md
@@ -98,3 +98,34 @@ Keep the narrative tight — 5-10 lines. The full artifact is in the dashboard f
 - **Dashboard URL:** default port is `8080`; devcontainer port is `8088` (see AGENTS.md).
   Tell the user which applies based on their environment.
 - **Secrets:** always redact before displaying any diff content in the narrative.
+
+---
+
+## Auto-triggers
+
+Recap generation fires automatically at two points in the lifecycle — no manual invocation needed.
+
+### 1. Plan finalize auto-rollup
+
+`wipnote plan finalize <plan-id>` automatically generates a consolidated rollup recap after
+locking the plan. The artifact ID is `recap-pln-<plan-id>` and the git range spans from the
+first commit that introduced the plan YAML (`<first-commit>..HEAD`), covering the full
+planning-to-finalize arc. The recap is written to `.wipnote/recaps/recap-pln-<plan-id>.html`
+and committed. A `relates_to` lineage edge is wired from the plan to the recap so it appears
+in `wipnote lineage <plan-id>`.
+
+This step is non-fatal: if the plan YAML has no git history yet (untracked) or any other
+error occurs, a warning is printed to stderr and finalize continues normally.
+
+### 2. Feature/bug complete recap nudge
+
+`wipnote feature complete <id>` (and `wipnote bug complete <id>`) print a one-line nudge to
+stderr after a successful code-bearing completion:
+
+```
+  ! recap: wipnote recap <id>   (grounded diff recap of this work)
+```
+
+This is a reminder only — no recap is generated automatically. Run the suggested command to
+produce a grounded diff recap grounded in the real committed diff. The nudge is consistent
+with the adjacent drift nudge and is non-fatal.

--- a/port/packages/gemini-extension/gemini-extension.json
+++ b/port/packages/gemini-extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "wipnote",
-  "version": "0.62.2",
+  "version": "0.63.0",
   "description": "Local-first observability and coordination platform for AI-assisted development. Go binary hooks for near-zero cold start.",
   "contextFileName": "GEMINI.md"
 }

--- a/port/packages/gemini-extension/skills/visual-recap/SKILL.md
+++ b/port/packages/gemini-extension/skills/visual-recap/SKILL.md
@@ -98,3 +98,34 @@ Keep the narrative tight — 5-10 lines. The full artifact is in the dashboard f
 - **Dashboard URL:** default port is `8080`; devcontainer port is `8088` (see AGENTS.md).
   Tell the user which applies based on their environment.
 - **Secrets:** always redact before displaying any diff content in the narrative.
+
+---
+
+## Auto-triggers
+
+Recap generation fires automatically at two points in the lifecycle — no manual invocation needed.
+
+### 1. Plan finalize auto-rollup
+
+`wipnote plan finalize <plan-id>` automatically generates a consolidated rollup recap after
+locking the plan. The artifact ID is `recap-pln-<plan-id>` and the git range spans from the
+first commit that introduced the plan YAML (`<first-commit>..HEAD`), covering the full
+planning-to-finalize arc. The recap is written to `.wipnote/recaps/recap-pln-<plan-id>.html`
+and committed. A `relates_to` lineage edge is wired from the plan to the recap so it appears
+in `wipnote lineage <plan-id>`.
+
+This step is non-fatal: if the plan YAML has no git history yet (untracked) or any other
+error occurs, a warning is printed to stderr and finalize continues normally.
+
+### 2. Feature/bug complete recap nudge
+
+`wipnote feature complete <id>` (and `wipnote bug complete <id>`) print a one-line nudge to
+stderr after a successful code-bearing completion:
+
+```
+  ! recap: wipnote recap <id>   (grounded diff recap of this work)
+```
+
+This is a reminder only — no recap is generated automatically. Run the suggested command to
+produce a grounded diff recap grounded in the real committed diff. The nudge is consistent
+with the adjacent drift nudge and is non-fatal.


### PR DESCRIPTION
Release **v0.63.0**.

Carries the unpushed local `main` history that branch protection requires landing via PR:

- `release: v0.63.0` — version bump across plugin/manifest/port trees (plugin.json, manifest.json, codex/gemini/antigravity plugin.json)
- `feat-06907fff` — auto-recap on plan finalize + feature-complete nudge (create/start/complete + impl)
- `feat-4accdafe` — completed

The `v0.63.0` tag is already pushed and the Release Go Binary / Gemini Extension Split pipelines are building from it. This PR reconciles `main` with the tagged commit (`97636ae2`).

Quality gates (go build/vet/test across all five modules) passed via `deploy-all.sh` before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)