### PR TITLE
Session/collector reaper — liveness detection → remediation (plan-5748e9a8)

### DIFF
--- a/cmd/wipnote/config.go
+++ b/cmd/wipnote/config.go
@@ -71,6 +71,21 @@ func startOrphanDrainLoop(ctx context.Context, writeDB *sql.DB, projectRoot stri
 	})
 }
 
+// startReaperLoop runs the session/collector reaper on a low frequency inside the
+// headless writer daemon. currentSessionID="" — the daemon owns no interactive
+// session (excludes nothing extra). includeCollectors=true — the daemon is the
+// ONLY place orphaned collectors are reaped. reportOnly is driven by the
+// reaper_daemon_report_only config knob (default false ⇒ remediate). Best-effort;
+// shares the single writable handle; stops on ctx cancellation.
+func startReaperLoop(ctx context.Context, writeDB *sql.DB, projectRoot string) {
+	if writeDB == nil || projectRoot == "" {
+		return
+	}
+	startDrainLoop(ctx, orphanDrainInterval, func() {
+		hooks.ReapStaleSessionsAndCollectors(writeDB, projectRoot, "", true, hooks.ReaperDaemonReportOnly(projectRoot))
+	})
+}
+
 // startReconcileDrainLoop auto-commits done-but-uncommitted work-item artifacts
 // off the hot path (feat-c08d1ba1 slice-6). The Stop hook no longer runs this
 // per-item git fork loop synchronously (it was the ~5.45s per-turn cost); this

--- a/cmd/wipnote/config.go
+++ b/cmd/wipnote/config.go
@@ -82,7 +82,7 @@ func startReaperLoop(ctx context.Context, writeDB *sql.DB, projectRoot string) {
 		return
 	}
 	startDrainLoop(ctx, orphanDrainInterval, func() {
-		hooks.ReapStaleSessionsAndCollectors(writeDB, projectRoot, "", true, hooks.ReaperDaemonReportOnly(projectRoot))
+		hooks.ReapStaleSessionsAndCollectors(writeDB, projectRoot, "", true, hooks.ReaperDaemonReportOnly(projectRoot), 0 /*unbounded*/)
 	})
 }
 

--- a/cmd/wipnote/dashboard_pane_test.go
+++ b/cmd/wipnote/dashboard_pane_test.go
@@ -76,9 +76,10 @@ func TestResumeViewPresentInHTML(t *testing.T) {
 	}
 	html := string(data)
 
+	// The standalone Resume tab (data-view="resume" / id="v-resume") was merged
+	// into the Sessions view (feat-021786c9); only the resumable-items content
+	// markers remain, now rendered inside the Sessions pane. Assert those.
 	for _, want := range []string{
-		`data-view="resume"`,
-		`id="v-resume"`,
 		`id="resume-count"`,
 		`id="resume-body"`,
 		`id="resume-empty"`,
@@ -86,7 +87,7 @@ func TestResumeViewPresentInHTML(t *testing.T) {
 		`id="resume-error"`,
 	} {
 		if !strings.Contains(html, want) {
-			t.Errorf("dashboard HTML missing resume view marker %q", want)
+			t.Errorf("dashboard HTML missing resumable-items marker %q", want)
 		}
 	}
 }

--- a/cmd/wipnote/reaper_loop_test.go
+++ b/cmd/wipnote/reaper_loop_test.go
@@ -95,7 +95,7 @@ func TestDaemonPassReapsOrphanCollector(t *testing.T) {
 	}
 
 	// Run the daemon-loop body directly: sessions + collectors, remediate.
-	rep := hooks.ReapStaleSessionsAndCollectors(database, projectRoot, "", true, false)
+	rep := hooks.ReapStaleSessionsAndCollectors(database, projectRoot, "", true, false, 0)
 	if rep == nil {
 		t.Fatal("ReapStaleSessionsAndCollectors returned nil report")
 	}

--- a/cmd/wipnote/reaper_loop_test.go
+++ b/cmd/wipnote/reaper_loop_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	dbpkg "github.com/shakestzd/wipnote/core/db"
+	"github.com/shakestzd/wipnote/core/hooks"
+	"github.com/shakestzd/wipnote/core/models"
+	"github.com/shakestzd/wipnote/observe/otel/collector"
+)
+
+// TestStartReaperLoopNoOp proves the nil/empty guards: startReaperLoop must
+// return without panic when writeDB is nil OR projectRoot is empty, so a
+// mis-wired daemon never crashes.
+func TestStartReaperLoopNoOp(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// nil DB → guarded return, no goroutine, no panic.
+	startReaperLoop(ctx, nil, "")
+
+	// non-nil DB but empty projectRoot → guarded return, no panic.
+	dbPath := filepath.Join(t.TempDir(), "wipnote.db")
+	database, err := dbpkg.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer database.Close()
+	startReaperLoop(ctx, database, "")
+}
+
+// TestDaemonPassReapsOrphanCollector exercises the daemon-loop BODY directly
+// (avoiding goroutine/ticker timing flakiness): a single
+// ReapStaleSessionsAndCollectors(writeDB, projectRoot, "", includeCollectors=true,
+// reportOnly=false) call — exactly what startReaperLoop ticks. The
+// observe/register init() (blank-imported by cmd/wipnote's main) wires the live
+// ReapCollectorFn seam, so this proves the daemon path reaps BOTH a stale session
+// AND a real orphaned collector subprocess. This complements the core/hooks test
+// that proves the HOOK path leaves collectors untouched.
+func TestDaemonPassReapsOrphanCollector(t *testing.T) {
+	projectRoot := t.TempDir()
+	dbPath := filepath.Join(projectRoot, ".wipnote", "wipnote.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir .wipnote: %v", err)
+	}
+	database, err := dbpkg.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer database.Close()
+
+	// Seed a stale-active session: no claim ⇒ heartbeat stale; dead .session-pid
+	// ⇒ owner process provably dead ⇒ reap-eligible.
+	const sid = "sess-daemon-orphan-001"
+	if err := dbpkg.InsertSession(database, &models.Session{
+		SessionID:     sid,
+		AgentAssigned: "claude-code",
+		Status:        "active",
+		CreatedAt:     time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+	sessDir := filepath.Join(projectRoot, ".wipnote", "sessions", sid)
+	if err := os.MkdirAll(sessDir, 0o755); err != nil {
+		t.Fatalf("mkdir sessDir: %v", err)
+	}
+	// Dead .session-pid: max int32 pid + a start-time line (never running).
+	if err := os.WriteFile(filepath.Join(sessDir, ".session-pid"), []byte("2147483647\n1"), 0o644); err != nil {
+		t.Fatalf("write .session-pid: %v", err)
+	}
+
+	// Spawn a REAL orphan collector subprocess and register it via
+	// WriteCollectorPID (records pid + /proc start time → IsCollectorAlive matches).
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	childPID := cmd.Process.Pid
+	t.Cleanup(func() {
+		// Defensive: ensure the child is gone even if an assertion fails first.
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	collector.WriteCollectorPID(projectRoot, sid, childPID)
+
+	collectorPID := filepath.Join(sessDir, ".collector-pid")
+	if _, err := os.Stat(collectorPID); err != nil {
+		t.Fatalf("precondition: .collector-pid must exist before reap: %v", err)
+	}
+
+	// Run the daemon-loop body directly: sessions + collectors, remediate.
+	rep := hooks.ReapStaleSessionsAndCollectors(database, projectRoot, "", true, false)
+	if rep == nil {
+		t.Fatal("ReapStaleSessionsAndCollectors returned nil report")
+	}
+
+	// (1) The session must be reaped (active → completed).
+	var status string
+	if err := database.QueryRow(`SELECT status FROM sessions WHERE session_id=?`, sid).Scan(&status); err != nil {
+		t.Fatalf("query session status: %v", err)
+	}
+	if status != "completed" {
+		t.Fatalf("session status=%q, want completed (daemon pass must reap stale session)", status)
+	}
+
+	// (2) The orphan collector subprocess must be killed. Reap the zombie, then
+	// kill(pid,0) must return ESRCH (no such process).
+	_, _ = cmd.Process.Wait()
+	if err := syscall.Kill(childPID, 0); err == nil {
+		t.Fatalf("collector pid %d should be dead after daemon reap", childPID)
+	}
+
+	// (3) The .collector-pid record must be cleared.
+	if _, err := os.Stat(collectorPID); !os.IsNotExist(err) {
+		t.Fatalf(".collector-pid must be removed after reaping the orphan collector (stat err=%v)", err)
+	}
+}

--- a/cmd/wipnote/serve_child.go
+++ b/cmd/wipnote/serve_child.go
@@ -309,6 +309,11 @@ func startWriterMaintenance(ctx context.Context, writeDB *sql.DB, wipnoteDir str
 	// that deterministic auto-commit off the interactive path so the durable
 	// record still lands in git.
 	startReconcileDrainLoop(ctx, writeDB, projectRoot)
+
+	// Periodic session/collector reaper (plan-5748e9a8): converts liveness detection
+	// into remediation — marks heartbeat-stale+process-dead active sessions ended and
+	// reaps identity-verified orphaned collectors. Dedicated pass, NOT full Reconcile.
+	startReaperLoop(ctx, writeDB, projectRoot)
 }
 
 // writerIdleTimeout resolves the headless writer's idle-exit window. It honours

--- a/cmd/wipnote/sqlite_write_boundary_test.go
+++ b/cmd/wipnote/sqlite_write_boundary_test.go
@@ -289,7 +289,7 @@ var approvedWriteSites = []writeSite{
 	},
 	{
 		File:           "cmd/wipnote/serve_child.go",
-		Line:           401,
+		Line:           406,
 		Function:       "runServeChild",
 		OpenExpr:       "dbpkg.OpenWritable",
 		Classification: intentionalCLIMutation,

--- a/core/hooks/lifecycle_injection.go
+++ b/core/hooks/lifecycle_injection.go
@@ -1,6 +1,9 @@
 package hooks
 
-import "database/sql"
+import (
+	"database/sql"
+	"time"
+)
 
 // Lifecycle injection points (feat-331927fb).
 //
@@ -28,4 +31,16 @@ var (
 	// not a plugin-core repo, or the checker is unavailable. Shared by the
 	// session-exit reconcile and the pre-commit port-drift guard.
 	PortDriftPathsFn func(repoRoot string) []string
+
+	// ReapCollectorFn terminates an identity-verified orphaned collector for sessDir
+	// (SIGTERM→grace→SIGKILL) and clears its .collector-pid. Returns the pid acted on
+	// and whether a live collector was actually reaped. nil ⇒ telemetry not wired ⇒
+	// collector reaping degrades to a no-op (best-effort, never block).
+	//
+	// The implementation lives in observe/otel/collector (ReapCollector) and is
+	// wired here by observe/register's init(). It is the identity-verified
+	// counterpart of the legacy signalCollector (which reads the pid as a raw int
+	// with NO start-time check): ReapCollector gates every kill on IsCollectorAlive,
+	// so a reused pid is never signalled.
+	ReapCollectorFn func(sessDir string, grace time.Duration) (pid int, reaped bool)
 )

--- a/core/hooks/reaper_config_test.go
+++ b/core/hooks/reaper_config_test.go
@@ -1,0 +1,127 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestReaperConfig(t *testing.T) {
+	t.Run("empty projectDir returns defaults", func(t *testing.T) {
+		if got := ReaperSessionTTL(""); got != 1800*time.Second {
+			t.Errorf("ReaperSessionTTL(\"\") = %v, want 1800s", got)
+		}
+		if got := ReaperCollectorGrace(""); got != 10*time.Second {
+			t.Errorf("ReaperCollectorGrace(\"\") = %v, want 10s", got)
+		}
+		if got := ReaperDaemonReportOnly(""); got != false {
+			t.Errorf("ReaperDaemonReportOnly(\"\") = %v, want false", got)
+		}
+	})
+
+	t.Run("missing config.json returns defaults", func(t *testing.T) {
+		dir := t.TempDir()
+		if got := ReaperSessionTTL(dir); got != 1800*time.Second {
+			t.Errorf("ReaperSessionTTL(no-config) = %v, want 1800s", got)
+		}
+		if got := ReaperCollectorGrace(dir); got != 10*time.Second {
+			t.Errorf("ReaperCollectorGrace(no-config) = %v, want 10s", got)
+		}
+		if got := ReaperDaemonReportOnly(dir); got != false {
+			t.Errorf("ReaperDaemonReportOnly(no-config) = %v, want false", got)
+		}
+	})
+
+	t.Run("valid config overrides are honored", func(t *testing.T) {
+		dir := t.TempDir()
+		configDir := filepath.Join(dir, ".wipnote")
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatalf("mkdir .wipnote: %v", err)
+		}
+		configJSON := `{
+			"reaper_session_ttl_seconds": 60,
+			"reaper_collector_grace_seconds": 3,
+			"reaper_daemon_report_only": true
+		}`
+		if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(configJSON), 0o644); err != nil {
+			t.Fatalf("write config.json: %v", err)
+		}
+
+		if got := ReaperSessionTTL(dir); got != 60*time.Second {
+			t.Errorf("ReaperSessionTTL = %v, want 60s", got)
+		}
+		if got := ReaperCollectorGrace(dir); got != 3*time.Second {
+			t.Errorf("ReaperCollectorGrace = %v, want 3s", got)
+		}
+		if got := ReaperDaemonReportOnly(dir); got != true {
+			t.Errorf("ReaperDaemonReportOnly = %v, want true", got)
+		}
+	})
+
+	t.Run("zero and negative overrides fall back to defaults", func(t *testing.T) {
+		dir := t.TempDir()
+		configDir := filepath.Join(dir, ".wipnote")
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatalf("mkdir .wipnote: %v", err)
+		}
+		configJSON := `{
+			"reaper_session_ttl_seconds": 0,
+			"reaper_collector_grace_seconds": -5
+		}`
+		if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(configJSON), 0o644); err != nil {
+			t.Fatalf("write config.json: %v", err)
+		}
+
+		if got := ReaperSessionTTL(dir); got != 1800*time.Second {
+			t.Errorf("ReaperSessionTTL(zero) = %v, want default 1800s", got)
+		}
+		if got := ReaperCollectorGrace(dir); got != 10*time.Second {
+			t.Errorf("ReaperCollectorGrace(negative) = %v, want default 10s", got)
+		}
+	})
+}
+
+func TestReaperReportOnly(t *testing.T) {
+	t.Run("true config returns true", func(t *testing.T) {
+		dir := t.TempDir()
+		configDir := filepath.Join(dir, ".wipnote")
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatalf("mkdir .wipnote: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"reaper_daemon_report_only": true}`), 0o644); err != nil {
+			t.Fatalf("write config.json: %v", err)
+		}
+		if got := ReaperDaemonReportOnly(dir); got != true {
+			t.Errorf("ReaperDaemonReportOnly = %v, want true", got)
+		}
+	})
+
+	t.Run("absent key returns false", func(t *testing.T) {
+		dir := t.TempDir()
+		configDir := filepath.Join(dir, ".wipnote")
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatalf("mkdir .wipnote: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{}`), 0o644); err != nil {
+			t.Fatalf("write config.json: %v", err)
+		}
+		if got := ReaperDaemonReportOnly(dir); got != false {
+			t.Errorf("ReaperDaemonReportOnly(absent) = %v, want false", got)
+		}
+	})
+
+	t.Run("explicit false returns false", func(t *testing.T) {
+		dir := t.TempDir()
+		configDir := filepath.Join(dir, ".wipnote")
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatalf("mkdir .wipnote: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"reaper_daemon_report_only": false}`), 0o644); err != nil {
+			t.Fatalf("write config.json: %v", err)
+		}
+		if got := ReaperDaemonReportOnly(dir); got != false {
+			t.Errorf("ReaperDaemonReportOnly(false) = %v, want false", got)
+		}
+	})
+}

