### PR TITLE
fix: cross-harness session-identity + research-guard + commit-guard (issue #144)

### DIFF
--- a/cmd/wipnote/claude_chooser.go
+++ b/cmd/wipnote/claude_chooser.go
@@ -175,16 +175,18 @@ func resolveCurrentSessionIDs(projectRoot string) []string {
 	// during nested launches (for example Claude -> `wipnote codex --dev`), so
 	// it is a fallback, not the primary identity, when a launcher stamps a
 	// more specific harness marker.
+	//
+	// agent.HarnessNativeEnvSessionID() is the canonical shared implementation
+	// (WIPNOTE_HARNESS=codex→CODEX_THREAD_ID, gemini→GEMINI_SESSION_ID,
+	// antigravity→ANTIGRAVITY_SESSION_ID). Chooser-specific secondary IDs
+	// (WIPNOTE_OTEL_SESSION, CLAUDE_CODE_SESSION_ID, CLAUDE_SESSION_ID) are
+	// handled in the residual switch below.
 	currentHarness := strings.ToLower(strings.TrimSpace(os.Getenv(harnessEnvKey)))
+	if primaryID := agent.HarnessNativeEnvSessionID(); primaryID != "" {
+		nativeIDFound = add(primaryID) || nativeIDFound
+	}
 	switch currentHarness {
-	case harnessCodex:
-		nativeIDFound = add(os.Getenv("CODEX_THREAD_ID")) || nativeIDFound
-		nativeIDFound = add(os.Getenv("WIPNOTE_OTEL_SESSION")) || nativeIDFound
-	case harnessGemini:
-		nativeIDFound = add(os.Getenv("GEMINI_SESSION_ID")) || nativeIDFound
-		nativeIDFound = add(os.Getenv("WIPNOTE_OTEL_SESSION")) || nativeIDFound
-	case harnessAntigravity:
-		nativeIDFound = add(os.Getenv("ANTIGRAVITY_SESSION_ID")) || nativeIDFound
+	case harnessCodex, harnessGemini, harnessAntigravity:
 		nativeIDFound = add(os.Getenv("WIPNOTE_OTEL_SESSION")) || nativeIDFound
 	case harnessClaude:
 		nativeIDFound = add(os.Getenv("CLAUDE_CODE_SESSION_ID")) || nativeIDFound

--- a/cmd/wipnote/launchtui/spinner.go
+++ b/cmd/wipnote/launchtui/spinner.go
@@ -35,19 +35,26 @@ func isTTYWriter(w io.Writer) bool {
 //   - On a TTY: the spinner animates on one line while fn runs in a goroutine;
 //     fn's output is captured and rendered as a composed block beneath a final
 //     ✓ / ✗ resolution line once fn returns.
-//   - Off a TTY (pipe, file, io.Discard, tests): NO animation and NO extra
-//     chrome — a static label line is emitted before fn is called with w directly.
-//     fn's output then follows. This preserves the operational signal (the label)
-//     while keeping log/CI output plain and readable (feat-e97607b3, bug-7be9b180).
+//   - Off a TTY (pipe, file, io.Discard, tests): NO animation and NO ANSI color —
+//     fn is called with w directly, then a plain (no lipgloss, no ANSI) ✓ or ✗
+//     resolution line is emitted based on fn's actual return value. Emitting after
+//     fn means failed operations never get a premature success mark in CI logs
+//     (feat-e97607b3, bug-7be9b180, roborev-605).
 //
 // The spinner uses bubbles/spinner frame data driven by a plain ticker rather
 // than a full bubbletea program, so it never enters raw mode or the alternate
 // screen and cannot disturb the terminal state the launched harness inherits.
 func RunWithSpinner(w io.Writer, label string, fn func(io.Writer) error) error {
 	if !isTTYWriter(w) {
-		s := NewStyles()
-		fmt.Fprintln(w, s.StatusGreen.Render("✓ "+label))
-		return fn(w)
+		// Non-TTY: run fn first so its output appears before the status line,
+		// then emit a plain (no ANSI, no lipgloss) ✓/✗ line based on the result.
+		err := fn(w)
+		if err != nil {
+			fmt.Fprintln(w, "✗ "+label)
+		} else {
+			fmt.Fprintln(w, "✓ "+label)
+		}
+		return err
 	}
 
 	s := NewStyles()

--- a/cmd/wipnote/launchtui/spinner_test.go
+++ b/cmd/wipnote/launchtui/spinner_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 // TestRunWithSpinner_NonTTYPassthrough verifies the graceful-degrade contract:
-// off a TTY, RunWithSpinner emits the label as a static line and calls fn with
-// the caller's writer directly. No animation or spinner glyphs are added, but the
-// label and fn output both appear (feat-e97607b3, bug-7be9b180).
+// off a TTY, RunWithSpinner calls fn, then emits a plain (no ANSI) ✓ or ✗
+// resolution line. fn's output and the resolution line both appear; no lipgloss
+// color codes are emitted (feat-e97607b3, bug-7be9b180, roborev-605).
 func TestRunWithSpinner_NonTTYPassthrough(t *testing.T) {
 	var buf bytes.Buffer
 	calls := 0
@@ -27,21 +27,25 @@ func TestRunWithSpinner_NonTTYPassthrough(t *testing.T) {
 		t.Fatalf("fn should be called exactly once, got %d", calls)
 	}
 	output := buf.String()
-	// The output should now contain both the label line and fn's output
+	// Both fn output and the resolution label must appear.
 	if !strings.Contains(output, "Preparing worktree") {
 		t.Errorf("off-TTY output must include the label; got %q", output)
 	}
 	if !strings.Contains(output, "Worktree: /tmp/wt (branch: feat-x)") {
 		t.Errorf("off-TTY output must include fn's output; got %q", output)
 	}
-	// The label should be prefixed with ✓ to match TTY resolution style
+	// Resolution label must be ✓ (success) and ANSI-free.
 	if !strings.Contains(output, "✓ Preparing worktree") {
-		t.Errorf("off-TTY label should be prefixed with ✓; got %q", output)
+		t.Errorf("off-TTY resolution label should be prefixed with ✓; got %q", output)
+	}
+	if strings.ContainsAny(output, "\x1b") {
+		t.Errorf("off-TTY output must not contain ANSI escape sequences; got %q", output)
 	}
 }
 
 // TestRunWithSpinner_NonTTYErrorPropagates verifies fn's error is returned
-// unchanged and fn's output still passes through.
+// unchanged, fn's output passes through, and a ✗ resolution line is emitted
+// (not ✓ — failed operations must not get a misleading success mark in CI logs).
 func TestRunWithSpinner_NonTTYErrorPropagates(t *testing.T) {
 	var buf bytes.Buffer
 	sentinel := errors.New("worktree add failed")
@@ -52,14 +56,21 @@ func TestRunWithSpinner_NonTTYErrorPropagates(t *testing.T) {
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("expected sentinel error to propagate, got %v", err)
 	}
-	if !strings.Contains(buf.String(), "Warning: boom") {
-		t.Errorf("fn output should still pass through on error; got %q", buf.String())
+	output := buf.String()
+	if !strings.Contains(output, "Warning: boom") {
+		t.Errorf("fn output should still pass through on error; got %q", output)
+	}
+	if !strings.Contains(output, "✗ Preparing worktree") {
+		t.Errorf("off-TTY error path must emit ✗ resolution label; got %q", output)
+	}
+	if strings.Contains(output, "✓ Preparing worktree") {
+		t.Errorf("off-TTY error path must NOT emit ✓ (success) label; got %q", output)
 	}
 }
 
 // TestRunWithSpinner_NonTTYEmitsLabel verifies that on a non-TTY writer,
-// RunWithSpinner emits the label as a static line (with ✓ prefix) before
-// calling fn, even when fn produces no output (bug-7be9b180).
+// RunWithSpinner emits a plain ✓/✗ resolution line even when fn produces no
+// output, and that the output contains no ANSI escape sequences (roborev-605).
 func TestRunWithSpinner_NonTTYEmitsLabel(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -84,6 +95,9 @@ func TestRunWithSpinner_NonTTYEmitsLabel(t *testing.T) {
 			expected := "✓ " + tt.label
 			if !strings.Contains(output, expected) {
 				t.Errorf("off-TTY output must contain label line %q; got %q", expected, output)
+			}
+			if strings.ContainsAny(output, "\x1b") {
+				t.Errorf("off-TTY output must not contain ANSI escape sequences; got %q", output)
 			}
 		})
 	}

--- a/cmd/wipnote/workitem.go
+++ b/cmd/wipnote/workitem.go
@@ -576,11 +576,12 @@ func wiSetStatusWithAgent(typeName, id, status, sessionID, agentID string) error
 			// The correct way to attach a learning post-completion is via
 			// "wipnote arch add", not a non-existent "<type> edit --learning".
 			// Use a known-valid default kind (decision) in the remediation command.
+			// --links accepts work item IDs; --paths accepts file glob patterns.
 			slug := "learning-" + id
 			fmt.Fprintf(os.Stderr,
 				"warning: --learning validation failed (learning NOT attached): %v\n"+
 					"learning body was: %q\n"+
-					"to attach a valid learning, run:\n  wipnote arch add %s --kind decision --body %s --paths %s --created-by wipnote-completion\n",
+					"to attach a valid learning, run:\n  wipnote arch add %s --kind decision --body %s --links %s --created-by wipnote-completion\n",
 				validationErr,
 				learningBody,
 				shellQuote(slug),

--- a/cmd/wipnote/workitem_test.go
+++ b/cmd/wipnote/workitem_test.go
@@ -2142,9 +2142,9 @@ func TestLearningNonFatal_InvalidKind(t *testing.T) {
 		t.Fatalf("start feature: %v", err)
 	}
 
-	// Create a valid learning body (120 words, within limit).
-	validBody := strings.Repeat("word ", 120)
-	validBody = strings.TrimSpace(validBody)
+	// Create a learning body with shell metacharacters to test proper quoting/escaping.
+	// This body will be quoted by shellQuote (unlike the safe slug and id).
+	validBody := `danger; rm -rf $HOME && echo "pwned"` // contains ; space $ & " which are unsafe
 
 	// Set the global wiLearning flag to the valid body but use an INVALID kind.
 	defer func() {
@@ -2203,19 +2203,30 @@ func TestLearningNonFatal_InvalidKind(t *testing.T) {
 		t.Errorf("remediation command should use --links for work item ID; stderr: %s", stderrStr)
 	}
 
-	// 4. Verify shell safety: the slug and body should be properly quoted.
-	// shellQuote wraps values in single-quotes; check that the slug and id are quoted.
+	// 4. Verify shell safety: the body (which contains metacharacters) should be properly quoted.
+	// shellQuote only quotes when input contains unsafe characters; the slug and id are safe,
+	// so they appear unquoted. The body contains shell metacharacters and must be quoted/escaped.
 	if !strings.Contains(stderrStr, "wipnote arch add") {
 		t.Errorf("remediation command should contain 'wipnote arch add'; stderr: %s", stderrStr)
 	}
-	// Slug is "learning-" + featID — verify it appears single-quoted.
-	expectedSlugQuoted := "'learning-" + featID + "'"
-	if !strings.Contains(stderrStr, expectedSlugQuoted) {
-		t.Errorf("remediation command should contain quoted slug %q; stderr: %s", expectedSlugQuoted, stderrStr)
+
+	// Slug is "learning-" + featID (all safe chars) — should appear UNQUOTED.
+	expectedSlugUnquoted := "learning-" + featID
+	if !strings.Contains(stderrStr, expectedSlugUnquoted) {
+		t.Errorf("remediation command should contain unquoted slug %q; stderr: %s", expectedSlugUnquoted, stderrStr)
 	}
-	// Work item ID should appear quoted via --links.
-	expectedIDQuoted := "'"+featID+"'"
-	if !strings.Contains(stderrStr, expectedIDQuoted) {
-		t.Errorf("remediation command should contain quoted id %q after --links; stderr: %s", expectedIDQuoted, stderrStr)
+
+	// Work item ID (all safe chars) should appear UNQUOTED after --links.
+	// (Verify it's there; we don't need to separately check it's unquoted since safe values are never quoted.)
+	if !strings.Contains(stderrStr, "--links "+featID) {
+		t.Errorf("remediation command should contain --links %s; stderr: %s", featID, stderrStr)
+	}
+
+	// The learning body contains shell metacharacters (;, $, &, ", spaces) and must be quoted.
+	// shellQuote wraps it in single quotes and escapes internal single quotes as '\"'\"'.
+	// Our test body contains no single quotes, so the expected form is simply single-quoted.
+	expectedBodyQuoted := `'danger; rm -rf $HOME && echo "pwned"'`
+	if !strings.Contains(stderrStr, expectedBodyQuoted) {
+		t.Errorf("remediation command should contain properly quoted body %q; stderr: %s", expectedBodyQuoted, stderrStr)
 	}
 }

--- a/cmd/wipnote/workitem_test.go
+++ b/cmd/wipnote/workitem_test.go
@@ -2195,10 +2195,27 @@ func TestLearningNonFatal_InvalidKind(t *testing.T) {
 		t.Errorf("remediation command should contain --kind decision as a valid default; stderr: %s", stderrStr)
 	}
 
-	// 3. Verify shell safety: the slug and body should be properly quoted.
-	// The command should have wipnote arch add (slug) --kind decision --body (body) --paths (id)
-	// All user-derived values should be quoted.
+	// 3. Should use --links for the work item ID (not --paths which is for file globs).
+	if strings.Contains(stderrStr, "--paths") {
+		t.Errorf("remediation command should NOT use --paths for work item ID; stderr: %s", stderrStr)
+	}
+	if !strings.Contains(stderrStr, "--links") {
+		t.Errorf("remediation command should use --links for work item ID; stderr: %s", stderrStr)
+	}
+
+	// 4. Verify shell safety: the slug and body should be properly quoted.
+	// shellQuote wraps values in single-quotes; check that the slug and id are quoted.
 	if !strings.Contains(stderrStr, "wipnote arch add") {
 		t.Errorf("remediation command should contain 'wipnote arch add'; stderr: %s", stderrStr)
+	}
+	// Slug is "learning-" + featID — verify it appears single-quoted.
+	expectedSlugQuoted := "'learning-" + featID + "'"
+	if !strings.Contains(stderrStr, expectedSlugQuoted) {
+		t.Errorf("remediation command should contain quoted slug %q; stderr: %s", expectedSlugQuoted, stderrStr)
+	}
+	// Work item ID should appear quoted via --links.
+	expectedIDQuoted := "'"+featID+"'"
+	if !strings.Contains(stderrStr, expectedIDQuoted) {
+		t.Errorf("remediation command should contain quoted id %q after --links; stderr: %s", expectedIDQuoted, stderrStr)
 	}
 }

--- a/core/agent/detect.go
+++ b/core/agent/detect.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -93,6 +94,29 @@ func NormaliseSessionID(raw string) string {
 		return m
 	}
 	return raw
+}
+
+// HarnessNativeEnvSessionID returns the live session/thread ID stamped by the
+// current harness launcher. WIPNOTE_HARNESS is set to the harness name by the
+// wipnote launcher (codex, gemini, antigravity). When a non-Claude harness is
+// detected, the harness-native ID is preferred over WIPNOTE_SESSION_ID because
+// the latter may be inherited (stale) from a parent Claude orchestrator shell
+// (issue #144). Returns "" when no harness-native ID is found, or when running
+// under Claude (where WIPNOTE_SESSION_ID is always current via writeEnvVars).
+//
+// Precedence: CODEX_THREAD_ID → GEMINI_SESSION_ID → ANTIGRAVITY_SESSION_ID
+// depending on the value of WIPNOTE_HARNESS.
+func HarnessNativeEnvSessionID() string {
+	harness := strings.ToLower(strings.TrimSpace(os.Getenv("WIPNOTE_HARNESS")))
+	switch harness {
+	case "codex":
+		return strings.TrimSpace(os.Getenv("CODEX_THREAD_ID"))
+	case "gemini":
+		return strings.TrimSpace(os.Getenv("GEMINI_SESSION_ID"))
+	case "antigravity":
+		return strings.TrimSpace(os.Getenv("ANTIGRAVITY_SESSION_ID"))
+	}
+	return ""
 }
 
 func containsSlash(s string) bool {

--- a/core/agent/detect_test.go
+++ b/core/agent/detect_test.go
@@ -148,6 +148,76 @@ func TestResolveSessionID_GeneratesCLI(t *testing.T) {
 	_ = fmt.Sprintf("cli-PID-TS format: %q", result)
 }
 
+// --- HarnessNativeEnvSessionID tests ---
+
+// TestHarnessNativeEnvSessionID verifies the canonical harness-native session-id
+// resolver: WIPNOTE_HARNESS selects the right env var, and Claude / no-harness
+// both fall through to "" so callers can then consult WIPNOTE_SESSION_ID.
+func TestHarnessNativeEnvSessionID(t *testing.T) {
+	tests := []struct {
+		name         string
+		harness      string
+		codexThread  string
+		geminiSess   string
+		antigravSess string
+		want         string
+	}{
+		{
+			name:        "codex: CODEX_THREAD_ID returned",
+			harness:     "codex",
+			codexThread: "codex-thread-abc",
+			want:        "codex-thread-abc",
+		},
+		{
+			name:       "gemini: GEMINI_SESSION_ID returned",
+			harness:    "gemini",
+			geminiSess: "gemini-sess-xyz",
+			want:       "gemini-sess-xyz",
+		},
+		{
+			name:         "antigravity: ANTIGRAVITY_SESSION_ID returned",
+			harness:      "antigravity",
+			antigravSess: "antigravity-live-456",
+			want:         "antigravity-live-456",
+		},
+		{
+			name:    "claude harness: returns empty (falls through to WIPNOTE_SESSION_ID)",
+			harness: "claude",
+			want:    "",
+		},
+		{
+			name:    "no harness set: returns empty",
+			harness: "",
+			want:    "",
+		},
+		{
+			name:        "codex with empty CODEX_THREAD_ID: returns empty",
+			harness:     "codex",
+			codexThread: "",
+			want:        "",
+		},
+		{
+			name:        "whitespace-only CODEX_THREAD_ID is trimmed to empty",
+			harness:     "codex",
+			codexThread: "   ",
+			want:        "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("WIPNOTE_HARNESS", tc.harness)
+			t.Setenv("CODEX_THREAD_ID", tc.codexThread)
+			t.Setenv("GEMINI_SESSION_ID", tc.geminiSess)
+			t.Setenv("ANTIGRAVITY_SESSION_ID", tc.antigravSess)
+			got := agent.HarnessNativeEnvSessionID()
+			if got != tc.want {
+				t.Errorf("HarnessNativeEnvSessionID() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // --- NormaliseSessionID tests ---
 
 func TestNormaliseSessionID_PlainUUID(t *testing.T) {

--- a/core/hooks/pretooluse.go
+++ b/core/hooks/pretooluse.go
@@ -736,9 +736,21 @@ func isBashFileWrite(event *CloudEvent) bool {
 	return bashFileWritePattern.MatchString(cmd)
 }
 
+// isShellTool reports whether toolName is the harness-native shell invocation
+// tool. Each harness uses a different name:
+//   - Claude Code: "Bash"
+//   - Codex: "exec_command" / "functions.exec_command"
+//   - Gemini: "run_shell_command"
+//   - Antigravity: "run_command" (Antigravity translates run_shell_command →
+//     run_command in its generated agent manifests)
+//
+// This predicate gates shell-only guards (dependency-research check, YOLO commit
+// check, shell file-write protection). Keep in sync with researchShellToolNamesSQL
+// in yolo_guard.go (issue #144).
 func isShellTool(toolName string) bool {
 	switch toolName {
-	case "Bash", "exec_command", "functions.exec_command":
+	case "Bash", "exec_command", "functions.exec_command",
+		"run_shell_command", "run_command":
 		return true
 	}
 	return false

--- a/core/hooks/runner.go
+++ b/core/hooks/runner.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/shakestzd/wipnote/core/agent"
 	"github.com/shakestzd/wipnote/core/db/writequeue"
@@ -314,33 +313,13 @@ func NormaliseSessionID(raw string) string {
 	return agent.NormaliseSessionID(raw)
 }
 
-// harnessNativeEnvSessionID returns the live session/thread ID stamped by the
-// current harness launcher. WIPNOTE_HARNESS is set to the harness name by the
-// wipnote launcher (codex, gemini, antigravity). When present, the harness-
-// native ID is preferred over WIPNOTE_SESSION_ID because the latter may be
-// inherited (stale) from a parent Claude orchestrator shell (issue #144).
-// Returns "" when no harness-native ID is found or when running under Claude
-// (where WIPNOTE_SESSION_ID is always current via writeEnvVars).
-func harnessNativeEnvSessionID() string {
-	harness := strings.ToLower(strings.TrimSpace(os.Getenv("WIPNOTE_HARNESS")))
-	switch harness {
-	case "codex":
-		return strings.TrimSpace(os.Getenv("CODEX_THREAD_ID"))
-	case "gemini":
-		return strings.TrimSpace(os.Getenv("GEMINI_SESSION_ID"))
-	case "antigravity":
-		return strings.TrimSpace(os.Getenv("ANTIGRAVITY_SESSION_ID"))
-	}
-	return ""
-}
-
 // EnvSessionID returns the current session ID using a four-step fallback:
 //  1. CloudEvent session_id (always correct for hook invocations)
 //  2. Harness-native live ID (CODEX_THREAD_ID / GEMINI_SESSION_ID /
 //     ANTIGRAVITY_SESSION_ID), preferred over WIPNOTE_SESSION_ID when a
 //     non-Claude harness launcher is detected via WIPNOTE_HARNESS, because
 //     WIPNOTE_SESSION_ID may carry a stale ID inherited from a parent Claude
-//     orchestrator shell (issue #144).
+//     orchestrator shell (issue #144). Delegates to agent.HarnessNativeEnvSessionID.
 //  3. WIPNOTE_SESSION_ID env var (for CLI commands without a CloudEvent)
 //  4. .wipnote/.active-session file (last resort for edge cases)
 func EnvSessionID(eventSessionID string) string {
@@ -351,7 +330,7 @@ func EnvSessionID(eventSessionID string) string {
 		return sid
 	}
 	// Prefer harness-native live ID over a (possibly stale) WIPNOTE_SESSION_ID.
-	if v := harnessNativeEnvSessionID(); v != "" {
+	if v := agent.HarnessNativeEnvSessionID(); v != "" {
 		return v
 	}
 	// Env var fallback — used by CLI commands that don't have a CloudEvent.

--- a/core/hooks/runner.go
+++ b/core/hooks/runner.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/shakestzd/wipnote/core/agent"
 	"github.com/shakestzd/wipnote/core/db/writequeue"
@@ -313,16 +314,45 @@ func NormaliseSessionID(raw string) string {
 	return agent.NormaliseSessionID(raw)
 }
 
-// EnvSessionID returns the current session ID using a three-step fallback:
+// harnessNativeEnvSessionID returns the live session/thread ID stamped by the
+// current harness launcher. WIPNOTE_HARNESS is set to the harness name by the
+// wipnote launcher (codex, gemini, antigravity). When present, the harness-
+// native ID is preferred over WIPNOTE_SESSION_ID because the latter may be
+// inherited (stale) from a parent Claude orchestrator shell (issue #144).
+// Returns "" when no harness-native ID is found or when running under Claude
+// (where WIPNOTE_SESSION_ID is always current via writeEnvVars).
+func harnessNativeEnvSessionID() string {
+	harness := strings.ToLower(strings.TrimSpace(os.Getenv("WIPNOTE_HARNESS")))
+	switch harness {
+	case "codex":
+		return strings.TrimSpace(os.Getenv("CODEX_THREAD_ID"))
+	case "gemini":
+		return strings.TrimSpace(os.Getenv("GEMINI_SESSION_ID"))
+	case "antigravity":
+		return strings.TrimSpace(os.Getenv("ANTIGRAVITY_SESSION_ID"))
+	}
+	return ""
+}
+
+// EnvSessionID returns the current session ID using a four-step fallback:
 //  1. CloudEvent session_id (always correct for hook invocations)
-//  2. WIPNOTE_SESSION_ID env var (for CLI commands without a CloudEvent)
-//  3. .wipnote/.active-session file (last resort for edge cases)
+//  2. Harness-native live ID (CODEX_THREAD_ID / GEMINI_SESSION_ID /
+//     ANTIGRAVITY_SESSION_ID), preferred over WIPNOTE_SESSION_ID when a
+//     non-Claude harness launcher is detected via WIPNOTE_HARNESS, because
+//     WIPNOTE_SESSION_ID may carry a stale ID inherited from a parent Claude
+//     orchestrator shell (issue #144).
+//  3. WIPNOTE_SESSION_ID env var (for CLI commands without a CloudEvent)
+//  4. .wipnote/.active-session file (last resort for edge cases)
 func EnvSessionID(eventSessionID string) string {
 	// CloudEvent session_id is always correct for this hook invocation.
 	// It takes priority over the env var, which can be overwritten by a
 	// concurrent subagent's writeEnvVars call.
 	if sid := agent.NormaliseSessionID(eventSessionID); sid != "" {
 		return sid
+	}
+	// Prefer harness-native live ID over a (possibly stale) WIPNOTE_SESSION_ID.
+	if v := harnessNativeEnvSessionID(); v != "" {
+		return v
 	}
 	// Env var fallback — used by CLI commands that don't have a CloudEvent.
 	if v := os.Getenv("WIPNOTE_SESSION_ID"); v != "" {

--- a/core/hooks/runner_test.go
+++ b/core/hooks/runner_test.go
@@ -5,6 +5,86 @@ import (
 	"testing"
 )
 
+// TestEnvSessionID_HarnessAware verifies that EnvSessionID picks the
+// harness-native live session ID over a stale WIPNOTE_SESSION_ID when
+// WIPNOTE_HARNESS indicates a non-Claude harness (issue #144).
+func TestEnvSessionID_HarnessAware(t *testing.T) {
+	// Clear any leaked vars from the ambient test environment.
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	t.Setenv("WIPNOTE_PARENT_SESSION", "")
+	t.Setenv("NESTING_DEPTH", "")
+
+	stale := "stale-wipnote-session"
+
+	tests := []struct {
+		name         string
+		harness      string
+		codexThread  string
+		geminiSess   string
+		antigravSess string
+		wipnoteID    string
+		explicitArg  string
+		want         string
+	}{
+		{
+			name:        "Codex: CODEX_THREAD_ID wins over stale WIPNOTE_SESSION_ID",
+			harness:     "codex",
+			codexThread: "codex-thread-live-abc123",
+			wipnoteID:   stale,
+			want:        "codex-thread-live-abc123",
+		},
+		{
+			name:       "Gemini: GEMINI_SESSION_ID wins over stale WIPNOTE_SESSION_ID",
+			harness:    "gemini",
+			geminiSess: "gemini-live-session-xyz",
+			wipnoteID:  stale,
+			want:       "gemini-live-session-xyz",
+		},
+		{
+			name:         "Antigravity: ANTIGRAVITY_SESSION_ID wins over stale WIPNOTE_SESSION_ID",
+			harness:      "antigravity",
+			antigravSess: "antigravity-live-456",
+			wipnoteID:    stale,
+			want:         "antigravity-live-456",
+		},
+		{
+			name:      "Claude (no harness marker): falls through to WIPNOTE_SESSION_ID",
+			harness:   "claude",
+			wipnoteID: "wipnote-claude-session",
+			want:      "wipnote-claude-session",
+		},
+		{
+			name:      "No harness set: falls through to WIPNOTE_SESSION_ID",
+			harness:   "",
+			wipnoteID: "wipnote-only-session",
+			want:      "wipnote-only-session",
+		},
+		{
+			name:        "Explicit arg always wins (hook-path invariant)",
+			harness:     "codex",
+			codexThread: "codex-thread-live",
+			wipnoteID:   stale,
+			explicitArg: "explicit-event-session",
+			want:        "explicit-event-session",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("WIPNOTE_HARNESS", tc.harness)
+			t.Setenv("CODEX_THREAD_ID", tc.codexThread)
+			t.Setenv("GEMINI_SESSION_ID", tc.geminiSess)
+			t.Setenv("ANTIGRAVITY_SESSION_ID", tc.antigravSess)
+			t.Setenv("WIPNOTE_SESSION_ID", tc.wipnoteID)
+
+			got := EnvSessionID(tc.explicitArg)
+			if got != tc.want {
+				t.Errorf("EnvSessionID(%q) = %q, want %q", tc.explicitArg, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCloudEvent_AgentTeamsPayload(t *testing.T) {
 	payload := `{
 		"session_id": "sess-001",

--- a/core/hooks/worktree_commit_guard.go
+++ b/core/hooks/worktree_commit_guard.go
@@ -22,10 +22,10 @@ var agentBranchPrefixes = []string{"worktree-agent-", "subagent-"}
 //   - WIPNOTE_AGENT_BRANCH=1 env var is set → explicitly authorised → allow.
 //   - Branch is not main or master → allow.
 func checkSubagentCommitGuard(event *CloudEvent, parentSessionID string, projectDir string) string {
-	if event.ToolName != "Bash" {
+	if !isShellTool(event.ToolName) {
 		return ""
 	}
-	cmd, _ := event.ToolInput["command"].(string)
+	cmd := shellCommand(event.ToolInput)
 	if !gitCommitPattern.MatchString(cmd) {
 		return ""
 	}

--- a/core/hooks/worktree_commit_guard_test.go
+++ b/core/hooks/worktree_commit_guard_test.go
@@ -99,8 +99,100 @@ func TestCheckSubagentCommitGuard_SubagentOnMain(t *testing.T) {
 		}
 	})
 
-	// Non-Bash tool → always allowed.
-	t.Run("non_bash_tool_is_allowed", func(t *testing.T) {
+	// Gemini run_shell_command → should be blocked (cross-harness coverage).
+	t.Run("gemini_run_shell_command_is_blocked", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if err := initTestGitRepoOnBranch(t, tmpDir, "main"); err != nil {
+			t.Skipf("cannot init git repo: %v", err)
+		}
+		commitEvent := &CloudEvent{
+			ToolName:  "run_shell_command",
+			SessionID: "sub-sess-abc12345",
+			CWD:       tmpDir,
+			ToolInput: map[string]any{
+				"command": "git commit -m \"test commit\"",
+			},
+		}
+		reason := checkSubagentCommitGuard(commitEvent, "parent-sess-xyz", tmpDir)
+		if reason == "" {
+			t.Fatal("expected sub-agent commit via run_shell_command on main to be blocked, but it was allowed")
+		}
+		if !strings.Contains(reason, "blocked") {
+			t.Errorf("expected 'blocked' in reason, got: %q", reason)
+		}
+	})
+
+	// Antigravity run_command → should be blocked (cross-harness coverage).
+	t.Run("antigravity_run_command_is_blocked", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if err := initTestGitRepoOnBranch(t, tmpDir, "main"); err != nil {
+			t.Skipf("cannot init git repo: %v", err)
+		}
+		commitEvent := &CloudEvent{
+			ToolName:  "run_command",
+			SessionID: "sub-sess-abc12345",
+			CWD:       tmpDir,
+			ToolInput: map[string]any{
+				"command": "git commit -m \"test commit\"",
+			},
+		}
+		reason := checkSubagentCommitGuard(commitEvent, "parent-sess-xyz", tmpDir)
+		if reason == "" {
+			t.Fatal("expected sub-agent commit via run_command on main to be blocked, but it was allowed")
+		}
+		if !strings.Contains(reason, "blocked") {
+			t.Errorf("expected 'blocked' in reason, got: %q", reason)
+		}
+	})
+
+	// Codex exec_command with "cmd" key → should be blocked (cross-harness coverage).
+	t.Run("codex_exec_command_is_blocked", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if err := initTestGitRepoOnBranch(t, tmpDir, "main"); err != nil {
+			t.Skipf("cannot init git repo: %v", err)
+		}
+		commitEvent := &CloudEvent{
+			ToolName:  "exec_command",
+			SessionID: "sub-sess-abc12345",
+			CWD:       tmpDir,
+			ToolInput: map[string]any{
+				"cmd": "git commit -m \"test commit\"",
+			},
+		}
+		reason := checkSubagentCommitGuard(commitEvent, "parent-sess-xyz", tmpDir)
+		if reason == "" {
+			t.Fatal("expected sub-agent commit via exec_command on main to be blocked, but it was allowed")
+		}
+		if !strings.Contains(reason, "blocked") {
+			t.Errorf("expected 'blocked' in reason, got: %q", reason)
+		}
+	})
+
+	// Codex functions.exec_command with "cmd" key → should be blocked (cross-harness coverage).
+	t.Run("codex_functions_exec_command_is_blocked", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if err := initTestGitRepoOnBranch(t, tmpDir, "main"); err != nil {
+			t.Skipf("cannot init git repo: %v", err)
+		}
+		commitEvent := &CloudEvent{
+			ToolName:  "functions.exec_command",
+			SessionID: "sub-sess-abc12345",
+			CWD:       tmpDir,
+			ToolInput: map[string]any{
+				"cmd": "git commit -m \"test commit\"",
+			},
+		}
+		reason := checkSubagentCommitGuard(commitEvent, "parent-sess-xyz", tmpDir)
+		if reason == "" {
+			t.Fatal("expected sub-agent commit via functions.exec_command on main to be blocked, but it was allowed")
+		}
+		if !strings.Contains(reason, "blocked") {
+			t.Errorf("expected 'blocked' in reason, got: %q", reason)
+		}
+	})
+
+	// Non-shell tool → always allowed.
+	t.Run("non_shell_tool_is_allowed", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		if err := initTestGitRepoOnBranch(t, tmpDir, "main"); err != nil {
 			t.Skipf("cannot init git repo: %v", err)
@@ -116,7 +208,7 @@ func TestCheckSubagentCommitGuard_SubagentOnMain(t *testing.T) {
 		}
 		reason := checkSubagentCommitGuard(writeEvent, "parent-sess-xyz", tmpDir)
 		if reason != "" {
-			t.Errorf("expected non-Bash tool to be allowed, got: %q", reason)
+			t.Errorf("expected non-shell tool to be allowed, got: %q", reason)
 		}
 	})
 

--- a/core/hooks/yolo_guard.go
+++ b/core/hooks/yolo_guard.go
@@ -1105,10 +1105,11 @@ func buildInClause(ids []string) (string, []any) {
 
 // researchShellToolNamesSQL is the SQL IN-list fragment for all harness shell
 // tool names that can carry research reads: Bash (Claude Code), exec_command
-// and functions.exec_command (Codex), run_shell_command (Gemini). Used in both
-// buildResearchQuery and buildWebResearchQuery so the two stay in lockstep
-// (issue #144).
-const researchShellToolNamesSQL = `'Bash', 'exec_command', 'functions.exec_command', 'run_shell_command'`
+// and functions.exec_command (Codex), run_shell_command (Gemini),
+// run_command (Antigravity — Antigravity translates run_shell_command to
+// run_command in its agent manifests). Used in both buildResearchQuery and
+// buildWebResearchQuery so the two stay in lockstep (issue #144).
+const researchShellToolNamesSQL = `'Bash', 'exec_command', 'functions.exec_command', 'run_shell_command', 'run_command'`
 
 // buildResearchQuery builds the research detection SQL and its argument slice.
 // It matches Read/Grep/Glob (and equivalents) plus web/docs/GitHub research

--- a/core/hooks/yolo_guard.go
+++ b/core/hooks/yolo_guard.go
@@ -1103,6 +1103,13 @@ func buildInClause(ids []string) (string, []any) {
 	return "(" + strings.Join(placeholders, ", ") + ")", args
 }
 
+// researchShellToolNamesSQL is the SQL IN-list fragment for all harness shell
+// tool names that can carry research reads: Bash (Claude Code), exec_command
+// and functions.exec_command (Codex), run_shell_command (Gemini). Used in both
+// buildResearchQuery and buildWebResearchQuery so the two stay in lockstep
+// (issue #144).
+const researchShellToolNamesSQL = `'Bash', 'exec_command', 'functions.exec_command', 'run_shell_command'`
+
 // buildResearchQuery builds the research detection SQL and its argument slice.
 // It matches Read/Grep/Glob (and equivalents) plus web/docs/GitHub research
 // (WebSearch/WebFetch and `gh ...`) under any of the related session IDs, and
@@ -1127,7 +1134,7 @@ func buildResearchQuery(inClause string, inArgs []any, useAgentID bool, agentID,
 				'read_file', 'grep_search', 'glob', 'list_directory',
 				'web_fetch', 'web_search', 'google_web_search'
 			) OR (
-				tool_name = 'Bash' AND (
+				tool_name IN (`+researchShellToolNamesSQL+`) AND (
 					input_summary LIKE 'ls %%' OR input_summary = 'ls'
 					OR input_summary LIKE 'find %%'
 					OR input_summary LIKE 'cat %%'
@@ -1136,6 +1143,9 @@ func buildResearchQuery(inClause string, inArgs []any, useAgentID bool, agentID,
 					OR input_summary LIKE 'tail %%'
 					OR input_summary LIKE 'stat %%'
 					OR input_summary LIKE 'gh %%'
+					OR input_summary LIKE 'curl %%'
+					OR input_summary LIKE 'wipnote sh %%'
+					OR input_summary LIKE 'wipnote search %%'
 				)
 			)
 		  )
@@ -1153,8 +1163,8 @@ func buildResearchQuery(inClause string, inArgs []any, useAgentID bool, agentID,
 // The web tool-name list is kept in lockstep with isOrchestratorResearchTool
 // (which classifies the same tools as web/docs research), and the shell-tool
 // list with isShellTool, so a session that researched via Codex's web.* tools or
-// ran `gh search` through exec_command/functions.exec_command is not falsely
-// blocked (roborev #563/#566/#570).
+// ran `gh search` through exec_command/functions.exec_command/run_shell_command
+// is not falsely blocked (roborev #563/#566/#570, issue #144).
 func buildWebResearchQuery(inClause string, inArgs []any, useAgentID bool, agentID, projectDir string) (string, []any) {
 	sessionFilter, args := sessionOrAgentFilter(inClause, inArgs, useAgentID, agentID, projectDir)
 	query := fmt.Sprintf(`
@@ -1166,7 +1176,7 @@ func buildWebResearchQuery(inClause string, inArgs []any, useAgentID bool, agent
 				'web_search', 'web_fetch', 'google_web_search',
 				'web.search_query', 'web.open', 'web.find', 'web.click'
 			) OR (
-				tool_name IN ('Bash', 'exec_command', 'functions.exec_command')
+				tool_name IN (`+researchShellToolNamesSQL+`)
 				AND input_summary LIKE 'gh %%'
 			)
 		  )

--- a/core/hooks/yolo_guard_research_test.go
+++ b/core/hooks/yolo_guard_research_test.go
@@ -409,6 +409,19 @@ func TestHasRecentResearch_CrossHarnessShellTools(t *testing.T) {
 			inputSummary: "wipnote search 'fn foo'",
 			wantResearch: true,
 		},
+		// Antigravity shell tool (run_command) with a read-like command.
+		{
+			name:         "Antigravity run_command cat counts as research",
+			toolName:     "run_command",
+			inputSummary: "cat AGENTS.md",
+			wantResearch: true,
+		},
+		{
+			name:         "Antigravity run_command grep counts as research",
+			toolName:     "run_command",
+			inputSummary: "grep -rn SessionID core/",
+			wantResearch: true,
+		},
 		// Non-research shell commands must NOT count.
 		{
 			name:         "Bash rm does NOT count as research",
@@ -432,6 +445,12 @@ func TestHasRecentResearch_CrossHarnessShellTools(t *testing.T) {
 			name:         "run_shell_command echo does NOT count as research",
 			toolName:     "run_shell_command",
 			inputSummary: "echo done",
+			wantResearch: false,
+		},
+		{
+			name:         "Antigravity run_command rm does NOT count as research",
+			toolName:     "run_command",
+			inputSummary: "rm -rf build/",
 			wantResearch: false,
 		},
 	}

--- a/core/hooks/yolo_guard_research_test.go
+++ b/core/hooks/yolo_guard_research_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -348,5 +349,117 @@ func TestHasRecentResearch_AgentIDFallbackStillWorksRecent(t *testing.T) {
 	// Calling with this agent_id should return true because the Read is recent and in the same project.
 	if !hasRecentResearch(tdb.DB, sessID, agentID, ".") {
 		t.Error("expected hasRecentResearch=true: agent_id fallback should find recent events in the same project")
+	}
+}
+
+// TestHasRecentResearch_CrossHarnessShellTools verifies that shell reads
+// performed via non-Bash harness tool names (exec_command for Codex,
+// run_shell_command for Gemini) are credited as research (issue #144).
+// Also verifies that curl and wipnote sh/search count in all harnesses, while
+// non-research commands (rm, echo) still do NOT count.
+func TestHasRecentResearch_CrossHarnessShellTools(t *testing.T) {
+	cases := []struct {
+		name         string
+		toolName     string
+		inputSummary string
+		wantResearch bool
+	}{
+		// Codex shell tool with a read-like command.
+		{
+			name:         "Codex exec_command cat counts as research",
+			toolName:     "exec_command",
+			inputSummary: "cat foo.md",
+			wantResearch: true,
+		},
+		{
+			name:         "Codex functions.exec_command cat counts as research",
+			toolName:     "functions.exec_command",
+			inputSummary: "cat README.md",
+			wantResearch: true,
+		},
+		// Gemini shell tool with a read-like command.
+		{
+			name:         "Gemini run_shell_command grep counts as research",
+			toolName:     "run_shell_command",
+			inputSummary: "grep -rn foo /bar",
+			wantResearch: true,
+		},
+		{
+			name:         "Gemini run_shell_command ls counts as research",
+			toolName:     "run_shell_command",
+			inputSummary: "ls -la",
+			wantResearch: true,
+		},
+		// curl and wipnote sh/search via standard Bash.
+		{
+			name:         "Bash curl counts as research",
+			toolName:     "Bash",
+			inputSummary: "curl https://example.com/api",
+			wantResearch: true,
+		},
+		{
+			name:         "Bash wipnote sh counts as research",
+			toolName:     "Bash",
+			inputSummary: `wipnote sh "grep -rn foo ."`,
+			wantResearch: true,
+		},
+		{
+			name:         "Bash wipnote search counts as research",
+			toolName:     "Bash",
+			inputSummary: "wipnote search 'fn foo'",
+			wantResearch: true,
+		},
+		// Non-research shell commands must NOT count.
+		{
+			name:         "Bash rm does NOT count as research",
+			toolName:     "Bash",
+			inputSummary: "rm -rf /tmp/stuff",
+			wantResearch: false,
+		},
+		{
+			name:         "Bash echo does NOT count as research",
+			toolName:     "Bash",
+			inputSummary: "echo hello",
+			wantResearch: false,
+		},
+		{
+			name:         "exec_command rm does NOT count as research",
+			toolName:     "exec_command",
+			inputSummary: "rm file.txt",
+			wantResearch: false,
+		},
+		{
+			name:         "run_shell_command echo does NOT count as research",
+			toolName:     "run_shell_command",
+			inputSummary: "echo done",
+			wantResearch: false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tdb := setupTestDB(t)
+			defer tdb.DB.Close()
+
+			sessID := fmt.Sprintf("cross-harness-test-sess-%02d", i)
+			agentID := fmt.Sprintf("cross-harness-agent-%02d", i)
+
+			insertResearchTestSessionWithProject(t, tdb, sessID, "", ".")
+
+			// Insert the shell read event.
+			insertAgentEventFull(t, tdb, fmt.Sprintf("evt-shell-%02d", i), sessID, agentID, "tool_call", tc.toolName, tc.inputSummary)
+
+			// When wantResearch=false we also need a second tool_call so
+			// fail-open (zero tool_calls) does not mask the false-positive.
+			if !tc.wantResearch {
+				insertAgentEventFull(t, tdb, fmt.Sprintf("evt-other-%02d", i), sessID, agentID, "tool_call", "Write", "out.txt")
+			}
+
+			got := hasRecentResearch(tdb.DB, sessID, agentID, "")
+			if got != tc.wantResearch {
+				t.Errorf("hasRecentResearch for tool=%q cmd=%q = %v, want %v",
+					tc.toolName, tc.inputSummary, got, tc.wantResearch)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the two root-cause defects reported in #144, observed in a Codex session but rooted in harness-blind code shared by all three harnesses.

### Defect 1 — session-identity divergence (CLI claim vs. hook check)

The CLI claim path (`EnvSessionID` → `WIPNOTE_SESSION_ID` → `.active-session`) was **harness-blind**: it never consulted the live harness thread ID. The PreToolUse write-guard path resolves the live session from the harness payload (`CODEX_THREAD_ID` for Codex). When `WIPNOTE_SESSION_ID` carried a stale value inherited from a parent Claude orchestrator shell, the two disagreed: `wipnote feature start` claimed one session, the write hook checked another, and the write was blocked with a non-actionable "run `wipnote feature start`" instruction that did not fix it.

**Cross-harness verdict:** Codex **broken** (no current `WIPNOTE_SESSION_ID` unless inherited); Gemini **latent** same-class bug; Claude Code **safe** (`writeEnvVars` keeps `WIPNOTE_SESSION_ID` current via `CLAUDE_ENV_FILE`).

**Fix:** `EnvSessionID()` is now a four-step chain — explicit arg → harness-native live ID → `WIPNOTE_SESSION_ID` → `.active-session`. The harness→env-var precedence (`WIPNOTE_HARNESS=codex→CODEX_THREAD_ID`, `gemini→GEMINI_SESSION_ID`, `antigravity→ANTIGRAVITY_SESSION_ID`) is extracted into a single canonical resolver `agent.HarnessNativeEnvSessionID()` in `core/agent/detect.go`. Both `core/hooks/runner.go` and `cmd/wipnote/claude_chooser.go` delegate to it (the chooser keeps its residual `WIPNOTE_OTEL_SESSION` / Claude secondary-ID switch). The hook payload-first invariant (`resolveSessionIDWithHarness`) is unchanged.

### Defect 2 — research guard ignored `curl` and `wipnote sh`

The research-required guard counted shell reads only when `tool_name = 'Bash'` and only for a fixed prefix list (`ls/find/cat/grep/head/tail/stat/gh`). This excluded Codex `exec_command`, Gemini `run_shell_command`, and Antigravity `run_command` entirely, and never credited `curl`, `wipnote sh`, or `wipnote search` in any harness. In Codex — which has no native read tool, only `exec_command` — recent local reads and `curl` doc fetches could never satisfy the gate.

**Fix:** `buildResearchQuery` now credits all harness shell tools via a shared `researchShellToolNamesSQL` constant (`Bash`, `exec_command`, `functions.exec_command`, `run_shell_command`, `run_command`) and adds `curl`, `wipnote sh`, and `wipnote search` to the read-prefix allowlist; `buildWebResearchQuery` reuses the same constant so the two stay in lockstep.

## Additional cross-harness hardening (same root cause class)

- **`isShellTool()`** now recognizes `run_shell_command` (Gemini) and `run_command` (Antigravity) alongside `Bash`/`exec_command`/`functions.exec_command`, so every shell-only guard participates across harnesses.
- **`checkSubagentCommitGuard`** was Bash-only and silently let Gemini/Antigravity subagent commits bypass the main-branch guard; it now gates on `!isShellTool(event.ToolName)` and extracts the command via `shellCommand(event.ToolInput)`.
- **Non-TTY spinner** (`RunWithSpinner`) no longer emits a premature `✓` before the operation runs; it runs `fn` first, then emits a plain (ANSI-free) `✓`/`✗` based on the actual result — failed ops no longer get a misleading success mark in CI logs.
- **Completion-learning remediation** command now uses `--links` (work-item IDs) instead of `--paths` (file globs), with the quoting test corrected to assert shell-quoting on the arbitrary-text learning **body** (which contains metacharacters) rather than on the always-safe slug/id.

## Interaction with origin/main's research-enforcement floor

origin/main (v0.67.0) already shipped the parallel research-enforcement floor (`commit_research_guard.go`, `checkExternalTechResearchGuard`, the dependency-manifest commit gate). Those guards already delegate to the shared `isShellTool()` predicate and the `hasRecentWebResearch` / `buildWebResearchQuery` path rather than carrying their own shell-tool list, so the fixes here extend to them automatically with no duplication. None of the five fixes were already present on origin/main — all touched functions were at merge-base content, so every cherry-pick applied without manual conflict resolution.

## Verification

Scoped gates (both modules), all green:

- `go -C core build ./...` / `go -C core vet ./...` — pass
- `go -C core test ./hooks/ ./agent/` — `ok core/hooks`, `ok core/agent`
- `go build ./...` / `go vet ./cmd/wipnote/...` — pass
- `go test ./cmd/wipnote/launchtui/...` — `ok`
- `go test ./cmd/wipnote/ -run 'Learning|Remediat|Chooser|ShortSessionID|CommitGuard|SubagentCommit'` — `ok`

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
