### PR TITLE
fix(upgrade): atomic sibling-temp + rename install avoids ETXTBSY (bug-a199c652)

### DIFF
--- a/.wipnote/bugs/bug-2451e2a0.html
+++ b/.wipnote/bugs/bug-2451e2a0.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T18:26:28.500447"
-             data-updated="2026-06-22T18:27:27.576006" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T18:27:58.008558" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Address roborev-473 branch-review findings: daemon-routing correctness (ordering races &#43; envelope hardening &#43; writable-open contention)</h1>

--- a/.wipnote/bugs/bug-2451e2a0.html
+++ b/.wipnote/bugs/bug-2451e2a0.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-2451e2a0"
              data-type="bug"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T18:26:28.500447"
-             data-updated="2026-06-22T18:26:28.516823" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T18:27:27.576006" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Address roborev-473 branch-review findings: daemon-routing correctness (ordering races &#43; envelope hardening &#43; writable-open contention)</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -28,6 +28,12 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T18:26:28.51667">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T18:27:27.575827">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/bugs/bug-2451e2a0.html
+++ b/.wipnote/bugs/bug-2451e2a0.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Address roborev-473 branch-review findings: daemon-routing correctness (ordering races &#43; envelope hardening &#43; writable-open contention)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-2451e2a0"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-22T18:26:28.500447"
+             data-updated="2026-06-22T18:26:28.516823" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>Address roborev-473 branch-review findings: daemon-routing correctness (ordering races &#43; envelope hardening &#43; writable-open contention)</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T18:26:28.51667">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>roborev job 473 (verdict F, 7 Medium) on exec-plan-2390966a. Envelope: (6) apply.go JSON args decode to float64 -&gt; int64 precision loss; (7) sqlOpID %v hash collides across types. Ordering races from async conversion: (3) pending_subagent_starts enqueue-only but OTLP receiver reads it immediately -&gt; make applied-ack; (4) lineage insert enqueue-only vs SubagentStop direct close -&gt; route stop-close FIFO; (5) session_family_id async vs routeFamilyAttribution immediate read -&gt; applied-ack family-id. Writable-open contention: (1) hot hooks open writable OpenHookDB -&gt; read-only handles (writes are routed); (2) persistentPreRunE opens writable before EnsureSessionRouted -&gt; lazy fallback opener.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/bugs/bug-2a6a8076.html
+++ b/.wipnote/bugs/bug-2a6a8076.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-2a6a8076"
              data-type="bug"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-23T18:13:41.653349"
-             data-updated="2026-06-23T18:13:41.673822" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-23T18:29:26.790444" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Disjointed codex launch banners — 4 independently-sized launchtui boxes at inconsistent widths</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -28,6 +28,12 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-23T18:13:41.673517">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/8aa54b20-e82a-4878-93de-4928634aed00.html" data-relationship="implemented_in" data-since="2026-06-23T18:29:26.790274">session 8aa54b20-e82a-4878-93de-4928634aed00</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/bugs/bug-2a6a8076.html
+++ b/.wipnote/bugs/bug-2a6a8076.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Disjointed codex launch banners — 4 independently-sized launchtui boxes at inconsistent widths</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-2a6a8076"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-23T18:13:41.653349"
+             data-updated="2026-06-23T18:13:41.673822" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>Disjointed codex launch banners — 4 independently-sized launchtui boxes at inconsistent widths</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-23T18:13:41.673517">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>wipnote codex --dev prints 4 separate launchtui.BannerDetail boxes — Preparing Codex CLI dev mode (refreshCodexPluginCacheBestEffort), Codex wipnote setup (printCodexSetupSummary), Launching Codex CLI with wipnote context (printCodexLaunchBanner), Codex launch notice (renderCodexWarningBanner) in cmd/wipnote/codex.go — each auto-sized to its content, so they stack at wildly different widths and look disjointed. Same family as bug-62b4d0cf (claude launch UI unification), which was never applied to codex.go. Fix: render all codex launch banners at one consistent terminal-aware width and/or fold the preparing/setup/launching boxes into one coherent banner.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/bugs/bug-4c53f857.html
+++ b/.wipnote/bugs/bug-4c53f857.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>roborev-480 round-4: async dedup-before-apply loses write on failure &#43; OpFormatVersion not bumped for protocol change</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-4c53f857"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-22T21:15:48.781094"
+             data-updated="2026-06-22T21:15:48.811182" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>roborev-480 round-4: async dedup-before-apply loses write on failure &#43; OpFormatVersion not bumped for protocol change</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T21:15:48.811015">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Re-review job 480 (F, 2 Med, converging 6-&gt;4-&gt;3-&gt;2). (1) core/daemon/socket.go async ops added to dedup set on enqueue (before apply); if apply fails, same op_id retried -&gt; AckDuplicate -&gt; never re-run -&gt; derived write lost until reindex. Fix: remove op_id from dedup on apply failure (keep in-flight-dup protection), or promote to dedup only on successful apply. (2) core/daemon/wire.go OpFormatVersion still 1 despite async-ack + tagged-Args protocol changes; new-client/old-daemon skew misbehaves. Fix: bump OpFormatVersion + daemon validates version and error-acks mismatch so client falls back; mixed-version tests.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/bugs/bug-4c53f857.html
+++ b/.wipnote/bugs/bug-4c53f857.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-4c53f857"
              data-type="bug"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T21:15:48.781094"
-             data-updated="2026-06-22T21:15:48.811182" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T21:16:33.763034" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>roborev-480 round-4: async dedup-before-apply loses write on failure &#43; OpFormatVersion not bumped for protocol change</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -28,6 +28,12 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T21:15:48.811015">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T21:16:33.762858">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/bugs/bug-69da0ee7.html
+++ b/.wipnote/bugs/bug-69da0ee7.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-69da0ee7"
              data-type="bug"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T20:46:15.679571"
-             data-updated="2026-06-22T20:46:15.76006" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T20:46:59.890093" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>roborev-478 round-3: read-only hook dispatch bypasses DB-independent guards &#43; reconcile drain still capped at 500 &#43; envelope float64-&gt;int coercion</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -28,6 +28,12 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T20:46:15.759889">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T20:46:59.88991">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/bugs/bug-69da0ee7.html
+++ b/.wipnote/bugs/bug-69da0ee7.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>roborev-478 round-3: read-only hook dispatch bypasses DB-independent guards &#43; reconcile drain still capped at 500 &#43; envelope float64-&gt;int coercion</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-69da0ee7"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-22T20:46:15.679571"
+             data-updated="2026-06-22T20:46:15.76006" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>roborev-478 round-3: read-only hook dispatch bypasses DB-independent guards &#43; reconcile drain still capped at 500 &#43; envelope float64-&gt;int coercion</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T20:46:15.759889">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Re-review job 478 (F, converging: 2 Med + 1 Low). (1) Med cmd/wipnote/hook.go hookSubcmdReadOnly returns fallback when read-only DB missing -&gt; pretooluse DB-independent safety guards (block direct .wipnote writes etc.) never run on first-run/deleted-cache. Fix: invoke handler with nil DB so guards run; make handler nil-DB-safe. (2) Med core/hooks/session_end.go ReconcileDoneButUncommittedForProject documented uncapped but delegates to reconcileDoneButUncommitted capped at newest 500/status -&gt; older dirty terminal artifacts skipped. Fix: uncapped/paginated scan for serve-drain path + test &gt;500. (3) Low core/daemon/apply/apply.go NormalizeArgs coerces integral float64-&gt;int64 -&gt; RouteSQL float64(1.0) applies as int. Fix: type-preserving arg serialization (round-trip int64 exact AND float64 as float), type-tagged sqlOpID.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/bugs/bug-705c7525.html
+++ b/.wipnote/bugs/bug-705c7525.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>GH#125: work-item gate mismatches harness and wipnote session ids</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-705c7525"
+             data-type="bug"
+             data-status="todo"
+             data-priority="high"
+             data-created="2026-06-23T18:06:47.581141"
+             data-updated="2026-06-23T18:06:47.591241" data-agent-assigned="claude-code" data-track-id="trk-08dcbb33" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>GH#125: work-item gate mismatches harness and wipnote session ids</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-high">High Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-08dcbb33.html" data-relationship="part_of" data-since="2026-06-23T18:06:47.591074">trk-08dcbb33</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-steps>
+            <h3>Implementation Steps</h3>
+            <ol>
+                <li data-completed="false" data-step-id="step-bug-705c7525-0" data-agent="claude-code" data-created-by-agent="claude-code">⏳ Reproduce mismatched WIPNOTE_SESSION_ID versus harness session id claim lookup</li>
+                <li data-completed="false" data-step-id="step-bug-705c7525-1" data-agent="claude-code" data-created-by-agent="claude-code">⏳ Reconcile claim start and PreToolUse lookup for root and child sessions</li>
+                <li data-completed="false" data-step-id="step-bug-705c7525-2" data-agent="claude-code" data-created-by-agent="claude-code">⏳ Clarify research-gate messaging about which tool evidence satisfies it</li>
+            </ol>
+        </section>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>GitHub #125: PreToolUse work-item gate can block edits after feature start because feature start records the claim under WIPNOTE_SESSION_ID while the hook checks the harness session id. The same issue can strand delegated subagents whose session does not own the orchestrator claim, and the research-gate message is unclear that only harness Read/Grep/Glob evidence counts. Fix should reconcile harness and wipnote session ids, handle child/subagent ownership, and clarify the gate message. Source: https://github.com/shakestzd/wipnote/issues/125</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/bugs/bug-a199c652.html
+++ b/.wipnote/bugs/bug-a199c652.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>wipnote upgrade fails with &#39;text file busy&#39; (ETXTBSY) — non-atomic in-place install while binary is running</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-a199c652"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-23T18:20:18.38609"
+             data-updated="2026-06-23T18:20:18.509332" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>wipnote upgrade fails with &#39;text file busy&#39; (ETXTBSY) — non-atomic in-place install while binary is running</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-23T18:20:18.509103">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>wipnote upgrade downloads + checksum-verifies the new release, then installs by opening the target binary path for write in place. That fails with ETXTBSY whenever any wipnote process (claude/codex launcher, serve, otel-collect) is executing the binary. Repro: run wipnote upgrade from inside a running wipnote session. Fix: install via write-to-sibling-temp-on-the-same-filesystem then atomic rename — rename() replaces the directory entry and succeeds even on a busy executable; running processes keep the old inode until exit. Same family as bug-8fd0fac2 (build non-atomic install). Workaround used to install v0.64.2: extract release tarball, copy binary to a dotfile sibling in the install dir, mv -f over the target.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/bugs/bug-a782badf.html
+++ b/.wipnote/bugs/bug-a782badf.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>roborev-476 round-2: SessionStart routed args use sql.NullString (HIGH, silent daemon apply failure) &#43; read-only-open gaps &#43; gate not in approved profile</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-a782badf"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-22T19:16:49.153096"
+             data-updated="2026-06-22T19:16:49.267104" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>roborev-476 round-2: SessionStart routed args use sql.NullString (HIGH, silent daemon apply failure) &#43; read-only-open gaps &#43; gate not in approved profile</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T19:16:49.266748">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Re-review job 476 (verdict F). HIGH: core/hooks/session_start.go local nullableStr (line 854) returns sql.NullString; routeSessionUpsert + other routed writes pass it through RouteHookWrite -&gt; JSON-encodes as object -&gt; daemon Exec fails to bind -&gt; session/lineage writes silently never apply via daemon (enqueue-only acked, no fallback). Fix: nullableStr -&gt; any (nil/string); verify ALL routed session_start args JSON-safe; add real daemon-round-trip test asserting the session ROW lands. Med: dbgate.go OpenHookDBReadOnly uses OpenReadOnlyMigrated which opens writable to migrate first -&gt; use truly read-only open for hot hooks when DB exists. Med: hook.go session-start still opens writable OpenHookDB -&gt; read-only/bounded. Med: gate_durability_test.go verifies synthetic plan but .wipnote/guard-profile.yaml only runs build+vet -&gt; wire the contention fixture into the real approved gate or assert the real profile path.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/bugs/bug-a782badf.html
+++ b/.wipnote/bugs/bug-a782badf.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-a782badf"
              data-type="bug"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T19:16:49.153096"
-             data-updated="2026-06-22T19:16:49.267104" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T19:18:13.529732" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>roborev-476 round-2: SessionStart routed args use sql.NullString (HIGH, silent daemon apply failure) &#43; read-only-open gaps &#43; gate not in approved profile</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -28,6 +28,12 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T19:16:49.266748">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T19:18:13.529251">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/bugs/bug-aaf25c77.html
+++ b/.wipnote/bugs/bug-aaf25c77.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Manual &#39;wipnote sweep orphaned-events&#39; should bypass live-session protection</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-aaf25c77"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-22T06:00:21.122921"
+             data-updated="2026-06-22T06:00:21.282987" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.63.4-16-g7709d2ddd">
+
+        <header>
+            <h1>Manual &#39;wipnote sweep orphaned-events&#39; should bypass live-session protection</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="caused_by">
+                <h3>Caused By:</h3>
+                <ul>
+                    <li><a href="../features/feat-98096297.html" data-relationship="caused_by" data-since="2026-06-22T06:00:21.231586">feat-98096297</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T06:00:21.282738">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Follow-up to roborev P2 on PR #135 (bug-504095f2/#448/#455). FindStaleProjectOrphans protects non-terminal sessions (completed_at NULL) until the 24h hard cutoff to avoid false-aborting live long-running tools (sessions have no heartbeat). Correct for the AUTOMATIC drain + session-start cap, but the EXPLICIT manual path (cmd/wipnote/sweep.go -&gt; SweepOrphanedEventsForProject) is over-protected: a user who runs &#39;wipnote sweep orphaned-events&#39; has opted in and expects crashed-session orphans swept at the 5m threshold, not 24h. Fix: give the manual sweep an unprotected variant (or a --all/--include-active flag) that uses the pre-448 behavior, while keeping the automatic paths protected. Also consider adding a session heartbeat so live vs crashed can be distinguished (would remove the tradeoff entirely).</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/bugs/bug-b0a36bda.html
+++ b/.wipnote/bugs/bug-b0a36bda.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-b0a36bda"
              data-type="bug"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T21:37:45.08487"
-             data-updated="2026-06-22T21:37:45.094539" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T21:38:22.615938" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>roborev-482 round-5 (final/capped): async in-flight-duplicate dedup &#43; bounded-open migration retry exceeds &lt;1s</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -28,6 +28,12 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T21:37:45.094398">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T21:38:22.615823">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/bugs/bug-b0a36bda.html
+++ b/.wipnote/bugs/bug-b0a36bda.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>roborev-482 round-5 (final/capped): async in-flight-duplicate dedup &#43; bounded-open migration retry exceeds &lt;1s</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-b0a36bda"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-22T21:37:45.08487"
+             data-updated="2026-06-22T21:37:45.094539" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>roborev-482 round-5 (final/capped): async in-flight-duplicate dedup &#43; bounded-open migration retry exceeds &lt;1s</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T21:37:45.094398">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Re-review job 482 (F, 2 Med, plateaued). (1) core/daemon/socket.go async dedup: an in-flight duplicate (2nd client, same op_id, while 1st pending) gets AckDuplicate and skips fallback; if 1st apply fails the duplicate is lost. Fix: track pending vs applied op_ids separately; do NOT return durable AckDuplicate for a still-pending op (re-enqueue it / treat as non-durable so caller falls back); only confirmed-applied ops dedup durably. (2) core/db/open_modes.go OpenWithBusyTimeout wraps runMigrations in RetryOnBusy(DefaultBusyBackoff ~2.6s), so a bounded hook open (OpenHookDBWithBusyTimeout) on a stale/unmigrated DB under a held lock exceeds &lt;1s. Fix: skip migration when DB schema already current (cheap read check), and for the bounded open keep migration within the bounded timeout (no separate 2.6s retry). LAST capped fix pass per user.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/bugs/bug-be92c2f6.html
+++ b/.wipnote/bugs/bug-be92c2f6.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Hot-hook bounded-open/fallback &lt;1s tail under contention (roborev-484, deferred per loop cap)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-be92c2f6"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-22T21:57:52.288823"
+             data-updated="2026-06-22T21:57:52.297415" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>Hot-hook bounded-open/fallback &lt;1s tail under contention (roborev-484, deferred per loop cap)</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T21:57:52.297273">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Deferred follow-up from roborev-484 (loop capped after round 6 per user). The high-frequency hot-path writes are routed enqueue-only and &lt;1s; these are the rare fallback/cold-open edge cases that can still exceed &lt;1s under a held lock. (1) core/hooks/subagent_start.go:100 applied-ack pending fallback uses the production 5s handle -&gt; ~7s worst case; route fallback through a short-timeout handle. (2) cmd/wipnote/hook.go:77 production stop dispatches via 5s hookSubcmd while the contention gate measures a bounded handle -&gt; gate/prod mismatch; bound stop dispatch or route residual otel_signals writes + update gate. (3) core/db/open_modes.go:215 OpenWithBusyTimeout ApplyPragmas still RetryOnBusy(DefaultBusyBackoff) for journal_mode change under a held lock; add a bounded/no-retry pragma path. All recoverable/edge, no HIGH.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/bugs/bug-c9ec25a4.html
+++ b/.wipnote/bugs/bug-c9ec25a4.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Route subagent-start lineage writes through the daemon (last hot-hook contention residual)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-c9ec25a4"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-22T17:56:49.945311"
+             data-updated="2026-06-22T17:56:50.033435" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>Route subagent-start lineage writes through the daemon (last hot-hook contention residual)</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T17:56:50.033154">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Final hot-hook contention residual after plan-2390966a + bug-d792aee6. subagent-start still does 3 direct best-effort writes on the 5s OpenHookDB handle: BackfillParentSession (single UPDATE), InsertLineageTrace (single INSERT; args use nullStr=sql.NullString, NOT JSON-safe -&gt; must convert to nil/string for wire transport), UpsertPendingSubagentStart (single INSERT OR REPLACE; nullableStr args already JSON-safe). All errors are best-effort (debugLog only). Fix: expose Stmt builders from core/db, route via RouteHookWrite (enqueue-only; FIFO preserves order after the already-routed sessions insert). Make slice-8 gate faithful for subagent-start (production handle, assert &lt;1s; drop the documented-residual note).</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/bugs/bug-c9ec25a4.html
+++ b/.wipnote/bugs/bug-c9ec25a4.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-c9ec25a4"
              data-type="bug"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T17:56:49.945311"
-             data-updated="2026-06-22T17:56:50.033435" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T17:57:37.752015" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Route subagent-start lineage writes through the daemon (last hot-hook contention residual)</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -28,6 +28,12 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T17:56:50.033154">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T17:57:37.751867">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/bugs/bug-d792aee6.html
+++ b/.wipnote/bugs/bug-d792aee6.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Hot-path pretooluse claim writes &#43; launcher cold-insert still stall under contention (slice-8 findings)</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-d792aee6"
+             data-type="bug"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-22T16:28:37.429678"
+             data-updated="2026-06-22T16:28:37.443339" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>Hot-path pretooluse claim writes &#43; launcher cold-insert still stall under contention (slice-8 findings)</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T16:28:37.443204">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>plan-2390966a slice-8 acceptance findings. (1) pretooluse ReapExpiredClaims (every call) + HeartbeatClaimByWorkItem (when FeatureID set) are unrouted direct writes (return values discarded) on the 5s OpenHookDB handle -&gt; ~5s stall under a held external write lock; slice-8 gate masked it with a 250ms handle. Fix: expose SQL builders from core/db, route via RouteHookWrite (enqueue-only). (2) launcher new-session cold insert uses applied-ack RouteSessionInsert (~2.4s under held lock). Fix: add RouteSessionInsertAsync (enqueue-only) + swap the main.go adapter; SessionStart upsert is idempotent INSERT OR IGNORE so it&#39;s safe. Also make slice-8 gate faithful (production OpenHookDB handle, assert pretooluse + new-session chooser &lt;1s).</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/bugs/bug-d792aee6.html
+++ b/.wipnote/bugs/bug-d792aee6.html
@@ -10,15 +10,15 @@
 <body>
     <article id="bug-d792aee6"
              data-type="bug"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T16:28:37.429678"
-             data-updated="2026-06-22T16:28:37.443339" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T16:31:11.894706" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Hot-path pretooluse claim writes &#43; launcher cold-insert still stall under contention (slice-8 findings)</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -28,6 +28,12 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T16:28:37.443204">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T16:31:11.894561">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/bugs/bug-f3e1edbe.html
+++ b/.wipnote/bugs/bug-f3e1edbe.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>GH#137: check --gate fails when uv cache is sandbox-blocked</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="bug-f3e1edbe"
+             data-type="bug"
+             data-status="todo"
+             data-priority="high"
+             data-created="2026-06-23T18:06:46.893372"
+             data-updated="2026-06-23T18:06:46.939008" data-agent-assigned="claude-code" data-track-id="trk-b1d06a84" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>GH#137: check --gate fails when uv cache is sandbox-blocked</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-high">High Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-b1d06a84.html" data-relationship="part_of" data-since="2026-06-23T18:06:46.938736">trk-b1d06a84</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-steps>
+            <h3>Implementation Steps</h3>
+            <ol>
+                <li data-completed="false" data-step-id="step-bug-f3e1edbe-0" data-agent="claude-code" data-created-by-agent="claude-code">⏳ Reproduce uv cache permission failure in a sandboxed check --gate path</li>
+                <li data-completed="false" data-step-id="step-bug-f3e1edbe-1" data-agent="claude-code" data-created-by-agent="claude-code">⏳ Set UV_CACHE_DIR or equivalent workspace-local cache for uv-invoked gates</li>
+                <li data-completed="false" data-step-id="step-bug-f3e1edbe-2" data-agent="claude-code" data-created-by-agent="claude-code">⏳ Classify uv cache permission failures with targeted remediation and avoid misleading project-failure records</li>
+            </ol>
+        </section>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>GitHub #137: In Codex managed sandboxes, wipnote check --gate can fail before running the project lint because uv attempts to read a user-level cache outside the workspace. Direct uv run ruff check passes, but the wipnote-mediated gate records a failed gate caused by sandbox cache access. Fix should make uv-based checks use a workspace/wipnote-local cache or emit targeted remediation, and distinguish environment setup failure from project lint failure. Source: https://github.com/shakestzd/wipnote/issues/137</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-41b2aa52.html
+++ b/.wipnote/features/feat-41b2aa52.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T03:49:10.121077"
-             data-updated="2026-06-22T06:22:44.350779" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362">
+             data-updated="2026-06-22T08:15:01.787382" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362">
 
         <header>
             <h1>Collapse the hot-path write-site inventory &#43; retire band-aid scaffolding</h1>

--- a/.wipnote/features/feat-41b2aa52.html
+++ b/.wipnote/features/feat-41b2aa52.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Collapse the hot-path write-site inventory &#43; retire band-aid scaffolding</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-41b2aa52"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="medium"
+             data-created="2026-06-22T03:49:10.121077"
+             data-updated="2026-06-22T06:22:44.350779" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362">
+
+        <header>
+            <h1>Collapse the hot-path write-site inventory &#43; retire band-aid scaffolding</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="../features/feat-597bbf26.html" data-relationship="blocked_by">feat-597bbf26</a></li>
+                    <li><a href="../features/feat-8a4d2955.html" data-relationship="blocked_by">feat-8a4d2955</a></li>
+                    <li><a href="../features/feat-1ad54813.html" data-relationship="blocked_by">feat-1ad54813</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="../plans/plan-2390966a.html" data-relationship="planned_in" data-since="2026-06-22T03:49:10.131386">plan-2390966a</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T03:49:10.152988">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T06:22:44.350575">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>After migration, the hook tree and launcher no longer open writable handles
+on the hot path except via the documented last-resort fallback. Update
+approvedWriteSites (cmd/wipnote/sqlite_write_boundary_test.go) so the hot-path
+entries are reclassified as daemon-routed (fallback-only), tighten the
+boundary test to assert no NEW hot-path direct opens, remove the now-dead
+launch-timing scaffolding (or keep behind WIPNOTE_LAUNCH_TIMING), and ensure
+the inventory documents the remaining legitimate operator-CLI write sites.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-597bbf26.html
+++ b/.wipnote/features/feat-597bbf26.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Migrate SessionStart writes to the daemon</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-597bbf26"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="medium"
+             data-created="2026-06-22T03:49:09.907291"
+             data-updated="2026-06-22T05:42:46.08401" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362">
+
+        <header>
+            <h1>Migrate SessionStart writes to the daemon</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T03:49:09.932869">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="../features/feat-9710753b.html" data-relationship="blocked_by">feat-9710753b</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="../plans/plan-2390966a.html" data-relationship="planned_in" data-since="2026-06-22T03:49:09.914157">plan-2390966a</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T05:42:46.083817">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Replace SessionStart&#39;s direct writes (runSessionTransaction session upsert +
+lineage, transcript_path UPDATE, InsertEvent, SetSessionFamilyID,
+PropagateFamilyAttribution) with the existing typed routes where present
+(RouteSessionInsert) and RouteHookWrite for the long tail. Retire the
+session-start-only OpenHookDBWithBusyTimeout special-case in
+cmd/wipnote/hook.go (the policy now lives in RouteHookWrite). Keep the
+capped orphan sweep + serve drain from the prior fix.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-8a4d2955.html
+++ b/.wipnote/features/feat-8a4d2955.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Migrate pretooluse / user-prompt / subagent-start / stop writes to the daemon</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-8a4d2955"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="medium"
+             data-created="2026-06-22T03:49:09.943694"
+             data-updated="2026-06-22T05:43:04.754504" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362">
+
+        <header>
+            <h1>Migrate pretooluse / user-prompt / subagent-start / stop writes to the daemon</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="../plans/plan-2390966a.html" data-relationship="planned_in" data-since="2026-06-22T03:49:09.947959">plan-2390966a</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T03:49:09.961228">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="../features/feat-9710753b.html" data-relationship="blocked_by">feat-9710753b</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T05:43:04.754339">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Replace the direct writable Exec calls in PreToolUse, UserPrompt,
+SubagentStart, and Stop with RouteHookWrite / existing typed routes. These
+are the hot hooks that stalled 5-14s under a held lock in profiling
+(posttooluse already routes through the queue and is the reference).</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-bbb80917.html
+++ b/.wipnote/features/feat-bbb80917.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>CI durability gate: contention stress &#43; no-stall assertions</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-bbb80917"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="medium"
+             data-created="2026-06-22T03:49:10.166688"
+             data-updated="2026-06-22T08:37:19.398883" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362">
+
+        <header>
+            <h1>CI durability gate: contention stress &#43; no-stall assertions</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="../plans/plan-2390966a.html" data-relationship="planned_in" data-since="2026-06-22T03:49:10.174869">plan-2390966a</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T03:49:10.177224">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="../features/feat-597bbf26.html" data-relationship="blocked_by">feat-597bbf26</a></li>
+                    <li><a href="../features/feat-8a4d2955.html" data-relationship="blocked_by">feat-8a4d2955</a></li>
+                    <li><a href="../features/feat-1ad54813.html" data-relationship="blocked_by">feat-1ad54813</a></li>
+                    <li><a href="../features/feat-c08d1ba1.html" data-relationship="blocked_by">feat-c08d1ba1</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T08:37:19.398622">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Extend TestSQLiteContentionStress (cmd/wipnote) to drive the migrated hot
+hooks + launcher pre-run while an external connection holds BEGIN IMMEDIATE,
+asserting (a) zero first-party SQLITE_BUSY across 3 consecutive runs and
+(b) every hot hook + the chooser path completes &lt;1s under the held lock.
+Wire it into the quality gate / launch-readiness check so the durable
+property is enforced, not just observed.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-c08d1ba1.html
+++ b/.wipnote/features/feat-c08d1ba1.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Fix the ~5.45s uncontended stop-hook baseline</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-c08d1ba1"
+             data-type="feature"
+             data-status="in-progress"
+             data-priority="medium"
+             data-created="2026-06-22T03:49:10.028746"
+             data-updated="2026-06-22T06:22:16.238948" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362">
+
+        <header>
+            <h1>Fix the ~5.45s uncontended stop-hook baseline</h1>
+            <div class="metadata">
+                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="../plans/plan-2390966a.html" data-relationship="planned_in" data-since="2026-06-22T03:49:10.04057">plan-2390966a</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T03:49:10.063396">trk-6a1f5362</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="blocked_by">
+                <h3>Blocked By:</h3>
+                <ul>
+                    <li><a href="../features/feat-8a4d2955.html" data-relationship="blocked_by">feat-8a4d2955</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T06:22:16.23877">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Profile the Stop hook&#39;s ~5.45s cost with NO lock held (a baseline cost, like
+session-start&#39;s synchronous orphan sweep was) using the launch-timing /
+LogTimed instrumentation, identify the synchronous slow phase, and take it
+off the hot path (cap + defer to the serve drain, or background via the
+daemon) so session end is not gated on it.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-c08d1ba1.html
+++ b/.wipnote/features/feat-c08d1ba1.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T03:49:10.028746"
-             data-updated="2026-06-22T06:22:16.238948" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362">
+             data-updated="2026-06-22T08:14:40.552058" data-agent-assigned="claude-code" data-track-id="trk-6a1f5362">
 
         <header>
             <h1>Fix the ~5.45s uncontended stop-hook baseline</h1>
@@ -24,18 +24,6 @@
         </header>
 
         <nav data-graph-edges>
-            <section data-edge-type="planned_in">
-                <h3>Planned In:</h3>
-                <ul>
-                    <li><a href="../plans/plan-2390966a.html" data-relationship="planned_in" data-since="2026-06-22T03:49:10.04057">plan-2390966a</a></li>
-                </ul>
-            </section>
-            <section data-edge-type="part_of">
-                <h3>Part Of:</h3>
-                <ul>
-                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T03:49:10.063396">trk-6a1f5362</a></li>
-                </ul>
-            </section>
             <section data-edge-type="blocked_by">
                 <h3>Blocked By:</h3>
                 <ul>
@@ -46,6 +34,18 @@
                 <h3>Implemented In:</h3>
                 <ul>
                     <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T06:22:16.23877">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="planned_in">
+                <h3>Planned In:</h3>
+                <ul>
+                    <li><a href="../plans/plan-2390966a.html" data-relationship="planned_in" data-since="2026-06-22T03:49:10.04057">plan-2390966a</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-6a1f5362.html" data-relationship="part_of" data-since="2026-06-22T03:49:10.063396">trk-6a1f5362</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-dc8354ad.html
+++ b/.wipnote/features/feat-dc8354ad.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Release v0.64.2</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-dc8354ad"
+             data-type="feature"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-22T22:31:21.581861"
+             data-updated="2026-06-22T22:31:21.675646" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>Release v0.64.2</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="part_of">
+                <h3>Part Of:</h3>
+                <ul>
+                    <li><a href="../tracks/trk-0677c709.html" data-relationship="part_of" data-since="2026-06-22T22:31:21.675139">trk-0677c709</a></li>
+                </ul>
+            </section>
+        </nav>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Deploy wipnote v0.64.2 using scripts/deploy-all.sh after PR #136 landed.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-dc8354ad.html
+++ b/.wipnote/features/feat-dc8354ad.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T22:31:21.581861"
-             data-updated="2026-06-22T22:31:27.070571" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T22:41:38.209012" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Release v0.64.2</h1>

--- a/.wipnote/features/feat-dc8354ad.html
+++ b/.wipnote/features/feat-dc8354ad.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T22:31:21.581861"
-             data-updated="2026-06-22T22:41:38.209012" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T22:41:50.725394" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Release v0.64.2</h1>

--- a/.wipnote/features/feat-dc8354ad.html
+++ b/.wipnote/features/feat-dc8354ad.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T22:31:21.581861"
-             data-updated="2026-06-22T22:41:50.725394" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T22:42:04.137796" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Release v0.64.2</h1>

--- a/.wipnote/features/feat-dc8354ad.html
+++ b/.wipnote/features/feat-dc8354ad.html
@@ -13,7 +13,7 @@
              data-status="done"
              data-priority="medium"
              data-created="2026-06-22T22:31:21.581861"
-             data-updated="2026-06-22T22:44:07.495507" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T22:44:09.104175" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Release v0.64.2</h1>

--- a/.wipnote/features/feat-dc8354ad.html
+++ b/.wipnote/features/feat-dc8354ad.html
@@ -13,7 +13,7 @@
              data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T22:31:21.581861"
-             data-updated="2026-06-22T22:42:04.137796" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T22:43:20.752864" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Release v0.64.2</h1>

--- a/.wipnote/features/feat-dc8354ad.html
+++ b/.wipnote/features/feat-dc8354ad.html
@@ -10,15 +10,15 @@
 <body>
     <article id="feat-dc8354ad"
              data-type="feature"
-             data-status="in-progress"
+             data-status="done"
              data-priority="medium"
              data-created="2026-06-22T22:31:21.581861"
-             data-updated="2026-06-22T22:43:20.752864" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T22:44:07.495507" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Release v0.64.2</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>

--- a/.wipnote/features/feat-dc8354ad.html
+++ b/.wipnote/features/feat-dc8354ad.html
@@ -10,15 +10,15 @@
 <body>
     <article id="feat-dc8354ad"
              data-type="feature"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T22:31:21.581861"
-             data-updated="2026-06-22T22:31:21.675646" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T22:31:27.070571" data-agent-assigned="claude-code" data-track-id="trk-0677c709" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Release v0.64.2</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -28,6 +28,12 @@
                 <h3>Part Of:</h3>
                 <ul>
                     <li><a href="../tracks/trk-0677c709.html" data-relationship="part_of" data-since="2026-06-22T22:31:21.675139">trk-0677c709</a></li>
+                </ul>
+            </section>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T22:31:27.070404">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
                 </ul>
             </section>
         </nav>

--- a/.wipnote/features/feat-e6e561b0.html
+++ b/.wipnote/features/feat-e6e561b0.html
@@ -10,15 +10,15 @@
 <body>
     <article id="feat-e6e561b0"
              data-type="feature"
-             data-status="in-progress"
+             data-status="done"
              data-priority="medium"
              data-created="2026-06-22T22:23:34.604604"
-             data-updated="2026-06-22T22:23:44.686753" data-agent-assigned="claude-code" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T22:29:48.661662" data-agent-assigned="claude-code" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Merge PR #136</h1>
             <div class="metadata">
-                <span class="badge status-in-progress">In Progress</span>
+                <span class="badge status-done">Done</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
@@ -34,7 +34,7 @@
 
         <section data-content>
             <h3>Description</h3>
-            <p>Merge GitHub PR #136 after checking status and required context.</p>
+            <p>Merged GitHub PR #136 after branch protection was updated. PR title: Durable fix: eliminate multi-process SQLite write contention via single-writer daemon (plan-2390966a). Checks were green, merge state CLEAN, review approval no longer required. Merge method: merge commit. Merge commit: b7cd647d6691821e615853e696f382fba39d06b7.</p>
         </section>
     </article>
 </body>

--- a/.wipnote/features/feat-e6e561b0.html
+++ b/.wipnote/features/feat-e6e561b0.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="wipnote-version" content="1.0">
+    <title>Merge PR #136</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <article id="feat-e6e561b0"
+             data-type="feature"
+             data-status="todo"
+             data-priority="medium"
+             data-created="2026-06-22T22:23:34.604604"
+             data-updated="2026-06-22T22:23:34.719329" data-agent-assigned="claude-code" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+
+        <header>
+            <h1>Merge PR #136</h1>
+            <div class="metadata">
+                <span class="badge status-todo">Todo</span>
+                <span class="badge priority-medium">Medium Priority</span>
+            </div>
+        </header>
+
+        <section data-content>
+            <h3>Description</h3>
+            <p>Merge GitHub PR #136 after checking status and required context.</p>
+        </section>
+    </article>
+</body>
+</html>

--- a/.wipnote/features/feat-e6e561b0.html
+++ b/.wipnote/features/feat-e6e561b0.html
@@ -10,18 +10,27 @@
 <body>
     <article id="feat-e6e561b0"
              data-type="feature"
-             data-status="todo"
+             data-status="in-progress"
              data-priority="medium"
              data-created="2026-06-22T22:23:34.604604"
-             data-updated="2026-06-22T22:23:34.719329" data-agent-assigned="claude-code" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
+             data-updated="2026-06-22T22:23:44.686753" data-agent-assigned="claude-code" data-created-by-agent="claude-code" data-created-by-model="claude-opus-4-8[1m]" data-created-by-role="codex" data-created-by-cli-version="0.64.0-17-gac4898ffa">
 
         <header>
             <h1>Merge PR #136</h1>
             <div class="metadata">
-                <span class="badge status-todo">Todo</span>
+                <span class="badge status-in-progress">In Progress</span>
                 <span class="badge priority-medium">Medium Priority</span>
             </div>
         </header>
+
+        <nav data-graph-edges>
+            <section data-edge-type="implemented_in">
+                <h3>Implemented In:</h3>
+                <ul>
+                    <li><a href="../sessions/1ea41959-b6de-447b-b615-4de675ac89b5.html" data-relationship="implemented_in" data-since="2026-06-22T22:23:44.686629">session 1ea41959-b6de-447b-b615-4de675ac89b5</a></li>
+                </ul>
+            </section>
+        </nav>
 
         <section data-content>
             <h3>Description</h3>

--- a/cmd/wipnote/upgrade_cmd.go
+++ b/cmd/wipnote/upgrade_cmd.go
@@ -497,17 +497,60 @@ func copyDirRecursive(src, dst string) error {
 	})
 }
 