--- a/core/hooks/reaper_pass_test.go
+++ b/core/hooks/reaper_pass_test.go
@@ -130,7 +130,7 @@ func TestReapStaleSessions(t *testing.T) {
 	seedFreshClaim(t, database, "sess-fresh-dead", "feat-reapr01")
 	writeDeadPID(t, mkSessDir("sess-fresh-dead"))
 
-	rep := ReapStaleSessionsAndCollectors(database, projectDir, current, false, false)
+	rep := ReapStaleSessionsAndCollectors(database, projectDir, current, false, false, 0)
 
 	if !contains(rep.ReapedSessions, "sess-stale-dead") {
 		t.Fatalf("sess-stale-dead must be reaped; ReapedSessions=%v", rep.ReapedSessions)
@@ -151,9 +151,127 @@ func TestReapStaleSessions(t *testing.T) {
 
 	// Idempotency: a second pass finds nothing — the already-completed row is no
 	// longer active, so RowsAffected is 0.
-	rep2 := ReapStaleSessionsAndCollectors(database, projectDir, current, false, false)
+	rep2 := ReapStaleSessionsAndCollectors(database, projectDir, current, false, false, 0)
 	if len(rep2.ReapedSessions) != 0 {
 		t.Fatalf("second pass must be a no-op, got ReapedSessions=%v", rep2.ReapedSessions)
+	}
+}
+
+// claimStatus reads a claim row's status directly so tests can assert that the
+// reaper released (abandoned) a reaped session's claims.
+func claimStatus(t *testing.T, database *sql.DB, claimID string) string {
+	t.Helper()
+	var status string
+	if err := database.QueryRow(`SELECT status FROM claims WHERE claim_id=?`, claimID).Scan(&status); err != nil {
+		t.Fatalf("query claim status %s: %v", claimID, err)
+	}
+	return status
+}
+
+// TestReapReleasesClaims proves FIX B: a REAL reap of a stale session releases
+// (abandons) its still-active claims — mirroring normal SessionEnd — so a crashed
+// session's claims no longer block claim paths. The reportOnly/dry-run branch
+// must NOT release claims.
+func TestReapReleasesClaims(t *testing.T) {
+	mkSessDir := func(projectDir, sid string) string {
+		return filepath.Join(projectDir, ".wipnote", "sessions", sid)
+	}
+
+	t.Run("real reap releases the claim", func(t *testing.T) {
+		td := setupTestDB(t)
+		database := td.DB
+		projectDir := t.TempDir()
+		td.addFeature("feat-reapclaim01", "feature", "reaper claim work", "in-progress")
+
+		const current = "sess-current"
+		seedReaperSession(t, database, current)
+
+		// Stale-dead session that HOLDS a claim. seedFreshClaim gives it an
+		// in-progress claim with a recent heartbeat, so to make it heartbeat-stale
+		// we age the claim's heartbeat below.
+		seedReaperSession(t, database, "sess-stale-claim")
+		seedFreshClaim(t, database, "sess-stale-claim", "feat-reapclaim01")
+		writeDeadPID(t, mkSessDir(projectDir, "sess-stale-claim"))
+		// Age the claim heartbeat far past any TTL so SessionLivenessByHeartbeat
+		// reports the session heartbeat-stale.
+		if _, err := database.Exec(
+			`UPDATE claims SET last_heartbeat_at=? WHERE claim_id=?`,
+			time.Now().Add(-72*time.Hour).UTC().Format(time.RFC3339), "claim-sess-stale-claim",
+		); err != nil {
+			t.Fatalf("age claim heartbeat: %v", err)
+		}
+
+		rep := ReapStaleSessionsAndCollectors(database, projectDir, current, false, false, 0)
+		if !contains(rep.ReapedSessions, "sess-stale-claim") {
+			t.Fatalf("sess-stale-claim must be reaped; ReapedSessions=%v", rep.ReapedSessions)
+		}
+		if got := claimStatus(t, database, "claim-sess-stale-claim"); got != string(models.ClaimAbandoned) {
+			t.Fatalf("reaped session's claim status=%q, want abandoned (claims must be released on reap)", got)
+		}
+	})
+
+	t.Run("report-only does NOT release the claim", func(t *testing.T) {
+		td := setupTestDB(t)
+		database := td.DB
+		projectDir := t.TempDir()
+		td.addFeature("feat-reapclaim02", "feature", "reaper claim work", "in-progress")
+
+		const current = "sess-current"
+		seedReaperSession(t, database, current)
+
+		seedReaperSession(t, database, "sess-stale-claim2")
+		seedFreshClaim(t, database, "sess-stale-claim2", "feat-reapclaim02")
+		writeDeadPID(t, mkSessDir(projectDir, "sess-stale-claim2"))
+		if _, err := database.Exec(
+			`UPDATE claims SET last_heartbeat_at=? WHERE claim_id=?`,
+			time.Now().Add(-72*time.Hour).UTC().Format(time.RFC3339), "claim-sess-stale-claim2",
+		); err != nil {
+			t.Fatalf("age claim heartbeat: %v", err)
+		}
+
+		rep := ReapStaleSessionsAndCollectors(database, projectDir, current, false, true /*reportOnly*/, 0)
+		if !contains(rep.ReapedSessions, "sess-stale-claim2") {
+			t.Fatalf("report-only must list the would-reap session; got %v", rep.ReapedSessions)
+		}
+		if got := claimStatus(t, database, "claim-sess-stale-claim2"); got == string(models.ClaimAbandoned) {
+			t.Fatalf("report-only must NOT release claims: status=%q, want still-active", got)
+		}
+	})
+}
+
+// TestReapStaleSessionsCap proves FIX C: with 2+ reap-eligible sessions and
+// maxSessions=1, exactly one session is reaped per call (the remainder is left
+// for the daemon).
+func TestReapStaleSessionsCap(t *testing.T) {
+	td := setupTestDB(t)
+	database := td.DB
+	projectDir := t.TempDir()
+
+	mkSessDir := func(sid string) string {
+		return filepath.Join(projectDir, ".wipnote", "sessions", sid)
+	}
+
+	const current = "sess-current"
+	seedReaperSession(t, database, current)
+
+	// Three reap-eligible sessions: no claim ⇒ heartbeat stale; dead pid.
+	for _, sid := range []string{"sess-cap-a", "sess-cap-b", "sess-cap-c"} {
+		seedReaperSession(t, database, sid)
+		writeDeadPID(t, mkSessDir(sid))
+	}
+
+	rep := ReapStaleSessionsAndCollectors(database, projectDir, current, false, false, 1 /*maxSessions*/)
+	if len(rep.ReapedSessions) != 1 {
+		t.Fatalf("maxSessions=1 must reap exactly one session, got %d: %v", len(rep.ReapedSessions), rep.ReapedSessions)
+	}
+
+	// A second capped pass reaps the next one (the first is now completed).
+	rep2 := ReapStaleSessionsAndCollectors(database, projectDir, current, false, false, 1)
+	if len(rep2.ReapedSessions) != 1 {
+		t.Fatalf("second capped pass must reap exactly one more session, got %d: %v", len(rep2.ReapedSessions), rep2.ReapedSessions)
+	}
+	if rep2.ReapedSessions[0] == rep.ReapedSessions[0] {
+		t.Fatalf("second pass reaped the same session %q (cap/idempotency broken)", rep2.ReapedSessions[0])
 	}
 }
 
@@ -184,7 +302,7 @@ func TestReapReportOnly(t *testing.T) {
 		return 0, false
 	}
 
-	rep := ReapStaleSessionsAndCollectors(database, projectDir, current, true /*includeCollectors*/, true /*reportOnly*/)
+	rep := ReapStaleSessionsAndCollectors(database, projectDir, current, true /*includeCollectors*/, true /*reportOnly*/, 0)
 
 	if !contains(rep.ReapedSessions, "sess-stale-dead") {
 		t.Fatalf("report-only must still list would-reap session; got %v", rep.ReapedSessions)
@@ -238,7 +356,7 @@ func TestReapStaleSessionsAndCollectors_Seam(t *testing.T) {
 		return 4242, true
 	}
 
-	rep := ReapStaleSessionsAndCollectors(database, projectDir, current, true /*includeCollectors*/, false)
+	rep := ReapStaleSessionsAndCollectors(database, projectDir, current, true /*includeCollectors*/, false, 0)
 
 	// The fake must have been invoked for the NON-current orphan only.
 	if !contains(calledDirs, orphanDir) {
@@ -253,7 +371,7 @@ func TestReapStaleSessionsAndCollectors_Seam(t *testing.T) {
 
 	// nil seam ⇒ no panic, no collector action.
 	ReapCollectorFn = nil
-	repNil := ReapStaleSessionsAndCollectors(database, projectDir, current, true, false)
+	repNil := ReapStaleSessionsAndCollectors(database, projectDir, current, true, false, 0)
 	if len(repNil.ReapedCollectors) != 0 {
 		t.Fatalf("nil ReapCollectorFn must reap no collectors, got %v", repNil.ReapedCollectors)
 	}

--- a/core/hooks/reaper_pass_test.go
+++ b/core/hooks/reaper_pass_test.go
@@ -1,0 +1,260 @@
+package hooks
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/shakestzd/wipnote/core/db"
+	"github.com/shakestzd/wipnote/core/models"
+)
+
+// --- shared reaper-test seeding helpers ---
+
+// seedReaperSession inserts an active session row. setupTestDB already seeds
+// "test-sess"; these are the additional candidates the reaper scans.
+func seedReaperSession(t *testing.T, database *sql.DB, sid string) {
+	t.Helper()
+	_, err := database.Exec(
+		`INSERT INTO sessions (session_id, agent_assigned, created_at, status)
+		 VALUES (?,?,?,?)`,
+		sid, "claude-code", time.Now().UTC().Format(time.RFC3339), "active",
+	)
+	if err != nil {
+		t.Fatalf("seed session %s: %v", sid, err)
+	}
+}
+
+// seedFreshClaim gives a session an in-progress claim with a recent
+// last_heartbeat_at, so SessionLivenessByHeartbeat reports it live (heartbeat
+// NOT stale). A session with no claim at all is heartbeat-stale.
+func seedFreshClaim(t *testing.T, database *sql.DB, sid, workItemID string) {
+	t.Helper()
+	c := &models.Claim{
+		ClaimID:        "claim-" + sid,
+		WorkItemID:     workItemID,
+		OwnerSessionID: sid,
+		OwnerAgent:     "claude-code",
+		Status:         models.ClaimInProgress,
+	}
+	if err := db.ClaimItem(database, c, 30*time.Minute); err != nil {
+		t.Fatalf("ClaimItem(%s): %v", sid, err)
+	}
+}
+
+// writeAlivePID writes a .session-pid anchor for a process that is actually
+// alive — this test process (os.Getpid()) plus its real /proc start time — so
+// IsSessionProcessAlive returns true (owner LIVE → never reaped).
+func writeAlivePID(t *testing.T, sessDir string) {
+	t.Helper()
+	if err := os.MkdirAll(sessDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", sessDir, err)
+	}
+	pid := os.Getpid()
+	content := strconv.Itoa(pid)
+	if st, ok := readProcStartTime(pid); ok {
+		content += "\n" + strconv.FormatUint(st, 10)
+	}
+	if err := os.WriteFile(filepath.Join(sessDir, ".session-pid"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write .session-pid: %v", err)
+	}
+}
+
+// writeDeadPID writes a .session-pid anchor for a pid that is certainly not
+// running (max int32), so IsSessionProcessAlive returns false (owner DEAD).
+func writeDeadPID(t *testing.T, sessDir string) {
+	t.Helper()
+	if err := os.MkdirAll(sessDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", sessDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(sessDir, ".session-pid"), []byte("2147483647\n1"), 0o644); err != nil {
+		t.Fatalf("write .session-pid: %v", err)
+	}
+}
+
+func sessionStatus(t *testing.T, database *sql.DB, sid string) string {
+	t.Helper()
+	var status string
+	if err := database.QueryRow(`SELECT status FROM sessions WHERE session_id=?`, sid).Scan(&status); err != nil {
+		t.Fatalf("query status %s: %v", sid, err)
+	}
+	return status
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestReapStaleSessions exercises the full {heartbeat fresh/stale} ×
+// {.session-pid process-alive / process-dead / missing} matrix. Only the cell
+// (stale heartbeat AND .session-pid present AND process-dead AND != current) is
+// eligible. Everything else safe-degrades to "leave active".
+func TestReapStaleSessions(t *testing.T) {
+	td := setupTestDB(t)
+	database := td.DB
+	projectDir := t.TempDir()
+	td.addFeature("feat-reapr01", "feature", "reaper work", "in-progress")
+
+	mkSessDir := func(sid string) string {
+		return filepath.Join(projectDir, ".wipnote", "sessions", sid)
+	}
+
+	// current: the running session — must NEVER be reaped even if it looked dead.
+	const current = "sess-current"
+	seedReaperSession(t, database, current)
+	writeDeadPID(t, mkSessDir(current)) // no claim → stale; dead pid; but it's current
+
+	// stale-dead: the ONLY reap-eligible session.
+	seedReaperSession(t, database, "sess-stale-dead")
+	writeDeadPID(t, mkSessDir("sess-stale-dead")) // no claim → heartbeat stale; pid dead
+
+	// stale-alive: long-idle but the owning process is alive → LIVE → not reaped.
+	seedReaperSession(t, database, "sess-stale-alive")
+	writeAlivePID(t, mkSessDir("sess-stale-alive")) // no claim → stale; but process alive
+
+	// stale-legacy: no .session-pid anchor → safe-degrade to LIVE → not reaped.
+	seedReaperSession(t, database, "sess-stale-legacy")
+	_ = os.MkdirAll(mkSessDir("sess-stale-legacy"), 0o755) // dir exists, no .session-pid
+
+	// fresh-dead: heartbeat fresh (recent claim) → not stale → not reaped even
+	// though the recorded pid is dead.
+	seedReaperSession(t, database, "sess-fresh-dead")
+	seedFreshClaim(t, database, "sess-fresh-dead", "feat-reapr01")
+	writeDeadPID(t, mkSessDir("sess-fresh-dead"))
+
+	rep := ReapStaleSessionsAndCollectors(database, projectDir, current, false, false)
+
+	if !contains(rep.ReapedSessions, "sess-stale-dead") {
+		t.Fatalf("sess-stale-dead must be reaped; ReapedSessions=%v", rep.ReapedSessions)
+	}
+	if len(rep.ReapedSessions) != 1 {
+		t.Fatalf("exactly one session must be reaped, got %v", rep.ReapedSessions)
+	}
+	if got := sessionStatus(t, database, "sess-stale-dead"); got != "completed" {
+		t.Fatalf("sess-stale-dead status=%q, want completed", got)
+	}
+
+	// Everything else stays active.
+	for _, sid := range []string{current, "sess-stale-alive", "sess-stale-legacy", "sess-fresh-dead"} {
+		if got := sessionStatus(t, database, sid); got != "active" {
+			t.Fatalf("%s status=%q, want active (must not be reaped)", sid, got)
+		}
+	}
+
+	// Idempotency: a second pass finds nothing — the already-completed row is no
+	// longer active, so RowsAffected is 0.
+	rep2 := ReapStaleSessionsAndCollectors(database, projectDir, current, false, false)
+	if len(rep2.ReapedSessions) != 0 {
+		t.Fatalf("second pass must be a no-op, got ReapedSessions=%v", rep2.ReapedSessions)
+	}
+}
+
+// TestReapReportOnly proves the dry-run mode: the would-reap session is listed
+// in ReapedSessions but its row is NOT mutated (still active), and the injected
+// ReapCollectorFn is never invoked.
+func TestReapReportOnly(t *testing.T) {
+	td := setupTestDB(t)
+	database := td.DB
+	projectDir := t.TempDir()
+
+	const current = "sess-current"
+	seedReaperSession(t, database, current)
+
+	seedReaperSession(t, database, "sess-stale-dead")
+	sessDir := filepath.Join(projectDir, ".wipnote", "sessions", "sess-stale-dead")
+	writeDeadPID(t, sessDir)
+	// Give the dead session a .collector-pid so the collector phase would fire.
+	if err := os.WriteFile(filepath.Join(sessDir, ".collector-pid"), []byte("2147483647\n1"), 0o644); err != nil {
+		t.Fatalf("write .collector-pid: %v", err)
+	}
+
+	prev := ReapCollectorFn
+	t.Cleanup(func() { ReapCollectorFn = prev })
+	called := false
+	ReapCollectorFn = func(string, time.Duration) (int, bool) {
+		called = true
+		return 0, false
+	}
+
+	rep := ReapStaleSessionsAndCollectors(database, projectDir, current, true /*includeCollectors*/, true /*reportOnly*/)
+
+	if !contains(rep.ReapedSessions, "sess-stale-dead") {
+		t.Fatalf("report-only must still list would-reap session; got %v", rep.ReapedSessions)
+	}
+	if got := sessionStatus(t, database, "sess-stale-dead"); got != "active" {
+		t.Fatalf("report-only must NOT mutate the row: status=%q, want active", got)
+	}
+	if !contains(rep.ReapedCollectors, "sess-stale-dead") {
+		t.Fatalf("report-only must list would-reap collector session; got %v", rep.ReapedCollectors)
+	}
+	if called {
+		t.Fatal("report-only must NOT invoke ReapCollectorFn")
+	}
+}
+
+// TestReapStaleSessionsAndCollectors_Seam proves the collector phase goes
+// through the injected ReapCollectorFn seam, excludes the current session, and
+// degrades to a no-op when the seam is nil.
+func TestReapStaleSessionsAndCollectors_Seam(t *testing.T) {
+	td := setupTestDB(t)
+	database := td.DB
+	projectDir := t.TempDir()
+
+	const current = "sess-current"
+	seedReaperSession(t, database, current)
+
+	mkOrphanCollector := func(sid string) string {
+		seedReaperSession(t, database, sid)
+		sessDir := filepath.Join(projectDir, ".wipnote", "sessions", sid)
+		writeDeadPID(t, sessDir) // owner process dead, no claim → heartbeat stale
+		if err := os.WriteFile(filepath.Join(sessDir, ".collector-pid"), []byte("2147483647\n1"), 0o644); err != nil {
+			t.Fatalf("write .collector-pid: %v", err)
+		}
+		return sessDir
+	}
+
+	// Two orphan collectors: one owned by the current session, one not.
+	currentSessDir := filepath.Join(projectDir, ".wipnote", "sessions", current)
+	_ = os.MkdirAll(currentSessDir, 0o755)
+	if err := os.WriteFile(filepath.Join(currentSessDir, ".collector-pid"), []byte("2147483647\n1"), 0o644); err != nil {
+		t.Fatalf("write current .collector-pid: %v", err)
+	}
+	orphanDir := mkOrphanCollector("sess-orphan")
+
+	prev := ReapCollectorFn
+	t.Cleanup(func() { ReapCollectorFn = prev })
+
+	var calledDirs []string
+	ReapCollectorFn = func(sessDir string, _ time.Duration) (int, bool) {
+		calledDirs = append(calledDirs, sessDir)
+		return 4242, true
+	}
+
+	rep := ReapStaleSessionsAndCollectors(database, projectDir, current, true /*includeCollectors*/, false)
+
+	// The fake must have been invoked for the NON-current orphan only.
+	if !contains(calledDirs, orphanDir) {
+		t.Fatalf("ReapCollectorFn not invoked for orphan %q; calledDirs=%v", orphanDir, calledDirs)
+	}
+	if contains(calledDirs, currentSessDir) {
+		t.Fatalf("ReapCollectorFn must NOT be invoked for the current session; calledDirs=%v", calledDirs)
+	}
+	if !contains(rep.ReapedCollectors, "sess-orphan:4242") {
+		t.Fatalf("ReapedCollectors must record the killed orphan; got %v", rep.ReapedCollectors)
+	}
+
+	// nil seam ⇒ no panic, no collector action.
+	ReapCollectorFn = nil
+	repNil := ReapStaleSessionsAndCollectors(database, projectDir, current, true, false)
+	if len(repNil.ReapedCollectors) != 0 {
+		t.Fatalf("nil ReapCollectorFn must reap no collectors, got %v", repNil.ReapedCollectors)
+	}
+}

--- a/core/hooks/session_end.go
+++ b/core/hooks/session_end.go
@@ -547,6 +547,18 @@ func SessionResume(event *CloudEvent, database *sql.DB, projectDir string) (*Hoo
 		debugLog(projectDir, "[error] handler=session-resume session=%s: update sessions: %v", sessionID[:minLen(sessionID, 8)], err)
 	}
 
+	// Refresh the session process-liveness anchor (feat-0a7db952, slice-1).
+	// On resume the new launcher rewrote .launch-mode with the LIVE pid, so
+	// re-resolving picks it up. Without this the resumed session would carry the
+	// dead pre-resume pid and be false-reaped. Best-effort: a write failure must
+	// NEVER block the hook; an unresolvable owner leaves the anchor untouched.
+	if ownerPID, ok := resolveOwningPID(projectDir); ok {
+		sessDir := filepath.Join(projectDir, ".wipnote", "sessions", sessionID)
+		if err := writeSessionPID(sessDir, ownerPID); err != nil {
+			debugLog(projectDir, "[session-resume] writeSessionPID failed (session=%s pid=%d): %v", sessionID[:minLen(sessionID, 8)], ownerPID, err)
+		}
+	}
+
 	// Re-export env vars so downstream hooks have the session ID.
 	writeEnvVars(sessionID, projectDir)
 

--- a/core/hooks/session_end.go
+++ b/core/hooks/session_end.go
@@ -975,6 +975,84 @@ func DrainReconcileWarnings(projectDir string) string {
 		strings.Join(lines, "\n")
 }
 
+// --- Reaper config knobs ---
+
+// defaultReaperSessionTTLSeconds is the heartbeat-stale cutoff (in seconds) beyond
+// which a session is eligible for reaping. Distinct from liveness_staleness_threshold_seconds
+// (defaultLivenessStalenessSeconds = 120s in core/db): that controls the liveness
+// query used by the serve-path claim reaper; this TTL controls the reaper's own
+// eligibility window (30m = 1800s).
+const (
+	defaultReaperSessionTTLSeconds     = 1800 // 30m heartbeat-stale cutoff for reap eligibility
+	defaultReaperCollectorGraceSeconds = 10   // SIGTERM→SIGKILL grace window
+)
+
+// reaperConfig decodes ONLY the three reaper-specific fields from .wipnote/config.json.
+// Everything else in config.json is ignored. This is the 3rd independent reader of
+// config.json in this codebase (the others are livenessConfig in core/db/session_repo.go
+// and readTaskCompletionConfig in core/hooks/task_completion_gate.go). There is no
+// shared config package; each call site reads independently. Accepted debt, NOT a
+// refactor target.
+type reaperConfig struct {
+	ReaperSessionTTLSeconds     int  `json:"reaper_session_ttl_seconds"`
+	ReaperCollectorGraceSeconds int  `json:"reaper_collector_grace_seconds"`
+	ReaperDaemonReportOnly      bool `json:"reaper_daemon_report_only"`
+}
+
+// readReaperConfig loads .wipnote/config.json from projectDir and decodes the
+// reaper fields. Returns a zero-value reaperConfig on projectDir=="" or any
+// read/parse error; callers apply their own per-field defaults.
+func readReaperConfig(projectDir string) reaperConfig {
+	if projectDir == "" {
+		return reaperConfig{}
+	}
+	data, err := os.ReadFile(filepath.Join(projectDir, ".wipnote", "config.json"))
+	if err != nil {
+		return reaperConfig{}
+	}
+	var cfg reaperConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return reaperConfig{}
+	}
+	return cfg
+}
+
+// ReaperSessionTTL returns the duration beyond which a session with a stale
+// heartbeat is eligible for reaping. Reads reaper_session_ttl_seconds from
+// .wipnote/config.json under projectDir; falls back to the 30m default when
+// the file is missing, unreadable, unparseable, or the value is non-positive.
+// projectDir=="" → default.
+func ReaperSessionTTL(projectDir string) time.Duration {
+	def := time.Duration(defaultReaperSessionTTLSeconds) * time.Second
+	cfg := readReaperConfig(projectDir)
+	if cfg.ReaperSessionTTLSeconds <= 0 {
+		return def
+	}
+	return time.Duration(cfg.ReaperSessionTTLSeconds) * time.Second
+}
+
+// ReaperCollectorGrace returns the SIGTERM→SIGKILL grace window for the
+// per-session OTel collector process during a reaper pass. Reads
+// reaper_collector_grace_seconds from .wipnote/config.json under projectDir;
+// falls back to the 10s default when the file is missing, unreadable,
+// unparseable, or the value is non-positive. projectDir=="" → default.
+func ReaperCollectorGrace(projectDir string) time.Duration {
+	def := time.Duration(defaultReaperCollectorGraceSeconds) * time.Second
+	cfg := readReaperConfig(projectDir)
+	if cfg.ReaperCollectorGraceSeconds <= 0 {
+		return def
+	}
+	return time.Duration(cfg.ReaperCollectorGraceSeconds) * time.Second
+}
+
+// ReaperDaemonReportOnly returns whether the reaper daemon should run in
+// report-only mode (log reap candidates without actually killing them). Reads
+// reaper_daemon_report_only from .wipnote/config.json under projectDir;
+// defaults to false (absence == false). projectDir=="" → false.
+func ReaperDaemonReportOnly(projectDir string) bool {
+	return readReaperConfig(projectDir).ReaperDaemonReportOnly
+}
+
 // runSessionExitReconcile is the shared Stop/SessionEnd entry point. It runs a
 // reconcile pass and applies the harness discriminator:
 //

--- a/core/hooks/session_end.go
+++ b/core/hooks/session_end.go
@@ -551,13 +551,11 @@ func SessionResume(event *CloudEvent, database *sql.DB, projectDir string) (*Hoo
 	// On resume the new launcher rewrote .launch-mode with the LIVE pid, so
 	// re-resolving picks it up. Without this the resumed session would carry the
 	// dead pre-resume pid and be false-reaped. Best-effort: a write failure must
-	// NEVER block the hook; an unresolvable owner leaves the anchor untouched.
-	if ownerPID, ok := resolveOwningPID(projectDir); ok {
-		sessDir := filepath.Join(projectDir, ".wipnote", "sessions", sessionID)
-		if err := writeSessionPID(sessDir, ownerPID); err != nil {
-			debugLog(projectDir, "[session-resume] writeSessionPID failed (session=%s pid=%d): %v", sessionID[:minLen(sessionID, 8)], ownerPID, err)
-		}
-	}
+	// NEVER block the hook; when NO fresh owner resolves, updateSessionPIDAnchor
+	// REMOVES any stale pre-existing anchor (degrade to LIVE) rather than leaving
+	// a dead pid in place.
+	sessDir := filepath.Join(projectDir, ".wipnote", "sessions", sessionID)
+	updateSessionPIDAnchor(projectDir, sessDir)
 
 	// Re-export env vars so downstream hooks have the session ID.
 	writeEnvVars(sessionID, projectDir)
@@ -1107,7 +1105,14 @@ func ReaperDaemonReportOnly(projectDir string) bool {
 // flag itself is NOT read here; slice 4's daemon passes the resolved bool.
 //
 // currentSessionID is always excluded from both phases.
-func ReapStaleSessionsAndCollectors(database *sql.DB, projectDir, currentSessionID string, includeCollectors bool, reportOnly bool) *ReconcileReport {
+//
+// maxSessions caps the SESSION-reap phase: when > 0, the loop stops once that
+// many sessions have been reaped (counting both real reaps and reportOnly
+// would-reaps), so the synchronous hook path cannot stall behind a large stale
+// backlog under write contention — the daemon catches the remainder within one
+// interval. maxSessions <= 0 ⇒ unbounded (daemon callers pass 0). The cap
+// applies ONLY to the session phase; the collector phase is daemon-only.
+func ReapStaleSessionsAndCollectors(database *sql.DB, projectDir, currentSessionID string, includeCollectors bool, reportOnly bool, maxSessions int) *ReconcileReport {
 	rep := &ReconcileReport{}
 	if database == nil {
 		return rep
@@ -1121,7 +1126,12 @@ func ReapStaleSessionsAndCollectors(database *sql.DB, projectDir, currentSession
 		debugLog(projectDir, "[reaper] list active sessions: %v", err)
 		sessions = nil
 	}
+	reapedCount := 0
 	for _, s := range sessions {
+		if maxSessions > 0 && reapedCount >= maxSessions {
+			// Hook-path cap reached: leave the remainder for the daemon.
+			break
+		}
 		sid := s.SessionID
 		if sid == "" || sid == currentSessionID {
 			continue
@@ -1134,6 +1144,7 @@ func ReapStaleSessionsAndCollectors(database *sql.DB, projectDir, currentSession
 		if reportOnly {
 			// Dry-run: record the would-reap set; perform no UPDATE.
 			rep.ReapedSessions = append(rep.ReapedSessions, sid)
+			reapedCount++
 			debugLog(projectDir, "[reaper] report-only: would reap stale session %s (heartbeat stale, owner process dead)", sid[:minLen(sid, 8)])
 			continue
 		}
@@ -1147,16 +1158,34 @@ func ReapStaleSessionsAndCollectors(database *sql.DB, projectDir, currentSession
 		}
 		if n, _ := res.RowsAffected(); n == 1 {
 			rep.ReapedSessions = append(rep.ReapedSessions, sid)
+			reapedCount++
 			debugLog(projectDir, "[reaper] reaped stale session %s → completed (heartbeat stale, owner process dead)", sid[:minLen(sid, 8)])
+			// Release any active claims the reaped session still held. Normal
+			// SessionEnd does this (db.ReleaseAllClaimsForSession); the reaper
+			// must mirror it or a crashed session's claims block claim paths
+			// forever. Only on a REAL reap — never in the reportOnly branch.
+			if released, relErr := db.ReleaseAllClaimsForSession(database, sid); relErr != nil {
+				debugLog(projectDir, "[reaper] release claims for reaped session %s: %v", sid[:minLen(sid, 8)], relErr)
+			} else if released > 0 {
+				debugLog(projectDir, "[reaper] released %d claims for reaped session %s", released, sid[:minLen(sid, 8)])
+			}
 		}
 	}
 
 	// --- (b) reap orphaned collectors ---
 	if includeCollectors && ReapCollectorFn != nil {
 		grace := ReaperCollectorGrace(projectDir)
-		dirs, _ := filepath.Glob(filepath.Join(projectDir, ".wipnote", "sessions", "*"))
-		for _, sessDir := range dirs {
-			sid := filepath.Base(sessDir)
+		// os.ReadDir (not filepath.Glob) so session ids / paths containing glob
+		// metacharacters ([ * ?) are scanned correctly — Glob would silently
+		// skip or mis-match them.
+		sessionsDir := filepath.Join(projectDir, ".wipnote", "sessions")
+		entries, _ := os.ReadDir(sessionsDir)
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			sid := e.Name()
+			sessDir := filepath.Join(sessionsDir, sid)
 			if sid == "" || sid == currentSessionID {
 				continue
 			}

--- a/core/hooks/session_end.go
+++ b/core/hooks/session_end.go
@@ -602,6 +602,16 @@ type ReconcileReport struct {
 	AutoCommitted []string `json:"auto_committed,omitempty"`
 	PortDrift     []string `json:"port_drift,omitempty"`
 	Orphaned      []string `json:"orphaned,omitempty"`
+
+	// ReapedSessions and ReapedCollectors are the forced-reap audit trail
+	// produced by ReapStaleSessionsAndCollectors (feat-88f92f44). They are
+	// deliberately report-only JSON fields with NO backing schema/DB column —
+	// this struct IS the audit trail; a migration would break migrations_test.go
+	// and there is no query that needs them indexed. ReapedSessions holds the
+	// session ids transitioned active→completed; ReapedCollectors holds
+	// "<sid>:<pid>" entries for each identity-verified orphan collector killed.
+	ReapedSessions   []string `json:"reaped_sessions,omitempty"`
+	ReapedCollectors []string `json:"reaped_collectors,omitempty"`
 }
 
 // HasAmbiguousDrift reports whether the pass found unresolved source-ambiguous
@@ -617,7 +627,8 @@ func (r *ReconcileReport) HasAmbiguousDrift() bool {
 // Empty reports whether the pass found nothing actionable at all.
 func (r *ReconcileReport) Empty() bool {
 	return r == nil ||
-		(len(r.AutoCommitted) == 0 && len(r.PortDrift) == 0 && len(r.Orphaned) == 0)
+		(len(r.AutoCommitted) == 0 && len(r.PortDrift) == 0 && len(r.Orphaned) == 0 &&
+			len(r.ReapedSessions) == 0 && len(r.ReapedCollectors) == 0)
 }
 
 // reconcileArtifactCommitFn is the injection seam for the deterministic
@@ -1063,6 +1074,115 @@ func ReaperCollectorGrace(projectDir string) time.Duration {
 // defaults to false (absence == false). projectDir=="" → false.
 func ReaperDaemonReportOnly(projectDir string) bool {
 	return readReaperConfig(projectDir).ReaperDaemonReportOnly
+}
+
+// ReapStaleSessionsAndCollectors is the idempotent, identity-verified reaper
+// pass (feat-88f92f44). It transitions crashed/abandoned sessions to completed
+// and (optionally) terminates orphaned per-session OTel collectors whose owning
+// session is provably dead. It NEVER touches the current session and NEVER
+// reaps a session it cannot positively prove dead — the safe-degrade direction
+// is always "leave active".
+//
+// (a) Sessions: a status='active' row is reaped only when its heartbeat is
+// stale (no claim heartbeat within ttl) AND its owning process is provably not
+// alive (SessionReapEligible, which folds the .session-pid kill(pid,0)+
+// start-time anchor). A long-IDLE but LIVE session (process alive) and a legacy
+// session with no .session-pid anchor both safe-degrade to LIVE and are left
+// active. Idempotency is the UPDATE's own `status='active'` guard plus a
+// RowsAffected()==1 check — a concurrent pass that already reaped a row sees 0.
+//
+// (b) Collectors (only when includeCollectors): for every session dir carrying
+// a .collector-pid, the OWNER-liveness gate fires first (never kill a live
+// session's collector): skip when the owner is heartbeat-fresh OR its process
+// is alive. Otherwise delegate to the injected ReapCollectorFn (observe's
+// ReapCollector), which itself gates the kill on IsCollectorAlive — so a
+// reused/dead collector pid is cleared without ever being signalled. A nil
+// ReapCollectorFn (telemetry not wired) degrades the whole collector phase to a
+// no-op.
+//
+// reportOnly drives the slice-3 reaper_daemon_report_only dry-run knob: when
+// true, the FULL detection still runs and rep.ReapedSessions/ReapedCollectors
+// are populated with the would-reap set, but NO side effects occur — the
+// session UPDATE is skipped and ReapCollectorFn is never called. The config
+// flag itself is NOT read here; slice 4's daemon passes the resolved bool.
+//
+// currentSessionID is always excluded from both phases.
+func ReapStaleSessionsAndCollectors(database *sql.DB, projectDir, currentSessionID string, includeCollectors bool, reportOnly bool) *ReconcileReport {
+	rep := &ReconcileReport{}
+	if database == nil {
+		return rep
+	}
+	ttl := ReaperSessionTTL(projectDir)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// --- (a) reap stale sessions ---
+	sessions, err := db.ListSessions(database, true /*activeOnly*/, 1_000_000)
+	if err != nil {
+		debugLog(projectDir, "[reaper] list active sessions: %v", err)
+		sessions = nil
+	}
+	for _, s := range sessions {
+		sid := s.SessionID
+		if sid == "" || sid == currentSessionID {
+			continue
+		}
+		heartbeatStale := !db.SessionLivenessByHeartbeat(database, sid, ttl)
+		sessDir := filepath.Join(projectDir, ".wipnote", "sessions", sid)
+		if !SessionReapEligible(heartbeatStale, sessDir) {
+			continue
+		}
+		if reportOnly {
+			// Dry-run: record the would-reap set; perform no UPDATE.
+			rep.ReapedSessions = append(rep.ReapedSessions, sid)
+			debugLog(projectDir, "[reaper] report-only: would reap stale session %s (heartbeat stale, owner process dead)", sid[:minLen(sid, 8)])
+			continue
+		}
+		res, execErr := database.Exec(
+			`UPDATE sessions SET status='completed', completed_at=? WHERE session_id=? AND status='active'`,
+			now, sid,
+		)
+		if execErr != nil {
+			debugLog(projectDir, "[reaper] reap session %s: %v", sid[:minLen(sid, 8)], execErr)
+			continue
+		}
+		if n, _ := res.RowsAffected(); n == 1 {
+			rep.ReapedSessions = append(rep.ReapedSessions, sid)
+			debugLog(projectDir, "[reaper] reaped stale session %s → completed (heartbeat stale, owner process dead)", sid[:minLen(sid, 8)])
+		}
+	}
+
+	// --- (b) reap orphaned collectors ---
+	if includeCollectors && ReapCollectorFn != nil {
+		grace := ReaperCollectorGrace(projectDir)
+		dirs, _ := filepath.Glob(filepath.Join(projectDir, ".wipnote", "sessions", "*"))
+		for _, sessDir := range dirs {
+			sid := filepath.Base(sessDir)
+			if sid == "" || sid == currentSessionID {
+				continue
+			}
+			if _, statErr := os.Stat(filepath.Join(sessDir, ".collector-pid")); statErr != nil {
+				continue // no collector record for this session
+			}
+			// Owner-liveness gate: never kill a live session's collector.
+			heartbeatStale := !db.SessionLivenessByHeartbeat(database, sid, ttl)
+			if !heartbeatStale || IsSessionProcessAlive(sessDir) {
+				continue
+			}
+			if reportOnly {
+				rep.ReapedCollectors = append(rep.ReapedCollectors, sid)
+				debugLog(projectDir, "[reaper] report-only: would reap orphan collector for session %s", sid[:minLen(sid, 8)])
+				continue
+			}
+			pid, reaped := ReapCollectorFn(sessDir, grace)
+			if reaped {
+				rep.ReapedCollectors = append(rep.ReapedCollectors, fmt.Sprintf("%s:%d", sid, pid))
+				debugLog(projectDir, "[reaper] reaped orphan collector pid=%d for session %s", pid, sid[:minLen(sid, 8)])
+			}
+			// !reaped ⇒ ReapCollector cleared a dead/reused record; not a kill.
+		}
+	}
+
+	return rep
 }
 
 // runSessionExitReconcile is the shared Stop/SessionEnd entry point. It runs a

--- a/core/hooks/session_liveness.go
+++ b/core/hooks/session_liveness.go
@@ -1,0 +1,176 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// Session process-liveness anchor (feat-0a7db952, slice-1).
+//
+// A session's SQLite heartbeat alone cannot distinguish a CRASHED session from a
+// long-IDLE but LIVE one — both stop updating the heartbeat. To make reaping
+// safe, SessionStart records the owning process's pid (and, on Linux, its /proc
+// start time) in a `.session-pid` file alongside the session dir, mirroring the
+// existing `.collector-pid` convention. Liveness is then a directly-pollable
+// fact: kill(pid, 0) plus a start-time match defeats PID reuse.
+//
+// Boundary note (accepted minor duplication): the `core` module CANNOT import
+// `observe` — `observe` already imports `core`, so importing back would risk a
+// module cycle. The /proc start-time reader below is therefore a deliberate
+// ~20-line copy of observe/otel/collector/lifecycle.go's readProcStartTime /
+// readCollectorPIDFile logic, kept in sync by convention rather than by import.
+
+// readProcStartTime returns the process start time from /proc/<pid>/stat field
+// 22 (clock ticks since boot). Returns ok=false on non-Linux systems or when the
+// proc entry is unreadable. Used for PID-reuse detection.
+//
+// Core-local copy of observe/otel/collector/lifecycle.go readProcStartTime (see
+// the boundary note above): core cannot import observe.
+func readProcStartTime(pid int) (uint64, bool) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, false
+	}
+	s := string(data)
+	// Field 2 (comm) is wrapped in parens and may itself contain spaces or
+	// parens. Split after the LAST closing paren.
+	idx := strings.LastIndex(s, ")")
+	if idx < 0 || idx+1 >= len(s) {
+		return 0, false
+	}
+	fields := strings.Fields(s[idx+1:])
+	// Index 0 here corresponds to field 3 (state); field 22 (starttime) is at
+	// index 19 of this slice.
+	if len(fields) < 20 {
+		return 0, false
+	}
+	st, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return st, true
+}
+
+// resolveOwningPID determines the pid of the process that owns this session, so
+// liveness can be polled directly. Resolution order:
+//
+//  1. .wipnote/.launch-mode (written by `wipnote claude` with os.Getpid() of the
+//     launcher) — authoritative for wipnote-launched sessions.
+//  2. Subagents (WIPNOTE_PARENT_SESSION set) without a usable launch-mode pid:
+//     fall through — we do not have a confidently-resolvable stable harness pid
+//     here, and a wrong pid is worse than none.
+//  3. Otherwise ok=false → caller OMITS .session-pid → the session safe-degrades
+//     to LIVE (never reaped). This degrade direction is the core invariant:
+//     never the reverse.
+func resolveOwningPID(projectDir string) (pid int, ok bool) {
+	markerPath := filepath.Join(projectDir, ".wipnote", ".launch-mode")
+	b, err := os.ReadFile(markerPath)
+	if err != nil {
+		return 0, false
+	}
+	var lm launchModeFile
+	if err := json.Unmarshal(b, &lm); err != nil {
+		return 0, false
+	}
+	if lm.PID > 0 {
+		return lm.PID, true
+	}
+	// No usable launch-mode pid. For subagents (and everything else) we
+	// deliberately fall through rather than guess a harness parent pid — a
+	// missing anchor degrades safely to LIVE.
+	return 0, false
+}
+
+// writeSessionPID writes the owning pid (and, on Linux, its /proc start time) to
+// <sessDir>/.session-pid, mirroring the .collector-pid format:
+//
+//	line 1: <pid>
+//	line 2: <starttime_ticks>   (omitted when /proc is unreadable / non-Linux)
+//
+// Best-effort: any failure is swallowed by the caller's logging — a write error
+// must NEVER block or fail the hook. Consumers (IsSessionProcessAlive) tolerate
+// both the 1-line and 2-line forms.
+func writeSessionPID(sessDir string, pid int) error {
+	if err := os.MkdirAll(sessDir, 0o755); err != nil {
+		return err
+	}
+	content := strconv.Itoa(pid)
+	if st, ok := readProcStartTime(pid); ok {
+		content += "\n" + strconv.FormatUint(st, 10)
+	}
+	return os.WriteFile(filepath.Join(sessDir, ".session-pid"), []byte(content), 0o644)
+}
+
+// readSessionPIDFile parses <sessDir>/.session-pid. hasStart is false for legacy
+// single-line files (or when start-time was unreadable at write time).
+func readSessionPIDFile(sessDir string) (pid int, starttime uint64, hasStart bool, err error) {
+	data, err := os.ReadFile(filepath.Join(sessDir, ".session-pid"))
+	if err != nil {
+		return 0, 0, false, err
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) == "" {
+		return 0, 0, false, fmt.Errorf("empty .session-pid in %s", sessDir)
+	}
+	pid, err = strconv.Atoi(strings.TrimSpace(lines[0]))
+	if err != nil {
+		return 0, 0, false, fmt.Errorf("parse session pid %q: %w", lines[0], err)
+	}
+	if len(lines) >= 2 {
+		if st, perr := strconv.ParseUint(strings.TrimSpace(lines[1]), 10, 64); perr == nil {
+			return pid, st, true, nil
+		}
+	}
+	return pid, 0, false, nil
+}
+
+// IsSessionProcessAlive reports whether the process that owns the session at
+// sessDir is still alive. The contract is SAFE-DEGRADE-TO-LIVE: anything we
+// cannot positively prove dead is reported alive, so a live idle session is
+// never reaped.
+//
+//   - .session-pid missing / unreadable → true (legacy or unresolved owner).
+//   - process gone (kill(pid,0) -> ESRCH/error) → false.
+//   - start-time recorded AND readable now AND mismatched → PID reuse → false.
+//   - otherwise → true.
+func IsSessionProcessAlive(sessDir string) bool {
+	pid, recordedStart, hasStart, err := readSessionPIDFile(sessDir)
+	if err != nil {
+		// Missing or unreadable anchor: legacy/unresolved degrades to LIVE.
+		return true
+	}
+	if pid <= 0 {
+		return true
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		// ESRCH (no such process) or EPERM-less error → treat as dead. We do
+		// not special-case EPERM here: a wipnote-launched owner is the same
+		// user, so EPERM is not expected; defaulting EPERM to dead is still the
+		// conservative choice only when the process truly differs, but in
+		// practice Kill(pid,0) returns nil when the process exists regardless.
+		return false
+	}
+	if !hasStart {
+		// Legacy / non-Linux write: PID-only liveness, already proven by Kill.
+		return true
+	}
+	actualStart, ok := readProcStartTime(pid)
+	if !ok {
+		// /proc unavailable at read time (non-Linux): fall back to PID-only.
+		return true
+	}
+	return actualStart == recordedStart
+}
+
+// SessionReapEligible is the pure reap-eligibility predicate. A session may be
+// reaped ONLY when its heartbeat is stale AND its owning process is provably not
+// alive. No DB access — slice-2 computes heartbeatStale from the DB and
+// ReaperSessionTTL, then calls this.
+func SessionReapEligible(heartbeatStale bool, sessDir string) bool {
+	return heartbeatStale && !IsSessionProcessAlive(sessDir)
+}

--- a/core/hooks/session_liveness.go
+++ b/core/hooks/session_liveness.go
@@ -2,13 +2,25 @@ package hooks
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 )
+
+// launchMarkerFreshWindow bounds how recently .wipnote/.launch-mode must have
+// been written for its recorded pid to be trusted as THIS session's owner. A
+// bare/old launch leaves a stale marker from a PRIOR wipnote session; its
+// dead-or-reused pid must NOT be written into a live session's .session-pid
+// anchor (which would false-reap the live session once its heartbeat goes
+// stale). Mirrors bareLaunchNudge's 30s staleness window (session_start.go).
+// A tighter window is the SAFE direction: worst case a legit session degrades
+// to LIVE and is simply never auto-reaped — never false-reaped.
+const launchMarkerFreshWindow = 30 * time.Second
 
 // Session process-liveness anchor (feat-0a7db952, slice-1).
 //
@@ -60,7 +72,10 @@ func readProcStartTime(pid int) (uint64, bool) {
 // liveness can be polled directly. Resolution order:
 //
 //  1. .wipnote/.launch-mode (written by `wipnote claude` with os.Getpid() of the
-//     launcher) — authoritative for wipnote-launched sessions.
+//     launcher) — authoritative for wipnote-launched sessions, but ONLY when the
+//     marker is FRESH (written within launchMarkerFreshWindow). A stale marker is
+//     a leftover from a PRIOR session; its pid is dead/reused and trusting it
+//     would false-reap THIS live session.
 //  2. Subagents (WIPNOTE_PARENT_SESSION set) without a usable launch-mode pid:
 //     fall through — we do not have a confidently-resolvable stable harness pid
 //     here, and a wrong pid is worse than none.
@@ -69,6 +84,16 @@ func readProcStartTime(pid int) (uint64, bool) {
 //     never the reverse.
 func resolveOwningPID(projectDir string) (pid int, ok bool) {
 	markerPath := filepath.Join(projectDir, ".wipnote", ".launch-mode")
+	info, statErr := os.Stat(markerPath)
+	if statErr != nil {
+		return 0, false
+	}
+	// Freshness gate: a marker older than the window belongs to a PRIOR session.
+	// Its recorded pid is dead or reused; do NOT anchor this session to it.
+	// Mirrors bareLaunchNudge's "not this session" staleness check.
+	if time.Since(info.ModTime()) > launchMarkerFreshWindow {
+		return 0, false
+	}
 	b, err := os.ReadFile(markerPath)
 	if err != nil {
 		return 0, false
@@ -84,6 +109,26 @@ func resolveOwningPID(projectDir string) (pid int, ok bool) {
 	// deliberately fall through rather than guess a harness parent pid — a
 	// missing anchor degrades safely to LIVE.
 	return 0, false
+}
+
+// updateSessionPIDAnchor refreshes (or, when no fresh owner resolves, REMOVES)
+// the .session-pid anchor for sessDir. Best-effort: never blocks/fails the hook.
+//
+// The removal arm is the FIX for stale-anchor false-reaps on resume: if the old
+// code only WROTE when an owner resolved, an unresolvable owner (stale/absent
+// .launch-mode) left a DEAD pre-existing .session-pid in place, which the reaper
+// would then treat as a provably-dead owner and false-reap. Dropping the anchor
+// degrades the session to LIVE instead.
+func updateSessionPIDAnchor(projectDir, sessDir string) {
+	if pid, ok := resolveOwningPID(projectDir); ok {
+		if err := writeSessionPID(sessDir, pid); err != nil {
+			debugLog(projectDir, "[session] writeSessionPID failed (%s pid=%d): %v", filepath.Base(sessDir), pid, err)
+		}
+		return
+	}
+	// No fresh owner: drop any stale anchor so the session degrades to LIVE
+	// rather than carrying a dead/foreign pid.
+	_ = os.Remove(filepath.Join(sessDir, ".session-pid"))
 }
 
 // writeSessionPID writes the owning pid (and, on Linux, its /proc start time) to
@@ -135,7 +180,8 @@ func readSessionPIDFile(sessDir string) (pid int, starttime uint64, hasStart boo
 // never reaped.
 //
 //   - .session-pid missing / unreadable → true (legacy or unresolved owner).
-//   - process gone (kill(pid,0) -> ESRCH/error) → false.
+//   - process gone (kill(pid,0) -> ESRCH) → false.
+//   - kill(pid,0) -> EPERM → process exists under another uid → true (ALIVE).
 //   - start-time recorded AND readable now AND mismatched → PID reuse → false.
 //   - otherwise → true.
 func IsSessionProcessAlive(sessDir string) bool {
@@ -148,11 +194,14 @@ func IsSessionProcessAlive(sessDir string) bool {
 		return true
 	}
 	if err := syscall.Kill(pid, 0); err != nil {
-		// ESRCH (no such process) or EPERM-less error → treat as dead. We do
-		// not special-case EPERM here: a wipnote-launched owner is the same
-		// user, so EPERM is not expected; defaulting EPERM to dead is still the
-		// conservative choice only when the process truly differs, but in
-		// practice Kill(pid,0) returns nil when the process exists regardless.
+		// EPERM means the process EXISTS but is owned by a different uid (e.g. a
+		// root process that reused the recorded pid). The process is ALIVE — we
+		// must NOT report it dead, or a live session whose pid was reused under
+		// another uid would be false-reaped. Safe-degrade to LIVE.
+		if errors.Is(err, syscall.EPERM) {
+			return true
+		}
+		// ESRCH (or any other error) → no such process → provably dead.
 		return false
 	}
 	if !hasStart {

--- a/core/hooks/session_liveness_test.go
+++ b/core/hooks/session_liveness_test.go
@@ -80,6 +80,54 @@ func TestIsSessionProcessAlive(t *testing.T) {
 	})
 }
 
+// TestResolveOwningPIDStaleMarkerOmits proves the launch-marker freshness gate
+// (FIX A): a FRESH .launch-mode with a valid pid resolves to ok=true, but once
+// the marker's mtime is aged past launchMarkerFreshWindow it belongs to a PRIOR
+// session and resolveOwningPID returns ok=false (so the caller omits the anchor
+// and the live session safe-degrades to LIVE instead of being false-reaped).
+func TestResolveOwningPIDStaleMarkerOmits(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, ".wipnote"), 0o755); err != nil {
+		t.Fatalf("mkdir .wipnote: %v", err)
+	}
+	markerPath := filepath.Join(projectDir, ".wipnote", ".launch-mode")
+	marker := launchModeFile{Mode: "claude", PID: 12345, Timestamp: time.Now().UTC().Format(time.RFC3339)}
+	data, err := json.Marshal(marker)
+	if err != nil {
+		t.Fatalf("marshal launch-mode: %v", err)
+	}
+	if err := os.WriteFile(markerPath, data, 0o644); err != nil {
+		t.Fatalf("write .launch-mode: %v", err)
+	}
+
+	// Fresh marker → resolves the recorded pid.
+	if pid, ok := resolveOwningPID(projectDir); !ok || pid != 12345 {
+		t.Fatalf("fresh marker: got (pid=%d, ok=%v), want (12345, true)", pid, ok)
+	}
+
+	// Age the marker ~1h into the past → stale → ok=false (omit anchor).
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(markerPath, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	if pid, ok := resolveOwningPID(projectDir); ok {
+		t.Fatalf("stale marker must NOT resolve an owner: got (pid=%d, ok=%v), want ok=false", pid, ok)
+	}
+}
+
+// TestIsSessionProcessAliveEPERM proves FIX H1: pid 1 (init) is root-owned, so a
+// non-root test process gets EPERM from kill(1,0) — which means the process
+// EXISTS (alive), not dead. IsSessionProcessAlive must return true (safe-degrade
+// to LIVE) rather than false-reaping. If the test happens to run as root it
+// returns true via the normal alive path; either way the assertion is true.
+func TestIsSessionProcessAliveEPERM(t *testing.T) {
+	sessDir := t.TempDir()
+	writeSessionPIDRaw(t, sessDir, "1") // pid 1 = init, root-owned, always running
+	if !IsSessionProcessAlive(sessDir) {
+		t.Fatalf("pid 1 (init) must read as ALIVE (EPERM=exists-under-other-uid), got dead")
+	}
+}
+
 func TestSessionReapEligible(t *testing.T) {
 	self := os.Getpid()
 	selfStart, hasStart := readProcStartTime(self)
@@ -192,5 +240,54 @@ func TestSessionResumeRefreshesPid(t *testing.T) {
 	// And the refreshed anchor must now read as ALIVE.
 	if !IsSessionProcessAlive(sessDir) {
 		t.Fatalf("expected refreshed session anchor to be alive")
+	}
+}
+
+// TestSessionResumeRemovesStaleAnchor proves the stale-anchor removal arm of FIX
+// A: when resume cannot resolve a fresh owner (no .launch-mode at all), any
+// pre-existing .session-pid is REMOVED so the resumed session degrades to LIVE
+// rather than carrying a dead pid that would false-reap it.
+func TestSessionResumeRemovesStaleAnchor(t *testing.T) {
+	clearNestedSessionEnv(t)
+
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, ".wipnote"), 0o755); err != nil {
+		t.Fatalf("mkdir .wipnote: %v", err)
+	}
+
+	database, err := openWipnoteTestDB(t, projectDir)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer database.Close()
+
+	sessionID := "test-resume-remove-stale-001"
+	if err := db.InsertSession(database, &models.Session{
+		SessionID:     sessionID,
+		AgentAssigned: "claude-code",
+		Status:        "completed",
+		CreatedAt:     time.Now().UTC(),
+		ProjectDir:    paths.NormalizeProjectDir(projectDir),
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	sessDir := filepath.Join(projectDir, ".wipnote", "sessions", sessionID)
+	// Pre-write a STALE dead pid anchor.
+	writeSessionPIDRaw(t, sessDir, "2147483647\n999999")
+
+	// No .launch-mode written → resolveOwningPID returns ok=false → the anchor
+	// must be REMOVED, not left in place.
+	event := &CloudEvent{SessionID: sessionID, CWD: projectDir}
+	if _, err := SessionResume(event, database, projectDir); err != nil {
+		t.Fatalf("SessionResume: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(sessDir, ".session-pid")); !os.IsNotExist(err) {
+		t.Fatalf("stale .session-pid must be removed on resume with unresolvable owner (stat err=%v)", err)
+	}
+	// With no anchor, the session safe-degrades to LIVE (never reaped).
+	if !IsSessionProcessAlive(sessDir) {
+		t.Fatalf("session with removed anchor must degrade to LIVE")
 	}
 }

--- a/core/hooks/session_liveness_test.go
+++ b/core/hooks/session_liveness_test.go
@@ -1,0 +1,196 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shakestzd/wipnote/core/db"
+	"github.com/shakestzd/wipnote/core/models"
+	"github.com/shakestzd/wipnote/core/paths"
+)
+
+// writeSessionPIDRaw writes a .session-pid file with explicit content so tests
+// can construct legacy (1-line) and starttime-bearing (2-line) variants without
+// depending on the production resolver.
+func writeSessionPIDRaw(t *testing.T, sessDir, content string) {
+	t.Helper()
+	if err := os.MkdirAll(sessDir, 0o755); err != nil {
+		t.Fatalf("mkdir sessDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sessDir, ".session-pid"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write .session-pid: %v", err)
+	}
+}
+
+func TestIsSessionProcessAlive(t *testing.T) {
+	self := os.Getpid()
+	selfStart, ok := readProcStartTime(self)
+
+	t.Run("self pid with real starttime is alive", func(t *testing.T) {
+		sessDir := t.TempDir()
+		content := strconv.Itoa(self)
+		if ok {
+			content += "\n" + strconv.FormatUint(selfStart, 10)
+		}
+		writeSessionPIDRaw(t, sessDir, content)
+		if !IsSessionProcessAlive(sessDir) {
+			t.Fatalf("expected self pid %d to be alive", self)
+		}
+	})
+
+	t.Run("self pid only (legacy single line) is alive", func(t *testing.T) {
+		sessDir := t.TempDir()
+		writeSessionPIDRaw(t, sessDir, strconv.Itoa(self))
+		if !IsSessionProcessAlive(sessDir) {
+			t.Fatalf("expected self pid %d (single line) to be alive", self)
+		}
+	})
+
+	t.Run("certainly-dead pid is dead", func(t *testing.T) {
+		sessDir := t.TempDir()
+		// 2147483647 = max int32; no such process on any realistic system.
+		writeSessionPIDRaw(t, sessDir, "2147483647")
+		if IsSessionProcessAlive(sessDir) {
+			t.Fatalf("expected pid 2147483647 to be reported dead")
+		}
+	})
+
+	t.Run("self pid with bogus starttime is dead (PID reuse)", func(t *testing.T) {
+		if !ok {
+			t.Skip("no /proc starttime available on this platform; PID-reuse path is unreachable")
+		}
+		sessDir := t.TempDir()
+		// starttime "1" can never match the real boot-relative start tick.
+		writeSessionPIDRaw(t, sessDir, strconv.Itoa(self)+"\n1")
+		if IsSessionProcessAlive(sessDir) {
+			t.Fatalf("expected starttime mismatch to be reported dead (PID reuse)")
+		}
+	})
+
+	t.Run("missing file is alive (legacy/unresolved degrades to LIVE)", func(t *testing.T) {
+		sessDir := t.TempDir() // no .session-pid written
+		if !IsSessionProcessAlive(sessDir) {
+			t.Fatalf("expected missing .session-pid to degrade to LIVE")
+		}
+	})
+}
+
+func TestSessionReapEligible(t *testing.T) {
+	self := os.Getpid()
+	selfStart, hasStart := readProcStartTime(self)
+
+	aliveDir := t.TempDir()
+	content := strconv.Itoa(self)
+	if hasStart {
+		content += "\n" + strconv.FormatUint(selfStart, 10)
+	}
+	writeSessionPIDRaw(t, aliveDir, content)
+
+	deadDir := t.TempDir()
+	writeSessionPIDRaw(t, deadDir, "2147483647")
+
+	missingDir := t.TempDir() // no .session-pid
+
+	cases := []struct {
+		name           string
+		heartbeatStale bool
+		sessDir        string
+		want           bool
+	}{
+		{"alive + stale -> not eligible", true, aliveDir, false},
+		{"alive + fresh -> not eligible", false, aliveDir, false},
+		{"dead + stale -> eligible", true, deadDir, true},
+		{"dead + fresh -> not eligible", false, deadDir, false},
+		{"missing + stale -> not eligible (LIVE)", true, missingDir, false},
+		{"missing + fresh -> not eligible (LIVE)", false, missingDir, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SessionReapEligible(tc.heartbeatStale, tc.sessDir); got != tc.want {
+				t.Fatalf("SessionReapEligible(%v, %q) = %v, want %v",
+					tc.heartbeatStale, tc.sessDir, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSessionResumeRefreshesPid(t *testing.T) {
+	clearNestedSessionEnv(t)
+
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, ".wipnote"), 0o755); err != nil {
+		t.Fatalf("mkdir .wipnote: %v", err)
+	}
+
+	database, err := openWipnoteTestDB(t, projectDir)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer database.Close()
+
+	sessionID := "test-resume-refresh-pid-001"
+	if err := db.InsertSession(database, &models.Session{
+		SessionID:     sessionID,
+		AgentAssigned: "claude-code",
+		Status:        "completed",
+		CreatedAt:     time.Now().UTC(),
+		ProjectDir:    paths.NormalizeProjectDir(projectDir),
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	sessDir := filepath.Join(projectDir, ".wipnote", "sessions", sessionID)
+	// Pre-write a STALE pid that is certainly not us.
+	writeSessionPIDRaw(t, sessDir, "2147483647\n999999")
+
+	// Write .launch-mode with the live (this-process) pid, mimicking the
+	// resuming launcher rewriting the marker.
+	marker := launchModeFile{Mode: "claude", PID: os.Getpid(), Timestamp: time.Now().UTC().Format(time.RFC3339)}
+	data, err := json.Marshal(marker)
+	if err != nil {
+		t.Fatalf("marshal launch-mode: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".wipnote", ".launch-mode"), data, 0o644); err != nil {
+		t.Fatalf("write .launch-mode: %v", err)
+	}
+
+	event := &CloudEvent{SessionID: sessionID, CWD: projectDir}
+	if _, err := SessionResume(event, database, projectDir); err != nil {
+		t.Fatalf("SessionResume: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(sessDir, ".session-pid"))
+	if err != nil {
+		t.Fatalf("read refreshed .session-pid: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(got)), "\n")
+	pid, err := strconv.Atoi(strings.TrimSpace(lines[0]))
+	if err != nil {
+		t.Fatalf("parse refreshed pid %q: %v", lines[0], err)
+	}
+	if pid != os.Getpid() {
+		t.Fatalf("expected refreshed pid %d, got %d (stale pid was carried)", os.Getpid(), pid)
+	}
+	// If we have a real starttime, the refreshed file must carry it on line 2.
+	if selfStart, ok := readProcStartTime(os.Getpid()); ok {
+		if len(lines) < 2 {
+			t.Fatalf("expected 2-line .session-pid with starttime, got %q", string(got))
+		}
+		recorded, err := strconv.ParseUint(strings.TrimSpace(lines[1]), 10, 64)
+		if err != nil {
+			t.Fatalf("parse refreshed starttime %q: %v", lines[1], err)
+		}
+		if recorded != selfStart {
+			t.Fatalf("refreshed starttime = %d, want %d", recorded, selfStart)
+		}
+	}
+	// And the refreshed anchor must now read as ALIVE.
+	if !IsSessionProcessAlive(sessDir) {
+		t.Fatalf("expected refreshed session anchor to be alive")
+	}
+}

--- a/core/hooks/session_start.go
+++ b/core/hooks/session_start.go
@@ -266,6 +266,18 @@ func SessionStart(event *CloudEvent, database *sql.DB, projectDir string) (*Hook
 		"session": shortID,
 	}, txStart, "session+lineage routed")
 
+	// Record the session process-liveness anchor (feat-0a7db952, slice-1).
+	// Writing the owning pid (+ /proc start-time) lets the reaper distinguish a
+	// crashed session from a long-idle LIVE one. Best-effort: a write failure
+	// must NEVER block or fail the hook — when the owner is unresolvable we omit
+	// .session-pid entirely so the session safe-degrades to LIVE (never reaped).
+	if ownerPID, ok := resolveOwningPID(projectDir); ok {
+		sessDir := filepath.Join(projectDir, ".wipnote", "sessions", sessionID)
+		if err := writeSessionPID(sessDir, ownerPID); err != nil {
+			debugLog(projectDir, "[session-start] writeSessionPID failed (session=%s pid=%d): %v", shortID, ownerPID, err)
+		}
+	}
+
 	// Write canonical session HTML file (non-critical, errors silently logged).
 	CreateSessionHTML(projectDir, s)
 

--- a/core/hooks/session_start.go
+++ b/core/hooks/session_start.go
@@ -112,6 +112,14 @@ var allowedHarnesses = map[string]struct{}{
 	"antigravity": {},
 }
 
+// sessionStartReapCap bounds how many stale sessions the SYNCHRONOUS SessionStart
+// self-heal reaper will transition per launch. The reaper runs on the hot hook
+// path; under write contention each candidate can cost ~one busy-timeout, so an
+// uncapped pass over a large stale backlog could stall the launcher. 64 keeps the
+// worst case bounded while the long-lived daemon (which passes 0 ⇒ unbounded)
+// catches any remainder within one interval.
+const sessionStartReapCap = 64
+
 // bareLaunchNudge returns an extra startup hint when Claude was started without
 // `wipnote claude` (i.e. .launch-mode is missing or older than 30 seconds).
 // Returns an empty string when the orchestrator system prompt is already active.
@@ -122,8 +130,9 @@ func bareLaunchNudge(projectDir string) string {
 	path := filepath.Join(projectDir, ".wipnote", ".launch-mode")
 	info, err := os.Stat(path)
 	if err == nil {
-		// File exists — check if it was written within the last 30 seconds.
-		if time.Since(info.ModTime()) <= 30*time.Second {
+		// File exists — check if it was written within the freshness window
+		// (shared with resolveOwningPID so both agree on "this session").
+		if time.Since(info.ModTime()) <= launchMarkerFreshWindow {
 			return ""
 		}
 	}
@@ -271,12 +280,8 @@ func SessionStart(event *CloudEvent, database *sql.DB, projectDir string) (*Hook
 	// crashed session from a long-idle LIVE one. Best-effort: a write failure
 	// must NEVER block or fail the hook — when the owner is unresolvable we omit
 	// .session-pid entirely so the session safe-degrades to LIVE (never reaped).
-	if ownerPID, ok := resolveOwningPID(projectDir); ok {
-		sessDir := filepath.Join(projectDir, ".wipnote", "sessions", sessionID)
-		if err := writeSessionPID(sessDir, ownerPID); err != nil {
-			debugLog(projectDir, "[session-start] writeSessionPID failed (session=%s pid=%d): %v", shortID, ownerPID, err)
-		}
-	}
+	sessDir := filepath.Join(projectDir, ".wipnote", "sessions", sessionID)
+	updateSessionPIDAnchor(projectDir, sessDir)
 
 	// Self-heal: reap stale-active SESSIONS left by a prior abnormal exit. Sessions
 	// only (includeCollectors=false) — marking ended is cheap and synchronous and
@@ -284,7 +289,7 @@ func SessionStart(event *CloudEvent, database *sql.DB, projectDir string) (*Hook
 	// the long-lived daemon (a fire-and-forget goroutine here would be killed on
 	// hook exit — roborev #542). Own sid passed for self-exclusion; not report-only.
 	if database != nil {
-		_ = ReapStaleSessionsAndCollectors(database, projectDir, sessionID, false, false)
+		_ = ReapStaleSessionsAndCollectors(database, projectDir, sessionID, false, false, sessionStartReapCap)
 	}
 
 	// Write canonical session HTML file (non-critical, errors silently logged).

--- a/core/hooks/session_start.go
+++ b/core/hooks/session_start.go
@@ -278,6 +278,15 @@ func SessionStart(event *CloudEvent, database *sql.DB, projectDir string) (*Hook
 		}
 	}
 
+	// Self-heal: reap stale-active SESSIONS left by a prior abnormal exit. Sessions
+	// only (includeCollectors=false) — marking ended is cheap and synchronous and
+	// completes before the short-lived hook process exits. Collectors are reaped by
+	// the long-lived daemon (a fire-and-forget goroutine here would be killed on
+	// hook exit — roborev #542). Own sid passed for self-exclusion; not report-only.
+	if database != nil {
+		_ = ReapStaleSessionsAndCollectors(database, projectDir, sessionID, false, false)
+	}
+
 	// Write canonical session HTML file (non-critical, errors silently logged).
 	CreateSessionHTML(projectDir, s)
 

--- a/core/hooks/session_start_reaper_test.go
+++ b/core/hooks/session_start_reaper_test.go
@@ -1,0 +1,84 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestSessionStartReapsStaleSessionsOnly proves the SessionStart wire-in (slice-4):
+// the hook self-heals by reaping stale-active SESSIONS left by a prior abnormal
+// exit, but does so SESSIONS-ONLY (includeCollectors=false). A stale OTHER session
+// with both a dead .session-pid AND an orphan .collector-pid is transitioned to
+// completed, while the collector seam (ReapCollectorFn) is NEVER invoked and the
+// orphan .collector-pid is left untouched — collectors are the daemon's job.
+func TestSessionStartReapsStaleSessionsOnly(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, ".wipnote"), 0o755); err != nil {
+		t.Fatalf("mkdir .wipnote: %v", err)
+	}
+
+	database, err := openWipnoteTestDB(t, projectDir)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer database.Close()
+
+	// Unset env vars that would override the resolved session ID or flag this as a
+	// subagent (which would make SessionStart write under the real session ID).
+	t.Setenv("CLAUDE_SESSION_ID", "")
+	t.Setenv("WIPNOTE_PARENT_SESSION", "")
+	t.Setenv("WIPNOTE_NESTING_DEPTH", "")
+	t.Setenv("CLAUDE_ENV_FILE", "")
+
+	// Seed a stale-active OTHER session: no claim ⇒ heartbeat stale; .session-pid
+	// with a certainly-dead pid ⇒ owner process dead ⇒ reap-eligible. Plus an
+	// orphan .collector-pid so the collector phase WOULD fire if it were enabled.
+	const other = "sess-stale-other-001"
+	seedReaperSession(t, database, other)
+	otherDir := filepath.Join(projectDir, ".wipnote", "sessions", other)
+	writeDeadPID(t, otherDir)
+	collectorPID := filepath.Join(otherDir, ".collector-pid")
+	if err := os.WriteFile(collectorPID, []byte("2147483647\n1"), 0o644); err != nil {
+		t.Fatalf("write .collector-pid: %v", err)
+	}
+
+	// Fake the collector seam so we can prove it is NEVER called on the hook path.
+	prev := ReapCollectorFn
+	t.Cleanup(func() { ReapCollectorFn = prev })
+	collectorCalled := false
+	ReapCollectorFn = func(string, time.Duration) (int, bool) {
+		collectorCalled = true
+		return 0, true
+	}
+
+	// Invoke SessionStart for a NEW session (CWD == projectDir keeps it hermetic:
+	// no worktree gitdir repair path is taken).
+	const current = "sess-start-new-001"
+	event := &CloudEvent{SessionID: current, CWD: projectDir}
+	if _, err := SessionStart(event, database, projectDir); err != nil {
+		t.Fatalf("SessionStart: %v", err)
+	}
+
+	// The OTHER stale session must be reaped (active → completed).
+	if got := sessionStatus(t, database, other); got != "completed" {
+		t.Fatalf("stale OTHER session status=%q, want completed (must be reaped on SessionStart)", got)
+	}
+
+	// The NEW session must remain active (self-exclusion).
+	if got := sessionStatus(t, database, current); got != "active" {
+		t.Fatalf("new session status=%q, want active (must NOT reap itself)", got)
+	}
+
+	// The collector seam must NEVER fire — SessionStart passes includeCollectors=false.
+	if collectorCalled {
+		t.Fatal("ReapCollectorFn was invoked: SessionStart must reap SESSIONS ONLY (includeCollectors=false)")
+	}
+
+	// The orphan .collector-pid must still exist — collectors are reaped by the
+	// long-lived daemon, never by the short-lived hook.
+	if _, err := os.Stat(collectorPID); err != nil {
+		t.Fatalf("orphan .collector-pid must be left untouched by the hook path: %v", err)
+	}
+}

--- a/observe/otel/collector/lifecycle.go
+++ b/observe/otel/collector/lifecycle.go
@@ -458,6 +458,52 @@ func RemoveCollectorPID(projectDir, sessionID string) {
 	_ = os.Remove(pidPath)
 }
 
+// ReapCollector terminates an identity-verified orphaned collector for the
+// session at sessDir and clears its .collector-pid. It is the reaper's
+// collector-killer and the identity-verified counterpart of the legacy
+// signalCollector (core/hooks/session_end.go), which reads the pid as a RAW int
+// with no start-time check. ReapCollector gates EVERY kill on IsCollectorAlive,
+// so a dead pid, a reused pid (start-time mismatch), or a missing record is
+// never signalled.
+//
+// Returns the pid found in the record (0 when none) and whether a live wipnote
+// collector was actually reaped:
+//
+//   - !alive (pid dead, start-time mismatch/reused, or no record): no signal is
+//     sent. The (possibly stale/reused) .collector-pid is removed idempotently.
+//     Returns (pid, false).
+//   - alive (verified wipnote collector): SIGTERM, then poll kill(pid,0) up to
+//     grace; if still alive, SIGKILL; then remove .collector-pid. Returns
+//     (pid, true).
+//
+// Best-effort and never blocks beyond grace. Wired into core/hooks via
+// hooks.ReapCollectorFn by observe/register.
+func ReapCollector(sessDir string, grace time.Duration) (pid int, reaped bool) {
+	alive, pid := IsCollectorAlive(sessDir)
+	pidPath := filepath.Join(sessDir, ".collector-pid")
+	if !alive {
+		// Dead, reused, or no record — never signal a pid we can't positively
+		// prove is the wipnote collector. Just clear the stale record.
+		_ = os.Remove(pidPath)
+		return pid, false
+	}
+
+	// Verified-live wipnote collector: graceful drain then escalate.
+	_ = syscall.Kill(pid, syscall.SIGTERM)
+	deadline := time.Now().Add(grace)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err != nil {
+			break // process exited
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err := syscall.Kill(pid, 0); err == nil {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+	}
+	_ = os.Remove(pidPath)
+	return pid, true
+}
+
 // WriteCollectorPID writes the collector PID to the session directory.
 // On Linux, also appends the process start time (clock ticks from
 // /proc/<pid>/stat field 22) on a second line so future liveness checks

--- a/observe/otel/collector/reap_test.go
+++ b/observe/otel/collector/reap_test.go
@@ -1,0 +1,113 @@
+package collector
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// collectorPIDExists reports whether the .collector-pid file is present in
+// sessDir.
+func collectorPIDExists(sessDir string) bool {
+	_, err := os.Stat(filepath.Join(sessDir, ".collector-pid"))
+	return err == nil
+}
+
+// TestReapCollector_IdentityGuard proves ReapCollector is NOT the raw
+// signalCollector: it writes a .collector-pid pointing at THIS live test
+// process (os.Getpid()) but with a BOGUS recorded start time, so the
+// start-time identity check in IsCollectorAlive rejects it as a reused pid.
+// ReapCollector must therefore NOT signal anything — the fact this test
+// process survives is the proof — and must clear the stale record.
+func TestReapCollector_IdentityGuard(t *testing.T) {
+	sessDir := t.TempDir()
+	pid := os.Getpid()
+	// pid is live, but starttime=1 will never match this process's real start.
+	content := strconv.Itoa(pid) + "\n1\n"
+	if err := os.WriteFile(filepath.Join(sessDir, ".collector-pid"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write .collector-pid: %v", err)
+	}
+
+	gotPID, reaped := ReapCollector(sessDir, 2*time.Second)
+
+	if reaped {
+		t.Fatal("identity mismatch must NOT be reaped (would have signalled a non-collector pid)")
+	}
+	if gotPID != pid {
+		t.Fatalf("returned pid=%d, want recorded pid %d", gotPID, pid)
+	}
+	// Prove we are still alive (ReapCollector did not signal us).
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("test process should be alive: %v", err)
+	}
+	if collectorPIDExists(sessDir) {
+		t.Fatal(".collector-pid must be cleared even when not reaped")
+	}
+}
+
+// TestReapCollector_DeadPid writes a record for a certainly-dead pid. No kill,
+// reaped==false, record cleared.
+func TestReapCollector_DeadPid(t *testing.T) {
+	sessDir := t.TempDir()
+	content := "2147483647\n1\n" // max int32 pid, never running
+	if err := os.WriteFile(filepath.Join(sessDir, ".collector-pid"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write .collector-pid: %v", err)
+	}
+
+	pid, reaped := ReapCollector(sessDir, 2*time.Second)
+	if reaped {
+		t.Fatal("dead pid must not be reaped")
+	}
+	if pid != 2147483647 {
+		t.Fatalf("returned pid=%d, want 2147483647", pid)
+	}
+	if collectorPIDExists(sessDir) {
+		t.Fatal(".collector-pid must be cleared for a dead pid")
+	}
+}
+
+// TestReapCollector_LiveCollector spawns a real child, records its pid+real
+// start time via WriteCollectorPID (so IsCollectorAlive verifies it), then
+// reaps it. The child must be gone, reaped==true, and the record cleared.
+func TestReapCollector_LiveCollector(t *testing.T) {
+	projectDir := t.TempDir()
+	const sid = "sess-live-collector"
+	sessDir := filepath.Join(projectDir, ".wipnote", "sessions", sid)
+
+	cmd := exec.Command("sleep", "300")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		// Defensive: ensure the child is gone even if the assertion path fails.
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	// WriteCollectorPID records the real pid + /proc start time → identity match.
+	WriteCollectorPID(projectDir, sid, cmd.Process.Pid)
+	if alive, _ := IsCollectorAlive(sessDir); !alive {
+		t.Fatalf("precondition: collector should be alive before reap")
+	}
+
+	pid, reaped := ReapCollector(sessDir, 2*time.Second)
+	if !reaped {
+		t.Fatal("live verified collector must be reaped")
+	}
+	if pid != cmd.Process.Pid {
+		t.Fatalf("returned pid=%d, want child pid %d", pid, cmd.Process.Pid)
+	}
+
+	// The child must be gone: reap the zombie and confirm kill(pid,0) → ESRCH.
+	_, _ = cmd.Process.Wait()
+	if err := syscall.Kill(cmd.Process.Pid, 0); err == nil {
+		t.Fatalf("child pid %d should be dead after reap", cmd.Process.Pid)
+	}
+	if collectorPIDExists(sessDir) {
+		t.Fatal(".collector-pid must be cleared after reaping a live collector")
+	}
+}

--- a/observe/register/observe.go
+++ b/observe/register/observe.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 
 	"github.com/shakestzd/wipnote/core/hooks"
+	"github.com/shakestzd/wipnote/observe/otel/collector"
 	"github.com/shakestzd/wipnote/observe/otel/materialize"
 	"github.com/shakestzd/wipnote/observe/otel/retention"
 	"github.com/shakestzd/wipnote/port/pluginbuild"
@@ -22,6 +23,7 @@ func init() {
 	hooks.RetentionSweepFn = runRetentionSweep
 	hooks.SessionMaterializeFn = materialize.Materialize
 	hooks.PortDriftPathsFn = portDriftPaths
+	hooks.ReapCollectorFn = collector.ReapCollector
 }
 
 // runRetentionSweep performs a disk-retention pass for the project: rotate


### PR DESCRIPTION
## Session/collector reaper — convert liveness detection into remediation (plan-5748e9a8, trk-c4615ad2)

wipnote detected liveness everywhere (claim heartbeats; collector pid kill-0 + start-time) but had **no reaper** that acted on it: a session set `active` at start only flipped to `completed` on a clean SessionEnd, so abnormal termination (agent kill, Codespaces disconnect, crash) stranded it `active` forever, and orphaned OTel collectors leaked RAM + ports. This adds a reaper that runs on SessionStart and on a periodic daemon tick.

### Slices
- **feat-d5fa4f19** — config knobs: `reaper_session_ttl_seconds` (1800), `reaper_collector_grace_seconds` (10), `reaper_daemon_report_only` (false), mirroring the `livenessConfig` reader.
- **feat-0a7db952** — session process-liveness anchor: writes `.session-pid` (pid + /proc start-time) from the `.launch-mode` marker; `IsSessionProcessAlive` + pure `SessionReapEligible`; refreshes on resume. **Safe-degrade-to-LIVE is the load-bearing invariant** — anything not provably dead is treated as live, so a long-idle session is never false-reaped.
- **feat-88f92f44** — reaper pass `ReapStaleSessionsAndCollectors`: idempotent `UPDATE … WHERE status='active'` + RowsAffected; identity-verified collector reap (`ReapCollector` composes `IsCollectorAlive`, **not** the raw-int `signalCollector`); audit via new `ReconcileReport.{ReapedSessions,ReapedCollectors}` — no schema/migration.
- **feat-2e98d8f0** — wire-in: SessionStart reaps **sessions only** (synchronous, bounded by `sessionStartReapCap`, no goroutine that could outlive the hook); the daemon `startReaperLoop` reaps sessions + collectors on the 5-min `orphanDrainInterval`. Both call the dedicated pass, never full `Reconcile`.

### Module boundary
`core` cannot import `observe` (observe→core already exists), so collector killing goes through a `ReapCollectorFn` injection seam in `core/hooks/lifecycle_injection.go`, wired from `observe/register` (same pattern as `PortDriftPathsFn`).

### Review fixes (bug-30a6cfad, bug-356321b6)
Two independent reviews (per-commit roborev panel + an adversarial agent) surfaced 5 real findings, all fixed with tests:
- **Stale `.launch-mode` → false-reap**: `resolveOwningPID` now gates on marker freshness (30s) and removes a stale `.session-pid` on resume.
- **`kill(pid,0)=EPERM` treated as dead** → now treated as ALIVE (Linux foreign-uid), preventing false-reap of a reused pid.
- **Reaped sessions leaked active claims** → now release claims (parity with SessionEnd).
- **Unbounded synchronous hook-path reaping** → capped; daemon does the full sweep.
- **`filepath.Glob` on paths with glob metacharacters** → `os.ReadDir`.
- Plus aligned a stale dashboard test and the write-boundary inventory after the wire-in shifted a line.

### Verification
- `go build`/`go vet` green across `core`, `observe`, root.
- Scoped reaper/liveness/collector/loop tests green; full `wipnote check --gate` passed; both reviews closed.

> Note: cleanly cherry-picked onto `main` (the original `trk-c4615ad2` branch history contains an unrelated 225 MB `events.ndjson` artifact from a prior `wipnote: sync` commit that exceeds GitHub's 100 MB limit; this PR carries only the 7 code commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
