### PR TITLE
fix(launcher): atomic upgrade install (ETXTBSY) + unified codex launch banners

### DIFF
--- a/cmd/wipnote/codex.go
+++ b/cmd/wipnote/codex.go
@@ -55,10 +55,8 @@ const codexMarketplaceSection = `[marketplaces.wipnote]`
 const codexPluginID = "wipnote@wipnote"
 const codexLocalPluginCacheVersion = "local"
 
-func printCodexLaunchBanner(headline string) {
-	fmt.Println(launchtui.RenderLaunchBanner(nil, launchtui.BannerInput{Headline: headline}))
-}
-
+// printCodexSetupSummary renders a summary banner for runCodexInit (--init mode).
+// In-launch setup details are folded into the launch banner by prepareCodexMarketplace.
 func printCodexSetupSummary(details []launchtui.BannerDetail) {
 	if len(details) == 0 {
 		return
@@ -69,6 +67,10 @@ func printCodexSetupSummary(details []launchtui.BannerDetail) {
 	}))
 }
 
+// renderCodexWarningBanner renders a visually distinct warning notice.
+// It is kept separate because sandbox degradation is discovered inside execCodex,
+// after the main launch banner has already been printed. Using the same
+// RenderLaunchBanner helper keeps the border style consistent.
 func renderCodexWarningBanner(warning string) string {
 	return launchtui.RenderLaunchBanner(nil, launchtui.BannerInput{
 		Headline:        "Codex launch notice",
@@ -1102,13 +1104,17 @@ func launchCodexDefaultWithMarketplace(resumeID, trackID, featureID, worktreePat
 	}
 	configPath := codexConfigPath()
 
-	if err := prepareCodexMarketplace(configPath, source, dryRun); err != nil {
+	setupDetails, err := prepareCodexMarketplace(configPath, source, dryRun)
+	if err != nil {
 		return err
 	}
 
 	if source == codexMarketplaceSourceDev && dryRun {
 		previewTarget := plannedCodexLaunchTarget(launchPlan, worktreePath, trackID, featureID, workItem, noWorktree, canonicalRoot)
-		printCodexLaunchBanner("Launching Codex CLI with wipnote context...")
+		fmt.Println(launchtui.RenderLaunchBanner(nil, launchtui.BannerInput{
+			Headline: "Launching Codex CLI with wipnote context (dev, dry-run)...",
+			Details:  setupDetails,
+		}))
 		fmt.Printf("[dry-run] would exec: codex (resume=%q, target=%s) in %s\n", resumeID, previewTarget, projectRoot)
 		return nil
 	}
@@ -1173,7 +1179,14 @@ func launchCodexDefaultWithMarketplace(resumeID, trackID, featureID, worktreePat
 		emitWorktreeCarryoverMessage(launchPlan, effectiveRoot, workDir, worktreeCreated, os.Stdout)
 	}
 
-	printCodexLaunchBanner("Launching Codex CLI with wipnote context...")
+	// Render a single launch banner combining prep/setup details and the
+	// launch headline — mirrors claude.go's one-banner-per-launch-path idiom
+	// (bug-2a6a8076). The sandbox-degradation warning fires inside execCodexFn
+	// and is the only banner that may follow (conditional, visually distinct).
+	fmt.Println(launchtui.RenderLaunchBanner(nil, launchtui.BannerInput{
+		Headline: "Launching Codex CLI with wipnote context...",
+		Details:  setupDetails,
+	}))
 	err = execCodexFn(codexLaunchOpts{
 		ResumeID:     resumeID,
 		ExtraArgs:    extraArgs,
@@ -1302,7 +1315,10 @@ func launchCodexDev(resumeID string, cleanup, dryRun, yolo bool, extraArgs []str
 	return launchCodexDefaultWithMarketplace(resumeID, trackID, featureID, worktreePath, workItem, noWorktree, yolo, extraArgs, codexMarketplaceSourceDev, cleanup, dryRun)
 }
 
-func prepareCodexMarketplace(configPath string, source codexMarketplaceSource, dryRun bool) error {
+// prepareCodexMarketplace runs pre-launch marketplace setup and returns any
+// noteworthy setup actions as BannerDetail rows for the caller to fold into
+// the single launch banner (rather than printing separate setup/launch boxes).
+func prepareCodexMarketplace(configPath string, source codexMarketplaceSource, dryRun bool) ([]launchtui.BannerDetail, error) {
 	switch source {
 	case codexMarketplaceSourceDev:
 		return prepareCodexDevMarketplace(configPath, dryRun)
@@ -1311,17 +1327,19 @@ func prepareCodexMarketplace(configPath string, source codexMarketplaceSource, d
 	}
 }
 
-func prepareCodexBundledMarketplace(configPath string) error {
+// prepareCodexBundledMarketplace sets up the bundled marketplace and returns
+// any noteworthy actions as BannerDetail rows (no banner rendered here).
+func prepareCodexBundledMarketplace(configPath string) ([]launchtui.BannerDetail, error) {
 	var setup []launchtui.BannerDetail
 	if !isCodexMarketplaceInstalledAt(configPath) {
 		bundled, err := resolveSharedTreePath("codex-marketplace")
 		if err != nil {
-			return fmt.Errorf("resolving bundled Codex marketplace: %w", err)
+			return nil, fmt.Errorf("resolving bundled Codex marketplace: %w", err)
 		}
 		bundledDir := codexMarketplaceAddArg(bundled)
 		if out, addErr := exec.Command("codex", "plugin", "marketplace", "add", bundledDir).CombinedOutput(); addErr != nil {
 			outStr := strings.TrimSpace(string(out))
-			return fmt.Errorf("WIPNOTE AGENTS NOT LOADED\n─────────────────────────\nFailed to register the wipnote marketplace with Codex CLI:\n  %v\n\nThe Codex session will run WITHOUT wipnote agents (researcher, feature-coder, etc.).\n\nTry:\n  - Run `wipnote codex --init` manually to retry the setup\n  - Check ~/.codex/config.toml for a stale marketplace entry under [plugins.\"wipnote@wipnote\"]\n  - Report this at https://github.com/shakestzd/wipnote/issues\n\nOutput:\n%s", addErr, outStr)
+			return nil, fmt.Errorf("WIPNOTE AGENTS NOT LOADED\n─────────────────────────\nFailed to register the wipnote marketplace with Codex CLI:\n  %v\n\nThe Codex session will run WITHOUT wipnote agents (researcher, feature-coder, etc.).\n\nTry:\n  - Run `wipnote codex --init` manually to retry the setup\n  - Check ~/.codex/config.toml for a stale marketplace entry under [plugins.\"wipnote@wipnote\"]\n  - Report this at https://github.com/shakestzd/wipnote/issues\n\nOutput:\n%s", addErr, outStr)
 		}
 		setup = append(setup, launchtui.BannerDetail{Label: "Marketplace", Value: "registered (bundled): " + bundledDir})
 	}
@@ -1340,10 +1358,9 @@ func prepareCodexBundledMarketplace(configPath string) error {
 		}
 	}
 	if err := refreshCodexPluginCacheBestEffort(configPath, &setup); err != nil {
-		return err
+		return nil, err
 	}
-	printCodexSetupSummary(setup)
-	return nil
+	return setup, nil
 }
 
 func refreshCodexPluginCacheBestEffort(configPath string, setup *[]launchtui.BannerDetail) error {
@@ -1376,15 +1393,16 @@ func refreshCodexPluginCacheBestEffort(configPath string, setup *[]launchtui.Ban
 	return nil
 }
 
-func prepareCodexDevMarketplace(configPath string, dryRun bool) error {
+// prepareCodexDevMarketplace sets up the local dev marketplace and returns
+// noteworthy actions as BannerDetail rows for the caller to fold into the
+// single launch banner (no separate "Preparing..." banner rendered here).
+func prepareCodexDevMarketplace(configPath string, dryRun bool) ([]launchtui.BannerDetail, error) {
 	localMarketplace, err := resolveLocalCodexMarketplace()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	fmt.Println(launchtui.RenderLaunchBanner(nil, launchtui.BannerInput{
-		Headline: "Preparing Codex CLI dev mode",
-		Details:  []launchtui.BannerDetail{{Label: "Local marketplace", Value: localMarketplace}},
-	}))
+	var setup []launchtui.BannerDetail
+	setup = append(setup, launchtui.BannerDetail{Label: "Local marketplace", Value: localMarketplace})
 	registeredPath := getCodexMarketplacePathAt(configPath)
 	localAbs, _ := filepath.Abs(localMarketplace)
 	registeredAbs, _ := filepath.Abs(registeredPath)
@@ -1393,16 +1411,15 @@ func prepareCodexDevMarketplace(configPath string, dryRun bool) error {
 		if oldPathDisplay == "" {
 			oldPathDisplay = "(unknown previous path)"
 		}
-		fmt.Printf("Replacing mismatched marketplace registration (%s)\n", oldPathDisplay)
 		if dryRun {
-			fmt.Printf("[dry-run] would remove wipnote registrations from %s\n", configPath)
+			setup = append(setup, launchtui.BannerDetail{Label: "Registration", Value: "[dry-run] would remove and replace (" + oldPathDisplay + ")"})
 		} else {
 			removed, rmErr := removeCodexWipnoteRegistrations(configPath)
 			if rmErr != nil {
-				return fmt.Errorf("removing mismatched marketplace from %s: %w", configPath, rmErr)
+				return nil, fmt.Errorf("removing mismatched marketplace from %s: %w", configPath, rmErr)
 			}
 			if removed {
-				fmt.Println("Mismatched registration removed from config.toml.")
+				setup = append(setup, launchtui.BannerDetail{Label: "Registration", Value: "replaced mismatched entry (" + oldPathDisplay + ")"})
 			}
 		}
 		registeredPath = ""
@@ -1412,45 +1429,53 @@ func prepareCodexDevMarketplace(configPath string, dryRun bool) error {
 	if registeredAbs != localDirAbs {
 		addArgs := []string{"plugin", "marketplace", "add", localDir}
 		if dryRun {
-			fmt.Printf("[dry-run] codex %s\n", strings.Join(addArgs, " "))
+			setup = append(setup, launchtui.BannerDetail{Label: "Marketplace", Value: "[dry-run] codex " + strings.Join(addArgs, " ")})
 		} else if out, err := exec.Command("codex", addArgs...).CombinedOutput(); err != nil {
-			return fmt.Errorf("registering local marketplace failed: %w\n%s", err, strings.TrimSpace(string(out)))
+			return nil, fmt.Errorf("registering local marketplace failed: %w\n%s", err, strings.TrimSpace(string(out)))
 		} else {
-			fmt.Println("Local marketplace registered.")
+			setup = append(setup, launchtui.BannerDetail{Label: "Marketplace", Value: "registered (local)"})
 		}
 	} else {
-		fmt.Println("Local marketplace already registered — proceeding.")
+		setup = append(setup, launchtui.BannerDetail{Label: "Marketplace", Value: "already registered (local)"})
 	}
 	if !dryRun && !isCodexHooksEnabledAt(configPath) {
 		if err := ensureCodexHooksEnabled(configPath); err != nil {
-			return fmt.Errorf("enabling hooks feature flag in %s: %w", configPath, err)
+			return nil, fmt.Errorf("enabling hooks feature flag in %s: %w", configPath, err)
 		}
-		fmt.Println("hooks feature flag enabled.")
+		setup = append(setup, launchtui.BannerDetail{Label: "Hooks flag", Value: "enabled"})
 	}
 	if !dryRun && !isCodexPluginEnabledAt(configPath) {
 		if err := ensureCodexPluginEnabled(configPath); err != nil {
-			return fmt.Errorf("enabling local wipnote plugin in %s: %w", configPath, err)
+			return nil, fmt.Errorf("enabling local wipnote plugin in %s: %w", configPath, err)
 		}
-		fmt.Println("Local wipnote plugin enabled.")
+		setup = append(setup, launchtui.BannerDetail{Label: "Plugin", Value: "enabled (local)"})
 	}
 	if dryRun {
-		fmt.Println("[dry-run] would install local wipnote plugin cache")
-		fmt.Println("[dry-run] would remove mirrored wipnote hooks from ~/.codex/hooks.json")
-		fmt.Println("[dry-run] would install wipnote Codex agents into ~/.codex/agents")
-		return nil
+		setup = append(setup, launchtui.BannerDetail{Label: "Plugin cache", Value: "[dry-run] would install locally"})
+		setup = append(setup, launchtui.BannerDetail{Label: "Hooks", Value: "[dry-run] would remove mirrored hooks from ~/.codex/hooks.json"})
+		setup = append(setup, launchtui.BannerDetail{Label: "Agents", Value: "[dry-run] would install wipnote agents into ~/.codex/agents"})
+		return setup, nil
 	}
-	return refreshCodexPluginCacheDev(configPath)
+	cacheDetails, err := refreshCodexPluginCacheDev(configPath)
+	if err != nil {
+		return nil, err
+	}
+	setup = append(setup, cacheDetails...)
+	return setup, nil
 }
 
-func refreshCodexPluginCacheDev(configPath string) error {
+// refreshCodexPluginCacheDev refreshes the local dev plugin cache and returns
+// any noteworthy actions as BannerDetail rows for the caller to fold into the
+// single launch banner (no banner rendered here).
+func refreshCodexPluginCacheDev(configPath string) ([]launchtui.BannerDetail, error) {
 	var setup []launchtui.BannerDetail
 	if installed, err := ensureCodexLocalPluginInstalled(configPath, true); err != nil {
-		return fmt.Errorf("installing local wipnote plugin cache: %w", err)
+		return nil, fmt.Errorf("installing local wipnote plugin cache: %w", err)
 	} else if installed {
 		setup = append(setup, launchtui.BannerDetail{Label: "Plugin cache", Value: "installed locally"})
 	}
 	if changed, err := pruneCodexGlobalHooksFromCache(); err != nil {
-		return fmt.Errorf("removing mirrored wipnote Codex hooks: %w", err)
+		return nil, fmt.Errorf("removing mirrored wipnote Codex hooks: %w", err)
 	} else if changed {
 		setup = append(setup, launchtui.BannerDetail{Label: "Mirrored hooks", Value: "removed from ~/.codex/hooks.json"})
 	} else {
@@ -1458,18 +1483,17 @@ func refreshCodexPluginCacheDev(configPath string) error {
 	}
 	pluginDir := codexInstalledPluginDirAt(codexPluginCachePath())
 	if changed, err := ensureCodexCustomAgentsInstalled(pluginDir, codexAgentsPath()); err != nil {
-		return fmt.Errorf("installing wipnote Codex agents: %w", err)
+		return nil, fmt.Errorf("installing wipnote Codex agents: %w", err)
 	} else if changed {
 		setup = append(setup, launchtui.BannerDetail{Label: "User agents", Value: "installed in ~/.codex/agents"})
 	}
 	projectRoot, _ := resolveProjectRoot()
 	if changed, err := ensureCodexCustomAgentsInstalled(pluginDir, codexProjectAgentsPath(projectRoot)); err != nil {
-		return fmt.Errorf("installing project wipnote Codex agents: %w", err)
+		return nil, fmt.Errorf("installing project wipnote Codex agents: %w", err)
 	} else if changed {
 		setup = append(setup, launchtui.BannerDetail{Label: "Project agents", Value: "installed in .codex/agents"})
 	}
-	printCodexSetupSummary(setup)
-	return nil
+	return setup, nil
 }
 
 // resolveLocalCodexMarketplace returns the absolute path to packages/codex-marketplace/

--- a/cmd/wipnote/codex_test.go
+++ b/cmd/wipnote/codex_test.go
@@ -1156,7 +1156,7 @@ func TestPrepareCodexDevMarketplace_RefreshesLocalCache(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWD) })
 
-	if err := prepareCodexDevMarketplace(filepath.Join(home, ".codex", "config.toml"), false); err != nil {
+	if _, err := prepareCodexDevMarketplace(filepath.Join(home, ".codex", "config.toml"), false); err != nil {
 		t.Fatalf("prepareCodexDevMarketplace: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(codexPluginCachePath(), codexLocalPluginCacheVersion, ".codex-plugin", "plugin.json")); err != nil {
@@ -1204,32 +1204,26 @@ func TestPrepareCodexDevMarketplace_DryRunDoesNotMutateCache(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWD) })
 
-	out := &strings.Builder{}
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-	done := make(chan struct{})
-	go func() {
-		_, _ = io.Copy(out, r)
-		close(done)
-	}()
-	t.Cleanup(func() { os.Stdout = oldStdout })
-
-	if err := prepareCodexDevMarketplace(filepath.Join(home, ".codex", "config.toml"), true); err != nil {
+	// prepareCodexDevMarketplace now returns BannerDetail rows instead of printing
+	// them directly; the caller folds them into the single launch banner.
+	details, err := prepareCodexDevMarketplace(filepath.Join(home, ".codex", "config.toml"), true)
+	if err != nil {
 		t.Fatalf("prepareCodexDevMarketplace dry-run: %v", err)
 	}
-	_ = w.Close()
-	<-done
-	got := out.String()
+	// Flatten all returned detail values for substring matching.
+	var detailValues strings.Builder
+	for _, d := range details {
+		detailValues.WriteString(d.Label + ": " + d.Value + "\n")
+	}
+	got := detailValues.String()
 	for _, want := range []string{
-		"[dry-run] would remove wipnote registrations",
 		"[dry-run] codex plugin marketplace add",
-		"[dry-run] would install local wipnote plugin cache",
-		"[dry-run] would remove mirrored wipnote hooks",
-		"[dry-run] would install wipnote Codex agents",
+		"[dry-run] would install locally",
+		"[dry-run] would remove mirrored hooks",
+		"[dry-run] would install wipnote agents",
 	} {
 		if !strings.Contains(got, want) {
-			t.Fatalf("dry-run output missing %q:\n%s", want, got)
+			t.Fatalf("dry-run details missing %q:\n%s", want, got)
 		}
 	}
 	if _, err := os.Stat(filepath.Join(codexPluginCachePath(), codexLocalPluginCacheVersion)); !os.IsNotExist(err) {
@@ -1271,7 +1265,7 @@ func TestPrepareCodexBundledMarketplace_RepairsWhenAlreadyInstalled(t *testing.T
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWD) })
 
-	if err := prepareCodexBundledMarketplace(filepath.Join(home, ".codex", "config.toml")); err != nil {
+	if _, err := prepareCodexBundledMarketplace(filepath.Join(home, ".codex", "config.toml")); err != nil {
 		t.Fatalf("prepareCodexBundledMarketplace: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(codexPluginCachePath(), codexLocalPluginCacheVersion, ".codex-plugin", "plugin.json")); err != nil {

--- a/cmd/wipnote/upgrade_cmd.go
+++ b/cmd/wipnote/upgrade_cmd.go
@@ -497,17 +497,60 @@ func copyDirRecursive(src, dst string) error {
 	})
 }
 
-// atomicReplace replaces dest with src. Tries os.Rename first (atomic on same
-// filesystem), falls back to copy + chmod + remove on cross-device.
+// atomicInstallBinary installs the binary at src to dest using the
+// sibling-temp + rename pattern. A temp file is created in the same directory
+// as dest (same filesystem), so os.Rename always succeeds without crossing a
+// device boundary. Rename replaces the directory entry atomically: a running
+// process keeps its old inode until exit, so this succeeds even when dest is a
+// busy/executing binary (avoids ETXTBSY from in-place O_TRUNC writes).
+func atomicInstallBinary(src, dest string) error {
+	destDir := filepath.Dir(dest)
+	tmp, err := os.CreateTemp(destDir, ".wipnote-upgrade-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating sibling temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	// Cleanup on any error so we never leave a .tmp turd behind.
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	in, err := os.Open(src)
+	if err != nil {
+		tmp.Close()
+		return fmt.Errorf("opening source binary: %w", err)
+	}
+	defer in.Close()
+
+	if _, err := io.Copy(tmp, in); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing temp binary: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("syncing temp binary: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp binary: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0o755); err != nil {
+		return fmt.Errorf("chmod temp binary: %w", err)
+	}
+	if err := os.Rename(tmpPath, dest); err != nil {
+		return fmt.Errorf("renaming temp to dest: %w", err)
+	}
+	success = true
+	return nil
+}
+
+// atomicReplace replaces dest with src using atomicInstallBinary (sibling-temp
+// + rename), which avoids ETXTBSY when dest is a currently-running executable.
 func atomicReplace(src, dest string) error {
-	if err := os.Rename(src, dest); err == nil {
-		return nil
-	}
-	// Cross-device fallback.
-	if err := copyBinary(src, dest); err != nil {
-		return err
-	}
-	return os.Remove(src)
+	return atomicInstallBinary(src, dest)
 }
 
 // checkWritable verifies the directory is writable by attempting to create a

--- a/cmd/wipnote/upgrade_extract_test.go
+++ b/cmd/wipnote/upgrade_extract_test.go
@@ -150,6 +150,65 @@ func TestExtractArchive_RejectsPathTraversal(t *testing.T) {
 	}
 }
 
+// TestAtomicInstallBinary verifies the sibling-temp + rename install path used
+// by atomicReplace. It confirms:
+//   - Correct content is written to the destination.
+//   - Destination is executable (0755).
+//   - Renaming over an existing file succeeds (simulates the "busy binary" case
+//     on Linux where O_TRUNC would return ETXTBSY).
+//   - No leftover .wipnote-upgrade-*.tmp turd in the install dir.
+func TestAtomicInstallBinary(t *testing.T) {
+	srcDir := t.TempDir()
+	installDir := t.TempDir()
+
+	// Write a fake binary in a separate source directory.
+	src := filepath.Join(srcDir, "wipnote")
+	wantContent := []byte("fake-binary-content-v2")
+	if err := os.WriteFile(src, wantContent, 0o755); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	dest := filepath.Join(installDir, "wipnote")
+
+	// Pre-populate dest so rename-over-existing is exercised.
+	if err := os.WriteFile(dest, []byte("old-content"), 0o755); err != nil {
+		t.Fatalf("write old dest: %v", err)
+	}
+
+	if err := atomicInstallBinary(src, dest); err != nil {
+		t.Fatalf("atomicInstallBinary: %v", err)
+	}
+
+	// Content must be the new binary.
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(got) != string(wantContent) {
+		t.Errorf("dest content = %q, want %q", got, wantContent)
+	}
+
+	// Must be executable.
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("dest not executable: mode=%o", info.Mode().Perm())
+	}
+
+	// No .wipnote-upgrade-*.tmp turds must be left behind.
+	entries, err := os.ReadDir(installDir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "wipnote" {
+			t.Errorf("unexpected leftover file in install dir: %s", e.Name())
+		}
+	}
+}
+
 // TestCopyDirRecursive_PreservesModes ensures that the cross-device fallback
 // in installPluginTree preserves executable permissions (e.g. for hooks/bin/*.sh).
 func TestCopyDirRecursive_PreservesModes(t *testing.T) {


### PR DESCRIPTION
Two independent launcher/install fixes, re-applied as clean commits off current main. Supersedes #139 and #140, which were closed because their diffs were polluted with unrelated work-item artifacts swept in from worktree bug-start.

## fix(upgrade): atomic sibling-temp + rename install (bug-a199c652)
`wipnote upgrade` installed by opening the running binary in place, failing with ETXTBSY whenever a wipnote process was executing it. `atomicReplace` also had a broken cross-device fallback (os.Rename EXDEV then copyBinary O_TRUNC over the busy target). New `atomicInstallBinary` writes a sibling temp in the destination dir (same filesystem), fsync, chmod 0755, then os.Rename over the target — atomic and succeeds on a busy executable (running processes keep the old inode until exit). Adds `TestAtomicInstallBinary`.

## fix(codex): unify launch banner widths (bug-2a6a8076)
`wipnote codex` rendered 4 independently auto-sized launch banners at inconsistent widths. The prepare/setup/launch helpers now return `[]launchtui.BannerDetail` and `launchCodexDefaultWithMarketplace` renders one combined `RenderLaunchBanner`; the post-launch sandbox-degradation notice stays a separate banner. Removes `printCodexLaunchBanner`. Mirrors the claude.go unification.

## Verification
`go build ./... && go vet ./...` pass; scoped tests pass (incl. TestAtomicInstallBinary); `wipnote build` -> v0.64.2-2-g62a60aac3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)