-// atomicReplace replaces dest with src. Tries os.Rename first (atomic on same
-// filesystem), falls back to copy + chmod + remove on cross-device.
+// atomicInstallBinary installs the binary at src to dest using the
+// sibling-temp + rename pattern. A temp file is created in the same directory
+// as dest (same filesystem), so os.Rename always succeeds without crossing a
+// device boundary. Rename replaces the directory entry atomically: a running
+// process keeps its old inode until exit, so this succeeds even when dest is a
+// busy/executing binary (avoids ETXTBSY from in-place O_TRUNC writes).
+func atomicInstallBinary(src, dest string) error {
+	destDir := filepath.Dir(dest)
+	tmp, err := os.CreateTemp(destDir, ".wipnote-upgrade-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating sibling temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	// Cleanup on any error so we never leave a .tmp turd behind.
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	in, err := os.Open(src)
+	if err != nil {
+		tmp.Close()
+		return fmt.Errorf("opening source binary: %w", err)
+	}
+	defer in.Close()
+
+	if _, err := io.Copy(tmp, in); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing temp binary: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("syncing temp binary: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp binary: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0o755); err != nil {
+		return fmt.Errorf("chmod temp binary: %w", err)
+	}
+	if err := os.Rename(tmpPath, dest); err != nil {
+		return fmt.Errorf("renaming temp to dest: %w", err)
+	}
+	success = true
+	return nil
+}
+
+// atomicReplace replaces dest with src using atomicInstallBinary (sibling-temp
+// + rename), which avoids ETXTBSY when dest is a currently-running executable.
 func atomicReplace(src, dest string) error {
-	if err := os.Rename(src, dest); err == nil {
-		return nil
-	}
-	// Cross-device fallback.
-	if err := copyBinary(src, dest); err != nil {
-		return err
-	}
-	return os.Remove(src)
+	return atomicInstallBinary(src, dest)
 }
 
 // checkWritable verifies the directory is writable by attempting to create a

--- a/cmd/wipnote/upgrade_extract_test.go
+++ b/cmd/wipnote/upgrade_extract_test.go
@@ -150,6 +150,65 @@ func TestExtractArchive_RejectsPathTraversal(t *testing.T) {
 	}
 }
 
+// TestAtomicInstallBinary verifies the sibling-temp + rename install path used
+// by atomicReplace. It confirms:
+//   - Correct content is written to the destination.
+//   - Destination is executable (0755).
+//   - Renaming over an existing file succeeds (simulates the "busy binary" case
+//     on Linux where O_TRUNC would return ETXTBSY).
+//   - No leftover .wipnote-upgrade-*.tmp turd in the install dir.
+func TestAtomicInstallBinary(t *testing.T) {
+	srcDir := t.TempDir()
+	installDir := t.TempDir()
+
+	// Write a fake binary in a separate source directory.
+	src := filepath.Join(srcDir, "wipnote")
+	wantContent := []byte("fake-binary-content-v2")
+	if err := os.WriteFile(src, wantContent, 0o755); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	dest := filepath.Join(installDir, "wipnote")
+
+	// Pre-populate dest so rename-over-existing is exercised.
+	if err := os.WriteFile(dest, []byte("old-content"), 0o755); err != nil {
+		t.Fatalf("write old dest: %v", err)
+	}
+
+	if err := atomicInstallBinary(src, dest); err != nil {
+		t.Fatalf("atomicInstallBinary: %v", err)
+	}
+
+	// Content must be the new binary.
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(got) != string(wantContent) {
+		t.Errorf("dest content = %q, want %q", got, wantContent)
+	}
+
+	// Must be executable.
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("dest not executable: mode=%o", info.Mode().Perm())
+	}
+
+	// No .wipnote-upgrade-*.tmp turds must be left behind.
+	entries, err := os.ReadDir(installDir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "wipnote" {
+			t.Errorf("unexpected leftover file in install dir: %s", e.Name())
+		}
+	}
+}
+
 // TestCopyDirRecursive_PreservesModes ensures that the cross-device fallback
 // in installPluginTree preserves executable permissions (e.g. for hooks/bin/*.sh).
 func TestCopyDirRecursive_PreservesModes(t *testing.T) {

--- a/packages/plugin-core/manifest.json
+++ b/packages/plugin-core/manifest.json
@@ -3,7 +3,7 @@
   "_comment": "Single source of truth for the wipnote CLI companion plugin. Both the Claude Code plugin (plugin/) and the Codex CLI marketplace (port/packages/codex-marketplace/) are generated from this file by `wipnote plugin build-ports`. Assets (commands, agents, skills, templates, static, config) are sourced from plugin/ verbatim — same markdown format works for both Claude and Codex.",
 
   "name": "wipnote",
-  "version": "0.64.1",
+  "version": "0.64.2",
   "description": "Local-first observability and coordination platform for AI-assisted development. Go binary hooks for near-zero cold start.",
   "author": {
     "name": "Shakes Dlamini",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wipnote",
-  "version": "0.64.1",
+  "version": "0.64.2",
   "description": "Local-first observability and coordination platform for AI-assisted development. Go binary hooks for near-zero cold start.",
   "author": {
     "name": "Shakes Dlamini"

--- a/port/packages/antigravity-extension/plugin.json
+++ b/port/packages/antigravity-extension/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wipnote",
-  "version": "0.64.1",
+  "version": "0.64.2",
   "description": "Local-first observability and coordination platform for AI-assisted development. Go binary hooks for near-zero cold start.",
   "author": {
     "name": "Shakes Dlamini"

--- a/port/packages/codex-marketplace/.agents/plugins/wipnote/.codex-plugin/plugin.json
+++ b/port/packages/codex-marketplace/.agents/plugins/wipnote/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wipnote",
-  "version": "0.64.1",
+  "version": "0.64.2",
   "description": "Local-first observability and coordination platform for AI-assisted development. Go binary hooks for near-zero cold start.",
   "author": {
     "name": "Shakes Dlamini",

--- a/port/packages/gemini-extension/gemini-extension.json
+++ b/port/packages/gemini-extension/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "wipnote",
-  "version": "0.64.1",
+  "version": "0.64.2",
   "description": "Local-first observability and coordination platform for AI-assisted development. Go binary hooks for near-zero cold start.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary

- **Root cause:** `atomicReplace` in `upgrade_cmd.go` tried `os.Rename(src, dest)` first (src lives in `/tmp`, dest in `~/.local/bin` — cross-device, fails with EXDEV), then fell back to `copyBinary(src, dest)` which opens the running target binary with `O_WRONLY|O_CREATE|O_TRUNC`, producing ETXTBSY on Linux when any wipnote process is executing it.
- **Fix:** Added `atomicInstallBinary(src, dest)` that creates a sibling temp file in `filepath.Dir(dest)` (same filesystem as the install target), streams the binary into it, fsyncs, chmods 0755, then renames over the destination. `rename(2)` replaces the directory entry atomically and succeeds even when the target is running — processes retain the old inode until exit. Deferred cleanup removes the temp on any error path to avoid `.tmp` turds.
- **No shared helper needed:** The build path (`build.go`) already does this correctly (`os.CreateTemp(installDir, ...)` + rename); the upgrade path was the only one missing this pattern. `atomicReplace` is now a one-liner wrapper over `atomicInstallBinary` to preserve the existing call site.

Fixes bug-a199c652. Same family as bug-8fd0fac2 (build non-atomic install).

## Test plan

- [x] Added `TestAtomicInstallBinary` in `cmd/wipnote/upgrade_extract_test.go`: renames over an existing file, asserts correct content, executable perms (0755), and no leftover `.wipnote-upgrade-*.tmp` files in the install dir.
- [x] `go build ./... && go vet ./...` pass clean.
- [x] `go test ./cmd/wipnote/ -run 'Upgrade|Install|Atomic'` — all pass including `TestAtomicInstallBinary`.
- [x] Verification binary built to isolated path (`$TMPDIR/wipnote-verify`) without touching shared install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qc9M9moQLTNNWwvnixurCh